### PR TITLE
ci: move node and npm versions from libs.version.toml to package.json

### DIFF
--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -1,11 +1,16 @@
+import groovy.json.JsonSlurper
+
 plugins {
     alias(libs.plugins.node)
 }
 
+val packageJson = JsonSlurper().parse(file("package.json")) as Map<*, *>
+val engines = packageJson["engines"] as Map<*, *>
+
 node {
     download = true
-    version = libs.versions.node
-    npmVersion = libs.versions.npm
+    version = engines["node"] as String
+    npmVersion = engines["npm"] as String
     npmInstallCommand = "ci"
 }
 
@@ -14,6 +19,6 @@ tasks.register("check") {
         "npm_audit",
         "npm_run_format",
         "npm_run_lint",
-        "npm_run_test-unit"
+        "npm_run_test-unit",
     )
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
+  "engines": {
+    "node": "22.14.0",
+    "npm": "10.9.2"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc && vite build",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,3 @@ gitSemVer = "org.danilopianini.git-sensitive-semantic-versioning:7.0.12"
 taskTree = "com.dorongold.task-tree:4.0.1"
 node = "com.github.node-gradle.node:7.1.0"
 
-[versions]
-node = "22.14.0"
-npm = "10.9.2"
-


### PR DESCRIPTION
This is done in order to enable Renovate to update npm and node