### PR TITLE
feat(frontend): add info footer, legal and 404 pages, avatar logout

### DIFF
--- a/frontend/src/components/homePage/ArticleLeaderboard.vue
+++ b/frontend/src/components/homePage/ArticleLeaderboard.vue
@@ -19,12 +19,15 @@
           :key="entry.canonicalTitle"
           class="ion-margin-bottom ion-no-padding"
         >
-          <ion-badge class="ion-margin ion-padding">
-            <ion-icon
-              :icon="trendingUpOutline"
-              :aria-label="$t('home.articleLeaderboard.goingUp')"
-            ></ion-icon>
-          </ion-badge>
+          <span
+            class="rank-badge"
+            :class="{ medal: isMedalRank(entry.filteredRank) }"
+            :aria-label="
+              $t('home.articleLeaderboard.rank', { rank: entry.filteredRank })
+            "
+          >
+            {{ rankLabel(entry.filteredRank) }}
+          </span>
           <ion-label class="ion-text-start ion-padding-horizontal">
             <a
               class="article-link"
@@ -32,9 +35,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <h3 class="ion-no-margin">
-                #{{ entry.filteredRank }} {{ entry.displayTitle }}
-              </h3>
+              <h3 class="ion-no-margin">{{ entry.displayTitle }}</h3>
             </a>
             <p class="ion-display-flex ion-align-items-center">
               <ion-icon
@@ -84,12 +85,11 @@ import {
   IonItem,
   IonLabel,
   IonText,
-  IonBadge,
   IonNote,
   IonIcon,
   IonChip,
 } from "@ionic/vue";
-import { eyeOutline, trendingUpOutline } from "ionicons/icons";
+import { eyeOutline } from "ionicons/icons";
 import { createWikimediaClient } from "@/services/wikimediaClient";
 import type { TopReadEntry } from "../../../../external-apis/wikimedia/wikimedia";
 
@@ -100,6 +100,16 @@ const views = ref<number>();
 const isLoading = ref(true);
 const hasError = ref(false);
 const wikimediaClient = createWikimediaClient();
+
+const MEDALS = ["🥇", "🥈", "🥉"];
+
+function isMedalRank(rank: number): boolean {
+  return rank >= 1 && rank <= MEDALS.length;
+}
+
+function rankLabel(rank: number): string {
+  return isMedalRank(rank) ? MEDALS[rank - 1] : `#${rank}`;
+}
 
 function formatCompactViews(value: number | undefined): string {
   if (value === undefined) {
@@ -216,14 +226,24 @@ h3 {
   text-decoration: none;
 }
 
-ion-item ion-badge {
-  --ion-margin: 0.5rem;
-  --ion-padding: 0.5rem;
-  --background: var(--ion-background-color-step-500);
+.rank-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 2.25rem;
+  height: 2.25rem;
+  margin: 0.5rem;
+  border-radius: 50%;
+  background: var(--ion-background-color-step-150);
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--ion-color-medium);
 }
 
-ion-badge ion-icon {
-  font-size: 1.3rem;
+.rank-badge.medal {
+  background: transparent;
+  font-size: 1.5rem;
 }
 
 ion-text.views {

--- a/frontend/src/components/teamDashboard/DashboardHero.vue
+++ b/frontend/src/components/teamDashboard/DashboardHero.vue
@@ -5,18 +5,15 @@
     <div class="hero-content">
       <!-- ── Identity + actions ─────────────────────── -->
       <div class="hero-left">
-        <!-- Greeting + team name, league chip aligned right -->
+        <!-- Greeting row with the league chip aligned right; the team name
+             sits below on its own full-width line so long names don't wrap
+             around the chip -->
         <div class="hero-top">
-          <div class="hero-heading">
-            <ion-text color="medium">
-              <p class="greeting-text ion-no-margin">
-                {{ $t("dashboard.hero.welcomeBack") }}
-              </p>
-            </ion-text>
-            <h1 class="team-name ion-no-margin">
-              {{ data?.team?.name ?? $t("dashboard.hero.yourTeam") }}
-            </h1>
-          </div>
+          <ion-text color="medium">
+            <p class="greeting-text ion-no-margin">
+              {{ $t("dashboard.hero.welcomeBack") }}
+            </p>
+          </ion-text>
 
           <ion-chip
             v-if="currentLeague"
@@ -42,6 +39,10 @@
             </ion-badge>
           </ion-chip>
         </div>
+
+        <h1 class="team-name ion-no-margin">
+          {{ data?.team?.name ?? $t("dashboard.hero.yourTeam") }}
+        </h1>
 
         <!-- Actions: Buy Articles + inbox bell -->
         <div class="hero-actions">
@@ -266,18 +267,13 @@ const allStats = computed<StatDef[]>(() => {
   gap: 0.875rem;
 }
 
-/* Heading left, league chip pushed to the right edge */
+/* Greeting left, league chip pushed to the right edge */
 .hero-top {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   flex-wrap: wrap;
-}
-
-.hero-heading {
-  min-width: 0;
-  flex: 1;
 }
 
 .league-chip {
@@ -304,7 +300,6 @@ const allStats = computed<StatDef[]>(() => {
 .greeting-text {
   font-size: 0.875rem;
   letter-spacing: 0.02em;
-  margin-bottom: 0.75rem;
 }
 
 .team-name {

--- a/frontend/src/composables/useToast.ts
+++ b/frontend/src/composables/useToast.ts
@@ -2,6 +2,19 @@ import { toastController } from "@ionic/vue";
 
 type ToastColor = "success" | "danger" | "primary" | "medium" | "dark";
 
+// Bottom toasts would cover the mobile navigation footer. Ionic keeps the
+// previous pages (each with its own NavBar footer) mounted but display:none
+// in the router outlet, so several footers can be in the DOM at once —
+// anchor to the one that is actually visible. offsetParent is null for the
+// hidden ones and on desktop widths, where the default bottom position is
+// fine.
+function bottomAnchor(): HTMLElement | undefined {
+  const footers = document.querySelectorAll<HTMLElement>(
+    "ion-footer.mobile-nav-footer"
+  );
+  return Array.from(footers).find((footer) => footer.offsetParent !== null);
+}
+
 export function useToast() {
   async function show(
     message: string,
@@ -13,6 +26,7 @@ export function useToast() {
       color,
       duration,
       position: "bottom",
+      positionAnchor: bottomAnchor(),
     });
     await toast.present();
   }
@@ -30,6 +44,7 @@ export function useToast() {
       color,
       duration: 0,
       position: "bottom",
+      positionAnchor: bottomAnchor(),
     });
     void toast.present();
     return async () => {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -9,6 +9,45 @@
     "signIn": "Sign In with Google",
     "signOut": "Sign Out"
   },
+  "footer": {
+    "technicalDocs": "Technical documentation",
+    "userGuide": "User guide",
+    "reportProblem": "Report a problem",
+    "legal": "Legal & privacy",
+    "madeBy": "made by",
+    "and": "and"
+  },
+  "notFound": {
+    "title": "404: Page not found",
+    "fromLine": "From FantasyWiki, the encyclopedia of pages nobody has written",
+    "body": "{path} has never been written, viewed, or signed by any team{citation}.",
+    "citationNeeded": "citation needed",
+    "infobox": {
+      "title": "Market profile",
+      "marketValue": "Market value",
+      "marketValueFigure": "0 credits",
+      "contract": "Contract status",
+      "contractFigure": "Free agent, forever"
+    },
+    "stubNotice": "This page is a stub. You can help by navigating somewhere that exists.",
+    "ctaHome": "Back to home",
+    "ctaMarket": "Scout the market"
+  },
+  "legal": {
+    "title": "Legal & Privacy",
+    "terms": {
+      "title": "Terms of use",
+      "body": "FantasyWiki is a non-commercial university project, provided as-is and without any warranty. Playing is free and the in-game budget and points have no monetary value."
+    },
+    "privacy": {
+      "title": "Privacy",
+      "body": "You sign in with your Google account. We store only your name, email address and profile picture, kept in a session cookie and alongside your game data (teams and leagues). There are no ads, analytics or other tracking."
+    },
+    "attribution": {
+      "title": "Wikimedia attribution",
+      "body": "Pageview data comes from the Wikimedia Pageviews API. Article titles and content belong to Wikipedia and are available under the CC BY-SA 4.0 license. FantasyWiki is not affiliated with or endorsed by the Wikimedia Foundation."
+    }
+  },
   "home": {
     "hero": {
       "badge": "Fantasy Sports meets Wikipedia",
@@ -104,7 +143,7 @@
     "articleLeaderboard": {
       "trendingToday": "🔥 Trending Today",
       "mostViewed": "Most viewed",
-      "goingUp": "Going up",
+      "rank": "Rank {rank}",
       "avg": "Avg: {value}",
       "perDay": "/day",
       "unavailable": "Top article data unavailable right now.",
@@ -252,6 +291,12 @@
       "termsPrefix": "By signing in you agree to our {terms} and {privacy}.",
       "terms": "Terms of Service",
       "privacy": "Privacy Policy"
+    },
+    "logout": {
+      "title": "Sign out?",
+      "message": "You are signed in as {name}.",
+      "confirm": "Sign Out",
+      "cancel": "Cancel"
     },
     "callback": {
       "signInFailed": "Sign-in failed",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -9,6 +9,45 @@
     "signIn": "Accedi con Google",
     "signOut": "Esci"
   },
+  "footer": {
+    "technicalDocs": "Documentazione tecnica",
+    "userGuide": "Guida utente",
+    "reportProblem": "Segnala un problema",
+    "legal": "Note legali e privacy",
+    "madeBy": "creato da",
+    "and": "e"
+  },
+  "notFound": {
+    "title": "404: Pagina non trovata",
+    "fromLine": "Da FantasyWiki, l'enciclopedia delle pagine mai scritte",
+    "body": "{path} non è mai stata scritta, letta o ingaggiata da nessuna squadra{citation}.",
+    "citationNeeded": "senza fonte",
+    "infobox": {
+      "title": "Profilo di mercato",
+      "marketValue": "Valore di mercato",
+      "marketValueFigure": "0 crediti",
+      "contract": "Stato contratto",
+      "contractFigure": "Svincolata, per sempre"
+    },
+    "stubNotice": "Questa pagina è uno stub. Puoi contribuire navigando verso una pagina che esiste.",
+    "ctaHome": "Torna alla home",
+    "ctaMarket": "Esplora il mercato"
+  },
+  "legal": {
+    "title": "Note legali e privacy",
+    "terms": {
+      "title": "Condizioni d'uso",
+      "body": "FantasyWiki è un progetto universitario non commerciale, fornito così com'è e senza alcuna garanzia. Giocare è gratuito e il budget e i punti di gioco non hanno alcun valore monetario."
+    },
+    "privacy": {
+      "title": "Privacy",
+      "body": "L'accesso avviene con il tuo account Google. Conserviamo solo nome, indirizzo email e immagine del profilo, in un cookie di sessione e insieme ai tuoi dati di gioco (squadre e leghe). Non ci sono pubblicità, analytics o altri tracciamenti."
+    },
+    "attribution": {
+      "title": "Attribuzione Wikimedia",
+      "body": "I dati sulle visualizzazioni provengono dalla Wikimedia Pageviews API. Titoli e contenuti degli articoli appartengono a Wikipedia e sono disponibili con licenza CC BY-SA 4.0. FantasyWiki non è affiliato né approvato dalla Wikimedia Foundation."
+    }
+  },
   "home": {
     "hero": {
       "badge": "Il fanta calcio incontra Wikipedia",
@@ -104,7 +143,7 @@
     "articleLeaderboard": {
       "trendingToday": "🔥 Di tendenza oggi",
       "mostViewed": "Più visti",
-      "goingUp": "In crescita",
+      "rank": "Posizione {rank}",
       "avg": "Media: {value}",
       "perDay": "/giorno",
       "unavailable": "Dati sugli articoli non disponibili al momento.",
@@ -252,6 +291,12 @@
       "termsPrefix": "Accedendo accetti i nostri {terms} e la {privacy}.",
       "terms": "Termini di servizio",
       "privacy": "Informativa sulla privacy"
+    },
+    "logout": {
+      "title": "Vuoi uscire?",
+      "message": "Sei connesso come {name}.",
+      "confirm": "Esci",
+      "cancel": "Annulla"
     },
     "callback": {
       "signInFailed": "Accesso fallito",

--- a/frontend/src/layout/InfoFooter.vue
+++ b/frontend/src/layout/InfoFooter.vue
@@ -1,0 +1,99 @@
+<template>
+  <footer class="info-footer">
+    <nav class="footer-links">
+      <!-- TODO: point to the GitHub Pages site once the report and the
+           user guide are published there. -->
+      <a :href="`${REPO_URL}#readme`" target="_blank" rel="noopener">
+        {{ $t("footer.technicalDocs") }}
+      </a>
+      <span aria-hidden="true">·</span>
+      <a :href="`${REPO_URL}/tree/master/docs`" target="_blank" rel="noopener">
+        {{ $t("footer.userGuide") }}
+      </a>
+      <span aria-hidden="true">·</span>
+      <a :href="REPO_URL" target="_blank" rel="noopener">
+        <ion-icon :icon="logoGithub" aria-hidden="true" />
+        GitHub
+      </a>
+      <span aria-hidden="true">·</span>
+      <a :href="`${REPO_URL}/issues`" target="_blank" rel="noopener">
+        {{ $t("footer.reportProblem") }}
+      </a>
+      <span aria-hidden="true">·</span>
+      <router-link to="/legal">{{ $t("footer.legal") }}</router-link>
+    </nav>
+    <p class="footer-credits">
+      © {{ new Date().getFullYear() }} FantasyWiki ·
+      {{ $t("footer.madeBy") }}
+      <a href="https://github.com/Fre0Grella" target="_blank" rel="noopener">
+        Marco Galeri
+      </a>
+      {{ $t("footer.and") }}
+      <a
+        href="https://github.com/luca-patrignani"
+        target="_blank"
+        rel="noopener"
+      >
+        Luca Patrignani
+      </a>
+    </p>
+  </footer>
+</template>
+
+<script setup lang="ts">
+import { IonIcon } from "@ionic/vue";
+import { logoGithub } from "ionicons/icons";
+
+const REPO_URL = "https://github.com/FantasyWiki/FantasyWiki";
+</script>
+
+<style scoped>
+.info-footer {
+  margin-top: 3rem;
+  padding: 1.25rem 0.5rem;
+  border-top: 1px solid var(--ion-border-color);
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--ion-color-medium);
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  column-gap: 0.6rem;
+  row-gap: 0.35rem;
+}
+
+.footer-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--ion-color-medium);
+  text-decoration: none;
+}
+
+.footer-links a:hover {
+  color: var(--ion-color-primary);
+}
+
+.footer-links ion-icon {
+  font-size: 1rem;
+}
+
+.footer-credits {
+  margin: 0.6rem 0 0;
+  font-size: 0.75rem;
+}
+
+.footer-credits a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.footer-credits a:hover {
+  color: var(--ion-color-primary);
+}
+</style>

--- a/frontend/src/layout/NavBar.vue
+++ b/frontend/src/layout/NavBar.vue
@@ -127,14 +127,30 @@
 
           <!-- Sign In / Out -->
           <ion-button
+            v-if="appStore.isAuthenticated"
+            fill="clear"
+            color="dark"
+            class="ion-hide-sm-down signout-button"
+            @click="handleAuth"
+          >
+            <ion-avatar
+              v-if="profilePicture"
+              slot="start"
+              class="profile-avatar"
+              aria-hidden="true"
+            >
+              <img :src="profilePicture" alt="" referrerpolicy="no-referrer" />
+            </ion-avatar>
+            {{ $t("nav.signOut") }}
+          </ion-button>
+          <ion-button
+            v-else
             color="primary"
             fill="solid"
             class="ion-hide-sm-down"
             @click="handleAuth"
           >
-            {{
-              appStore.isAuthenticated ? $t("nav.signOut") : $t("nav.signIn")
-            }}
+            {{ $t("nav.signIn") }}
           </ion-button>
         </div>
       </ion-toolbar>
@@ -142,6 +158,7 @@
 
     <ion-content :fullscreen="true" class="ion-padding">
       <slot></slot>
+      <info-footer></info-footer>
       <ion-modal
         :is-open="isLoginOpen"
         css-class="login-modal"
@@ -149,11 +166,22 @@
       >
         <login-page />
       </ion-modal>
+      <ion-modal
+        :is-open="isLogoutOpen"
+        css-class="login-modal"
+        @did-dismiss="onLogoutDismiss"
+      >
+        <logout-confirm-page />
+      </ion-modal>
     </ion-content>
 
     <!-- Mobile Footer -->
+    <!-- mobile-nav-footer is the positionAnchor for bottom toasts (see
+         useToast). It must be a class: the router outlet keeps previous
+         pages (each with its own NavBar) mounted, so the selector can match
+         several footers and useToast picks the visible one. -->
     <ion-footer
-      class="ion-hide-md-up transparent-top-layer"
+      class="mobile-nav-footer ion-hide-md-up transparent-top-layer"
       :translucent="true"
     >
       <ion-toolbar class="transparent-bot-layer">
@@ -167,7 +195,15 @@
             <ion-icon :icon="link.icon" />
           </ion-button>
           <ion-button fill="clear" @click="handleAuth">
+            <ion-avatar
+              v-if="profilePicture"
+              class="profile-avatar"
+              aria-hidden="true"
+            >
+              <img :src="profilePicture" alt="" referrerpolicy="no-referrer" />
+            </ion-avatar>
             <ion-icon
+              v-else
               :icon="appStore.isAuthenticated ? logOutOutline : logInOutline"
             />
           </ion-button>
@@ -183,6 +219,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import {
   IonModal,
+  IonAvatar,
   IonButton,
   IonBadge,
   IonContent,
@@ -209,7 +246,9 @@ import {
 } from "ionicons/icons";
 
 import AppLogo from "@/components/AppLogo.vue";
+import InfoFooter from "@/layout/InfoFooter.vue";
 import LoginPage from "@/views/auth/LoginPage.vue";
+import LogoutConfirmPage from "@/views/auth/LogoutConfirmPage.vue";
 import { useAppStore } from "@/stores/app";
 import { useLeagueStore } from "@/stores/league";
 import { useNotifications } from "@/composables/useNotifications";
@@ -219,6 +258,7 @@ const router = useRouter();
 const route = useRoute();
 const { t } = useI18n();
 const isLoginOpen = ref(false);
+const isLogoutOpen = ref(false);
 
 // State
 const appStore = useAppStore();
@@ -260,6 +300,12 @@ function selectLanguage(code: string) {
   langPopoverOpen.value = false;
 }
 
+// Google profile picture from the session; shown in the auth buttons so a
+// logged-in state is visible at a glance (issue #385).
+const profilePicture = computed(() =>
+  appStore.isAuthenticated ? appStore.currentUser?.picture : undefined
+);
+
 const navLinks = computed(() => [
   { name: t("nav.dashboard"), href: "/dashboard", icon: gridOutline },
   { name: t("nav.leagues"), href: "/leagues", icon: trophyOutline },
@@ -274,13 +320,24 @@ const toggleTheme = () => {
   localStorage.setItem("theme", appStore.isDarkMode ? "dark" : "light");
 };
 
-const handleAuth = async () => {
+// Signing out asks for confirmation in a modal (same style as the login
+// one); the store is only touched when the modal is dismissed with the
+// "confirm" role.
+const handleAuth = () => {
   if (appStore.isAuthenticated) {
+    isLogoutOpen.value = true;
+  } else {
+    // No route change: "/signin" was never a real route and would now hit
+    // the 404 catch-all; the modal simply opens over the current page.
+    isLoginOpen.value = true;
+  }
+};
+
+const onLogoutDismiss = (event: CustomEvent) => {
+  isLogoutOpen.value = false;
+  if (event.detail.role === "confirm") {
     appStore.logout();
     router.push("/");
-  } else {
-    router.push("/signin");
-    isLoginOpen.value = true;
   }
 };
 
@@ -367,6 +424,20 @@ ion-footer {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.profile-avatar {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+.signout-button {
+  font-weight: 500;
+  text-transform: none;
+}
+
+.signout-button .profile-avatar {
+  margin-inline-end: 0.5rem;
 }
 
 ion-modal {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -8,6 +8,8 @@ import EnvInfoPage from "@/views/EnvInfoPage.vue";
 import TeamPage from "@/views/TeamPage.vue";
 import TeamCreationPage from "@/views/TeamCreationPage.vue";
 import MarketPage from "@/views/MarketPage.vue";
+import LegalPage from "@/views/LegalPage.vue";
+import NotFoundPage from "@/views/NotFoundPage.vue";
 import { useAppStore } from "@/stores/app";
 
 const routes: Array<RouteRecordRaw> = [
@@ -40,6 +42,12 @@ const routes: Array<RouteRecordRaw> = [
     meta: { public: true },
   },
   {
+    path: "/legal",
+    name: "Legal",
+    component: LegalPage,
+    meta: { public: true },
+  },
+  {
     path: "/auth/callback",
     name: "AuthCallback",
     component: AuthCallbackPage,
@@ -64,6 +72,13 @@ const routes: Array<RouteRecordRaw> = [
     path: "/market",
     name: "Market",
     component: MarketPage,
+  },
+  // Catch-all 404 — must stay last
+  {
+    path: "/:pathMatch(.*)*",
+    name: "NotFound",
+    component: NotFoundPage,
+    meta: { public: true },
   },
 ];
 

--- a/frontend/src/tests/InfoFooter.spec.ts
+++ b/frontend/src/tests/InfoFooter.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import router from "@/router/index";
+import InfoFooter from "@/layout/InfoFooter.vue";
+
+describe("InfoFooter.vue", () => {
+  it("shows repository, issues and legal links", async () => {
+    await router.push("/");
+    await router.isReady();
+
+    const wrapper = mount(InfoFooter, {
+      global: { plugins: [router] },
+    });
+
+    const hrefs = wrapper.findAll("a").map((a) => a.attributes("href"));
+    expect(hrefs).toContain("https://github.com/FantasyWiki/FantasyWiki");
+    expect(hrefs).toContain(
+      "https://github.com/FantasyWiki/FantasyWiki/issues"
+    );
+    expect(wrapper.find("a[href='/legal']").exists()).toBe(true);
+  });
+
+  it("credits both authors", async () => {
+    await router.push("/");
+    await router.isReady();
+
+    const wrapper = mount(InfoFooter, {
+      global: { plugins: [router] },
+    });
+
+    expect(wrapper.text()).toContain("Marco Galeri");
+    expect(wrapper.text()).toContain("Luca Patrignani");
+  });
+});

--- a/frontend/src/tests/LegalPage.spec.ts
+++ b/frontend/src/tests/LegalPage.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, Pinia, setActivePinia } from "pinia";
+import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
+import router from "@/router/index";
+import LegalPage from "@/views/LegalPage.vue";
+
+describe("LegalPage.vue", () => {
+  let pinia: Pinia;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  it("renders the terms, privacy and attribution sections", async () => {
+    await router.push("/legal");
+    await router.isReady();
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+
+    const wrapper = mount(LegalPage, {
+      global: {
+        plugins: [router, pinia, [VueQueryPlugin, { queryClient }]],
+      },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Terms of use");
+    expect(wrapper.text()).toContain("Privacy");
+    expect(wrapper.text()).toContain("Wikimedia attribution");
+  });
+});

--- a/frontend/src/tests/NotFoundPage.spec.ts
+++ b/frontend/src/tests/NotFoundPage.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, Pinia, setActivePinia } from "pinia";
+import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
+import router from "@/router/index";
+import NotFoundPage from "@/views/NotFoundPage.vue";
+
+describe("NotFoundPage.vue", () => {
+  let pinia: Pinia;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  it("is reached by the catch-all route and shows the attempted path", async () => {
+    await router.push("/this/does-not-exist");
+    await router.isReady();
+
+    expect(router.currentRoute.value.name).toBe("NotFound");
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+
+    const wrapper = mount(NotFoundPage, {
+      global: {
+        plugins: [router, pinia, [VueQueryPlugin, { queryClient }]],
+      },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("404: Page not found");
+    expect(wrapper.find(".nf-path").text()).toBe("/this/does-not-exist");
+    expect(wrapper.text()).toContain("citation needed");
+    expect(wrapper.text()).toContain("Market profile");
+  });
+});

--- a/frontend/src/tests/auth/LogoutConfirmPage.spec.ts
+++ b/frontend/src/tests/auth/LogoutConfirmPage.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, Pinia, setActivePinia } from "pinia";
+import router from "@/router/index";
+import LogoutConfirmPage from "@/views/auth/LogoutConfirmPage.vue";
+import { useAppStore } from "@/stores/app";
+
+describe("LogoutConfirmPage.vue", () => {
+  let pinia: Pinia;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  it("shows the signed-in user's identity and avatar", async () => {
+    await router.push("/");
+    await router.isReady();
+
+    const appStore = useAppStore();
+    appStore.isAuthenticated = true;
+    appStore.currentUser = {
+      sub: "test-user",
+      name: "Test User",
+      email: "test@example.com",
+      picture: "https://example.com/avatar.png",
+    };
+
+    const wrapper = mount(LogoutConfirmPage, {
+      global: { plugins: [router, pinia] },
+    });
+
+    expect(wrapper.text()).toContain("Test User");
+    expect(wrapper.text()).toContain("test@example.com");
+    expect(wrapper.find("ion-avatar img").attributes("src")).toBe(
+      "https://example.com/avatar.png"
+    );
+  });
+});

--- a/frontend/src/views/LegalPage.vue
+++ b/frontend/src/views/LegalPage.vue
@@ -1,0 +1,50 @@
+<template>
+  <nav-bar>
+    <div class="legal-content">
+      <h1>{{ $t("legal.title") }}</h1>
+
+      <section>
+        <h2>{{ $t("legal.terms.title") }}</h2>
+        <p>{{ $t("legal.terms.body") }}</p>
+      </section>
+
+      <section>
+        <h2>{{ $t("legal.privacy.title") }}</h2>
+        <p>{{ $t("legal.privacy.body") }}</p>
+      </section>
+
+      <section>
+        <h2>{{ $t("legal.attribution.title") }}</h2>
+        <p>{{ $t("legal.attribution.body") }}</p>
+      </section>
+    </div>
+  </nav-bar>
+</template>
+
+<script setup lang="ts">
+import NavBar from "@/layout/NavBar.vue";
+</script>
+
+<style scoped>
+.legal-content {
+  max-width: 44rem;
+  margin: 0 auto;
+  padding: 1rem 0.5rem 2rem;
+}
+
+h1 {
+  font-size: 1.75rem;
+  margin-bottom: 1.5rem;
+}
+
+h2 {
+  font-size: 1.125rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+p {
+  margin: 0;
+  line-height: 1.6;
+  color: var(--ion-color-medium);
+}
+</style>

--- a/frontend/src/views/NotFoundPage.vue
+++ b/frontend/src/views/NotFoundPage.vue
@@ -1,0 +1,309 @@
+<template>
+  <nav-bar>
+    <article class="notfound">
+      <h1 class="nf-title">{{ $t("notFound.title") }}</h1>
+      <p class="nf-from">{{ $t("notFound.fromLine") }}</p>
+
+      <!-- Wikipedia-style infobox: floats right of the stub text on
+           desktop, stacks above it on mobile -->
+      <aside class="nf-infobox" :aria-label="$t('notFound.infobox.title')">
+        <p class="nf-infobox__title">{{ $t("notFound.infobox.title") }}</p>
+        <dl>
+          <div class="nf-infobox__row">
+            <dt>{{ $t("notFound.infobox.marketValue") }}</dt>
+            <dd>{{ $t("notFound.infobox.marketValueFigure") }}</dd>
+          </div>
+          <div class="nf-infobox__row">
+            <dt>{{ $t("notFound.infobox.contract") }}</dt>
+            <dd>{{ $t("notFound.infobox.contractFigure") }}</dd>
+          </div>
+        </dl>
+        <div class="nf-infobox__trend">
+          <svg
+            class="nf-sparkline"
+            viewBox="0 0 120 48"
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            <defs>
+              <marker
+                id="nf-arrow"
+                viewBox="0 0 10 10"
+                refX="8"
+                refY="5"
+                markerWidth="5"
+                markerHeight="5"
+                orient="auto-start-reverse"
+              >
+                <path d="M0,0 L10,5 L0,10 z" class="nf-sparkline__arrow" />
+              </marker>
+            </defs>
+            <polyline
+              class="nf-sparkline__line"
+              points="4,8 30,16 42,10 66,30 80,26 106,42"
+              marker-end="url(#nf-arrow)"
+            />
+          </svg>
+          <ion-chip color="danger" outline class="nf-trend-chip">
+            <ion-icon :icon="trendingDownOutline" />
+            <ion-label>100%</ion-label>
+          </ion-chip>
+        </div>
+      </aside>
+
+      <p class="nf-body">
+        <i18n-t keypath="notFound.body" tag="span">
+          <template #path
+            ><code class="nf-path">{{ attemptedPath }}</code></template
+          >
+          <template #citation
+            ><sup class="nf-cite"
+              >[{{ $t("notFound.citationNeeded") }}]</sup
+            ></template
+          >
+        </i18n-t>
+      </p>
+
+      <div class="nf-stub-notice">
+        <ion-icon :icon="constructOutline" aria-hidden="true" />
+        <p>{{ $t("notFound.stubNotice") }}</p>
+      </div>
+
+      <div class="nf-actions">
+        <ion-button color="primary" fill="solid" @click="router.push('/home')">
+          <ion-icon slot="start" :icon="homeOutline" />
+          {{ $t("notFound.ctaHome") }}
+        </ion-button>
+        <ion-button
+          color="primary"
+          fill="outline"
+          @click="router.push('/market')"
+        >
+          <ion-icon slot="start" :icon="storefrontOutline" />
+          {{ $t("notFound.ctaMarket") }}
+        </ion-button>
+      </div>
+    </article>
+  </nav-bar>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { IonButton, IonChip, IonIcon, IonLabel } from "@ionic/vue";
+import {
+  constructOutline,
+  homeOutline,
+  storefrontOutline,
+  trendingDownOutline,
+} from "ionicons/icons";
+import NavBar from "@/layout/NavBar.vue";
+
+const route = useRoute();
+const router = useRouter();
+
+const attemptedPath = computed(() => route.path);
+</script>
+
+<style scoped>
+.notfound {
+  max-width: 46rem;
+  margin: 1.5rem auto 2rem;
+  padding: 0 0.5rem;
+}
+
+/* Wikipedia article title: serif with the classic thin rule below */
+.nf-title {
+  font-family: var(--font-family-headings), serif;
+  font-size: clamp(1.85rem, 6vw, 2.5rem);
+  font-weight: 700;
+  line-height: 1.15;
+  margin: 0 0 0.35rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid var(--ion-border-color);
+}
+
+.nf-from {
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ion-color-medium);
+  margin: 0 0 1.25rem;
+}
+
+.nf-body {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.7;
+  max-width: 65ch;
+}
+
+.nf-path {
+  font-size: 0.9em;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  background: rgba(var(--ion-color-primary-rgb), 0.08);
+  border: 1px solid var(--ion-border-color);
+  word-break: break-all;
+}
+
+.nf-cite {
+  font-size: 0.7em;
+  color: var(--ion-color-primary);
+  white-space: nowrap;
+}
+
+/* ── Infobox ─────────────────────────────────── */
+.nf-infobox {
+  border: 1px solid var(--ion-border-color);
+  border-radius: 8px;
+  background: rgba(var(--ion-color-primary-rgb), 0.04);
+  padding: 0.75rem 0.9rem;
+  font-size: 0.85rem;
+  margin: 0 0 1.25rem;
+}
+
+@media (min-width: 576px) {
+  .nf-infobox {
+    float: right;
+    width: 15.5rem;
+    margin: 0 0 1rem 1.5rem;
+  }
+}
+
+.nf-infobox__title {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-family-headings), serif;
+  font-weight: 700;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.nf-infobox dl {
+  margin: 0;
+}
+
+.nf-infobox__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.3rem 0;
+}
+
+.nf-infobox__row + .nf-infobox__row {
+  border-top: 1px solid var(--ion-border-color);
+}
+
+.nf-infobox__row dt {
+  color: var(--ion-color-medium);
+}
+
+.nf-infobox__row dd {
+  margin: 0;
+  font-weight: 600;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.nf-infobox__trend {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--ion-border-color);
+  margin-top: 0.3rem;
+}
+
+.nf-sparkline {
+  flex: 1;
+  height: 2.5rem;
+  overflow: visible;
+}
+
+/* The asset's lifetime performance: a market crash in miniature.
+   Draws itself once; conveys the "dead asset" state, then stays still. */
+.nf-sparkline__line {
+  fill: none;
+  stroke: var(--ion-color-danger);
+  stroke-width: 2.5;
+  stroke-linejoin: round;
+  stroke-dasharray: 130;
+  stroke-dashoffset: 130;
+  animation: nf-draw 0.8s cubic-bezier(0.22, 1, 0.36, 1) 0.15s forwards;
+}
+
+/* The arrowhead lands only once the line reaches it */
+.nf-sparkline__arrow {
+  fill: var(--ion-color-danger);
+  opacity: 0;
+  animation: nf-appear 0.2s ease-out 0.85s forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nf-sparkline__line {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+
+  .nf-sparkline__arrow {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+@keyframes nf-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes nf-appear {
+  to {
+    opacity: 1;
+  }
+}
+
+.nf-trend-chip {
+  margin: 0;
+  height: 1.6rem;
+  font-size: 0.75rem;
+  --background: transparent;
+  flex-shrink: 0;
+  pointer-events: none;
+}
+
+/* ── Stub notice ─────────────────────────────── */
+.nf-stub-notice {
+  clear: both;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--ion-border-color);
+  border-radius: 8px;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ion-color-medium);
+}
+
+.nf-stub-notice ion-icon {
+  font-size: 1.4rem;
+  flex-shrink: 0;
+  color: var(--ion-color-primary);
+}
+
+.nf-stub-notice p {
+  margin: 0;
+}
+
+.nf-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.nf-actions ion-button {
+  --border-radius: 0.5rem;
+}
+</style>

--- a/frontend/src/views/auth/LoginPage.vue
+++ b/frontend/src/views/auth/LoginPage.vue
@@ -24,10 +24,14 @@
       <p>
         <i18n-t keypath="auth.login.termsPrefix" tag="span">
           <template #terms
-            ><a href="#">{{ $t("auth.login.terms") }}</a></template
+            ><router-link to="/legal">{{
+              $t("auth.login.terms")
+            }}</router-link></template
           >
           <template #privacy
-            ><a href="#">{{ $t("auth.login.privacy") }}</a></template
+            ><router-link to="/legal">{{
+              $t("auth.login.privacy")
+            }}</router-link></template
           >
         </i18n-t>
       </p>

--- a/frontend/src/views/auth/LogoutConfirmPage.vue
+++ b/frontend/src/views/auth/LogoutConfirmPage.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="logout-card">
+    <button class="dismiss-btn" @click="dismiss">
+      <ion-icon :icon="closeOutline" />
+    </button>
+
+    <ion-avatar v-if="user?.picture" class="logout-avatar">
+      <img :src="user.picture" alt="" referrerpolicy="no-referrer" />
+    </ion-avatar>
+
+    <ion-text class="logout-title">
+      <h2>{{ $t("auth.logout.title") }}</h2>
+    </ion-text>
+
+    <ion-text color="medium" class="logout-message">
+      <p>{{ $t("auth.logout.message", { name: user?.name ?? "" }) }}</p>
+      <p class="logout-email">{{ user?.email }}</p>
+    </ion-text>
+
+    <ion-button
+      expand="block"
+      color="danger"
+      class="logout-btn"
+      @click="confirm"
+    >
+      {{ $t("auth.logout.confirm") }}
+    </ion-button>
+    <ion-button
+      expand="block"
+      fill="outline"
+      class="logout-btn"
+      @click="dismiss"
+    >
+      {{ $t("auth.logout.cancel") }}
+    </ion-button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  IonAvatar,
+  IonButton,
+  IonIcon,
+  IonText,
+  modalController,
+} from "@ionic/vue";
+import { closeOutline } from "ionicons/icons";
+import { computed } from "vue";
+import { useAppStore } from "@/stores/app";
+
+const appStore = useAppStore();
+const user = computed(() => appStore.currentUser);
+
+function dismiss() {
+  modalController.dismiss(null, "cancel");
+}
+
+// The NavBar owns the actual logout: it reads this role from didDismiss so
+// store mutation and navigation stay in the layout, like the login flow.
+function confirm() {
+  modalController.dismiss(null, "confirm");
+}
+</script>
+
+<style scoped>
+.logout-card {
+  position: relative;
+  padding: 2.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.dismiss-btn {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ion-color-medium);
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.logout-avatar {
+  width: 4rem;
+  height: 4rem;
+}
+
+.logout-title h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.logout-message {
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.logout-message p {
+  margin: 0;
+}
+
+.logout-email {
+  font-size: 0.8rem;
+}
+
+.logout-btn {
+  width: 100%;
+  --border-radius: 8px;
+}
+</style>


### PR DESCRIPTION
UI/cosmetic pass across the app, closing five issues: the landing leaderboard, mobile toast placement, auth button, information footer with legal page, and a themed 404 page.                                                                                
                                                                                                                                                                                                                                                                
  Closes #47, closes #48, closes #284, closes #384, closes #385.                                                                                                                                                                                                
                                                                                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                
  ### Landing page (#284)                                                                                                                                                                                                                                       
  - Article leaderboard entries now show medal badges (🥇🥈🥉) for the top 3 and a stylized rank circle for the rest, replacing the generic trending icon; the redundant `#n` prefix was dropped from titles.                                                   
                                                                                                                                                                                                                                                                
  ### Toasts on mobile (#384)                                                                                                                                                                                                                                   
  - Bottom toasts no longer cover the mobile navigation bar: they anchor above it via Ionic's `positionAnchor`. The anchor is resolved per toast among the footers kept mounted by the router outlet, picking the visible one; desktop keeps the default        
  position.                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                
  ### Auth button (#385)                                                                                                                                                                                                                                        
  - When signed in, the Google profile picture is shown as an avatar: next to "Sign Out" (borderless) on desktop, in place of the logout icon in the mobile nav.                                                                                                
  - Signing out now asks for confirmation in a modal (same style as the login one) showing avatar, name, and email; logout only happens on confirm.                                                                                                             
  - Removed a dead `router.push("/signin")` (route never existed).                                                                                                                                                                                              
                                                                                                                                                                                                                                                                
  ### Information footer + legal page (#47)                                                                                                                                                                                                                     
  - Compact, signature-style footer at the end of every page: technical documentation, user guide (both pointing at the repo until GitHub Pages is up), GitHub, report a problem, legal link, plus copyright and author credits.                                
  - New public `/legal` page with the minimal necessary content: terms of use, privacy, and Wikimedia attribution. The previously dead Terms/Privacy links in the login modal now point there.                                                                  
                                                                                                                                                                                                                                                                
  ### 404 page (#48)                                                                                                                                                                                                                                            
  - New catch-all route rendering a wiki-stub parody: article-style title, the attempted path with a [citation needed] joke, a "Market profile" infobox (0 credits, free agent forever) with an animated crashing trend line, and CTAs back to home/market.     
                                                                                                                                                                                                                                                                
  ### Misc                                                                                                                                                                                                                                                      
  - Dashboard hero: league chip moved up beside the greeting so the team name spans the full width without wrapping.                                                                                                                                            
                                                                                                                                                                                                                                                                
  All copy is localized (en/it). New component specs for the footer, legal page, and logout modal; full suite at 97 tests passing.