### PR TITLE
feat: deploy QA from master push, production from v* tag push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy-production:
-    if: github.ref_name == 'master'
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     uses: ./.github/workflows/deploy-target.yml
     with:
       environment: production
@@ -23,7 +23,7 @@ jobs:
       JWT_SECRET: ${{ secrets.JWT_SECRET_PRODUCTION }}
 
   deploy-preview:
-    if: github.ref_name == 'dev'
+    if: github.ref_type == 'branch' && github.ref_name == 'master'
     uses: ./.github/workflows/deploy-target.yml
     with:
       environment: preview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,10 +114,12 @@ With `VITE_MOCK=true`, MSW intercepts all `/api/*` calls except `/api/session` a
 
 ## Deployment
 
-Branch-based deploys to Cloudflare (see `docs/deploy-strategy.md`):
+Branch/tag-based deploys to Cloudflare (see `docs/deploy-strategy.md`):
 
-- `master` → production Worker `backend`, Pages project `frontend`, D1 `db`
-- `dev` → QA Worker `backend-preview`, Pages `frontend` (dev branch), D1 `db-preview`
+- `master` (branch push) → QA Worker `backend-preview`, Pages `frontend` (dev branch), D1 `db-preview` (`dev.fantasywiki.pages.dev`)
+- `v*` (tag push) → production Worker `backend`, Pages project `frontend`, D1 `db` (`fantasywiki.pages.dev`)
 - `feature/*` and `renovate/*` → CI only (`./gradlew check`), no deploy
 
-The `dispatcher.yml` workflow routes to `build.yml` (CI, all branches) and `deploy.yml` (deploy on `master`/`dev`).
+Every commit on `master` deploys to QA. Once a feature is verified there, push a `v*` tag pointing at that `master` commit to deploy it to production.
+
+The `ci-cd.yml` workflow calls `check.yml` (CI, all branches/tags) and `deploy.yml` (deploy on `master` branch pushes and `v*` tag pushes).

--- a/docs/deploy-strategy.md
+++ b/docs/deploy-strategy.md
@@ -1,44 +1,51 @@
 # Deploy Strategy and Branch Policy
 
-This document describes the FantasyWiki Cloudflare deployment strategy across local, QA (`dev`), and production (`master`) environments.
+This document describes the FantasyWiki Cloudflare deployment strategy across local, QA (`master`), and production (version tag) environments.
 
 ---
 
-## Branch Policy
+## Branch / Tag Policy
 
-| Branch | Trigger | Deploy | Environments |
-|--------|---------|--------|--------------|
-| **master** | push / PR | ✅ Production | Prod Workers, Prod Pages, Prod D1 |
-| **dev** | push | ✅ QA | `backend-preview`, `frontend` (dev branch), `db-preview` |
+| Ref | Trigger | Deploy | Environments |
+|-----|---------|--------|--------------|
+| **master** (branch) | push / PR | ✅ QA | `backend-preview`, `frontend` (dev branch), `db-preview` |
+| **v\*** (tag) | push (tag creation) | ✅ Production | Prod Workers, Prod Pages, Prod D1 |
 | **feature/** | push / PR | ❌ CI only | No deploy |
 | **renovate/** | push | ❌ Skip | No deploy (dependency updates) |
+
+Every commit on `master` is automatically deployed to `dev.fantasywiki.pages.dev` (QA). Once a feature on `master` is confirmed working, create a `v*` tag (e.g. `v1.2.0`) pointing at that commit — pushing the tag deploys that exact commit to production (`fantasywiki.pages.dev`).
+
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
 
 ---
 
 ## CI/CD Workflows
 
-### 1. Dispatcher Workflow (`dispatcher.yml`)
-- **Trigger**: `push`, `pull_request`, `workflow_dispatch`
+### 1. CI/CD Workflow (`ci-cd.yml`)
+- **Trigger**: `push` (branches and tags), `pull_request`, `workflow_dispatch`
 - **Purpose**: route CI/CD execution and call reusable workflows
-- **Output**: calls `build.yml` (CI) and `deploy.yml` (deployment flow)
+- **Output**: calls `check.yml` (CI) and `deploy.yml` (deployment flow)
 
-### 2. Build Workflow (`build.yml`)
-- **Trigger**: `workflow_call` from `dispatcher.yml`
+### 2. Check Workflow (`check.yml`)
+- **Trigger**: `workflow_call` from `ci-cd.yml`
 - **Purpose**:
-  - run `./gradlew check` on all branches
+  - run `./gradlew check` on all branches and tags
   - no deployment logic (CI only)
 
 ### 3. Deploy Workflow (`deploy.yml`)
 - **Trigger**: `workflow_call`, `workflow_dispatch`
 - **Purpose**: deploy backend, frontend, and D1 migrations to explicit target environments
-  - `master`: backend `backend`, Pages project `frontend`, D1 `db`
-  - `dev`: backend `backend-preview`, Pages project `frontend`, D1 `db-preview`
+  - `master` (branch push): backend `backend-preview`, Pages project `frontend`, D1 `db-preview`
+  - `v*` (tag push): backend `backend`, Pages project `frontend`, D1 `db`
 
 ---
 
 ## Cloudflare Environments
 
-### Production (`master`)
+### Production (`v*` tag)
 - **Backend Worker**: `backend` (`luca0patrignani.workers.dev`)
 - **Frontend Pages**: `frontend` (`fantasywiki.pages.dev`)
 - **D1 Database**: production database (`db`)
@@ -46,7 +53,7 @@ This document describes the FantasyWiki Cloudflare deployment strategy across lo
   - `FRONTEND_URL=fantasywiki.pages.dev`
   - `VITE_BACKEND_URL=luca0patrignani.workers.dev`
 
-### QA (`dev`)
+### QA (`master`)
 - **Backend Worker**: `backend-preview`
 - **Frontend Pages**: `frontend` (`dev.fantasywiki.pages.dev`)
 - **D1 Database**: preview database (`db-preview`)
@@ -92,7 +99,7 @@ npx wrangler d1 migrations apply db-preview --remote
 ### 3. Test QA Deployment
 
 ```bash
-git push origin dev
+git push origin master
 ```
 
 Then verify the `deploy.yml` workflow in GitHub Actions.
@@ -103,9 +110,11 @@ Then verify the `deploy.yml` workflow in GitHub Actions.
 
 ### Production Rollback
 
+Re-tag a known-good commit on `master` and push it; pushing a `v*` tag always (re)deploys production from that commit.
+
 ```bash
-git revert <commit-hash>
-git push origin master
+git tag v1.2.1 <known-good-commit-hash>
+git push origin v1.2.1
 ```
 
 ### QA D1 Debug Query

--- a/docs/dev-branch-deployment.md
+++ b/docs/dev-branch-deployment.md
@@ -1,17 +1,17 @@
-# Dev Branch and QA Deployment
+# Master Branch and QA Deployment / Production Release via Tags
 
-This document explains what the `dev` branch is used for and how QA deployment works on Cloudflare.
+This document explains how QA deployment works on `master` and how production releases are cut via version tags.
 
-## Purpose of the `dev` Branch
+## Purpose of the `master` Branch
 
-The `dev` branch is the cloud **quality assurance** environment:
+Every push to `master` deploys to the cloud **quality assurance** environment:
 - it validates frontend, backend, and database integration in a real remote setup
-- it catches deployment/configuration issues before merging to `master`
+- it catches deployment/configuration issues before a production release
 
-## Branch Policy
+## Branch / Tag Policy
 
-- `master` → **production**
-- `dev` → **QA**
+- `master` (branch push) → **QA**
+- `v*` (tag push, e.g. `v1.2.0`) → **production**
 - `feature/*` → no deployment (CI only)
 
 ## Deployment Workflow
@@ -19,31 +19,31 @@ The `dev` branch is the cloud **quality assurance** environment:
 Deployment is handled by a single reusable workflow:
 
 - file: `.github/workflows/deploy.yml`
-- trigger path: called from `dispatcher.yml` on repository events
+- trigger path: called from `ci-cd.yml` on repository events
 - manual trigger: `workflow_dispatch`
 
-## What Gets Deployed on `dev`
+## What Gets Deployed on `master`
 
-When `dev` is deployed, the workflow deploys:
+When `master` is pushed, the workflow deploys:
 
 1. **QA Backend Worker**
    - worker name: `backend-preview`
    - deploy command uses `--env=preview`
 
 2. **QA Frontend**
-   - Cloudflare Pages project: `frontend` (deployed from `dev` branch)
+   - Cloudflare Pages project: `frontend` (deployed as the dev branch alias, `dev.fantasywiki.pages.dev`)
    - frontend build variable: `VITE_BACKEND_URL=https://backend-preview.luca0patrignani.workers.dev`
 
 3. **QA D1 Database**
    - remote migrations applied to preview D1
    - database name passed to migration step: `db-preview`
 
-## What Gets Deployed on `master`
+## What Gets Deployed on a `v*` Tag
 
-When `master` is deployed, the workflow deploys:
+When a tag matching `v*` is pushed, the workflow deploys:
 
 1. backend `backend`
-2. frontend Pages project `frontend` (production)
+2. frontend Pages project `frontend` (production, `fantasywiki.pages.dev`)
 3. D1 migrations on production database `db`
 
 ## Required GitHub Secrets
@@ -55,5 +55,10 @@ When `master` is deployed, the workflow deploys:
 ## Recommended Delivery Flow
 
 1. develop on feature branches
-2. merge to `dev` for full cloud QA validation
-3. merge to `master` for production release
+2. merge to `master` for full cloud QA validation
+3. once verified on QA, push a `v*` tag pointing at that `master` commit for production release:
+
+   ```bash
+   git tag v1.2.0
+   git push origin v1.2.0
+   ```

--- a/docs/setup-qa-deploy.md
+++ b/docs/setup-qa-deploy.md
@@ -1,6 +1,6 @@
 # Setup QA Deploy
 
-Quick guide to enable automatic QA deployment on branch `dev` with a dedicated QA D1 database.
+Quick guide to enable automatic QA deployment on push to `master` with a dedicated QA D1 database. Production deploys are triggered separately by pushing a `v*` tag (see `dev-branch-deployment.md` and `deploy-strategy.md`).
 
 ---
 
@@ -60,11 +60,10 @@ If any are missing, add them with the same process as Step 2.
 
 ---
 
-## Step 5: Create Branch `dev`
+## Step 5: Push to `master`
 
 ```bash
-git checkout -b dev
-git push origin dev
+git push origin master
 ```
 
 GitHub Actions will automatically run the `deploy.yml` workflow.
@@ -77,11 +76,11 @@ Go to: https://github.com/luca0patrignani/FantasyWiki/actions
 
 Find the "Deploy" workflow. The following jobs should pass:
 - ✅ check
-- ✅ deploy-backend (matrix: dev)
-- ✅ deploy-frontend (matrix: dev)
-- ✅ migrate-d1 (matrix: dev)
+- ✅ deploy-backend (preview)
+- ✅ deploy-frontend (preview)
+- ✅ migrate-d1 (preview)
 
-If `migrate-d1` fails on `dev`, ensure:
+If `migrate-d1` fails on `master`, ensure:
 1. `D1_QA_DATABASE_ID` is configured (Step 2)
 2. The QA database exists on Cloudflare (`wrangler d1 list --remote`)
 
@@ -93,7 +92,7 @@ If you need to deploy QA without a push:
 
 1. Open: https://github.com/luca0patrignani/FantasyWiki/actions/workflows/deploy.yml
 2. Click "Run workflow"
-3. Select branch: `dev`
+3. Select branch: `master`
 4. Click "Run workflow"
 
 ---
@@ -104,7 +103,7 @@ If QA is broken:
 
 ```bash
 git revert <commit-hash>
-git push origin dev
+git push origin master
 ```
 
 The workflow will redeploy with the reverted code.
@@ -148,4 +147,4 @@ If build or runtime fails due to backend URL:
 
 1. [Read the full deploy strategy](deploy-strategy.md)
 2. [Configure D1 migrations (optional)](../backend/README.md#type-generation)
-3. Validate on `dev` before opening a PR to `master`
+3. Validate on `master` (QA) before pushing a `v*` tag for production


### PR DESCRIPTION
Previously master pushes deployed straight to production and the dev
branch deployed to QA. Now master pushes always deploy to QA
(dev.fantasywiki.pages.dev), and production (fantasywiki.pages.dev)
only deploys when a v* tag is pushed, so a release is only cut once a
feature has been verified on QA.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017Jp8U6TNYEfN9T7yXTTpX2