### PR TITLE
docs: add nightly scoring-engine plan and reconcile chemistry math

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ tasks.register("check") {
         "npm_ci",
         ":frontend:check",
         ":backend:check",
+        ":scoring-engine:check",
     )
 }
 
@@ -49,6 +50,7 @@ tasks.register("fix") {
     dependsOn(
         ":frontend:fix",
         ":backend:fix",
+        ":scoring-engine:ktlintFormat",
     )
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,21 @@
+[versions]
+kotlin = "2.2.21"
+kotest = "6.0.7"
+mockito = "5.21.0"
+kover = "0.9.8"
+
+[libraries]
+kotest-junit5-jvm = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "kotest" }
+kotest-assertions-core-jvm = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+
+[bundles]
+kotlin-testing = [ "kotest-junit5-jvm", "kotest-assertions-core-jvm", "mockito-core" ]
+
 [plugins]
 gitSemVer = "org.danilopianini.git-sensitive-semantic-versioning:7.0.22"
 taskTree = "com.dorongold.task-tree:4.0.1"
 node = "com.github.node-gradle.node:7.1.0"
-
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-qa = "org.danilopianini.gradle-kotlin-qa:1.8.0"
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/scoring-engine/build.gradle.kts
+++ b/scoring-engine/build.gradle.kts
@@ -1,0 +1,42 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.qa)
+    alias(libs.plugins.kover)
+}
+
+group = "io.github.fantasywiki"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    testImplementation(libs.bundles.kotlin.testing)
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        allWarningsAsErrors = true
+        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging {
+        showStandardStreams = true
+        showCauses = true
+        showStackTraces = true
+        events(*TestLogEvent.values())
+        exceptionFormat = TestExceptionFormat.FULL
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.koverXmlReport)
+}

--- a/scoring-engine/src/main/kotlin/io/github/fantasywiki/scoring/Scoring.kt
+++ b/scoring-engine/src/main/kotlin/io/github/fantasywiki/scoring/Scoring.kt
@@ -1,0 +1,47 @@
+package io.github.fantasywiki.scoring
+
+import kotlin.math.log2
+import kotlin.math.max
+
+/** Directionality of a resolved chemistry link between two contracted articles. */
+enum class ChemistryLink {
+    /** Both articles link to each other. */
+    MUTUAL,
+
+    /** Exactly one article links to the other. */
+    ONE_WAY,
+
+    /** Neither article links to the other. */
+    NONE,
+}
+
+/**
+ * Pure scoring math for the nightly scoring engine.
+ *
+ * Placeholder stub of the base-points curve and chemistry synergy described in
+ * `docs/plan-scoring-engine-kotlin.md` (§9). It exists so the code-quality and
+ * coverage tooling has real, tested code to run against; the full engine lands
+ * in a later phase.
+ */
+object Scoring {
+    private const val ZERO_THRESHOLD = 2_000.0
+    private const val KINK_VIEWS = 150_000.0
+    private const val TAIL_DIVISOR = 50_000.0
+    private const val KINK_POINTS = 6.23
+    private const val MUTUAL_BONUS = 1.5
+    private const val ONE_WAY_BONUS = 0.5
+
+    /** Base points awarded for a single article's normalized daily views [views]. */
+    fun basePoints(views: Double): Double = if (views <= KINK_VIEWS) {
+        max(0.0, log2(views / ZERO_THRESHOLD))
+    } else {
+        KINK_POINTS + (views - KINK_VIEWS) / TAIL_DIVISOR
+    }
+
+    /** Chemistry synergy contributed by a single resolved [link] between two articles. */
+    fun synergy(link: ChemistryLink): Double = when (link) {
+        ChemistryLink.MUTUAL -> MUTUAL_BONUS
+        ChemistryLink.ONE_WAY -> ONE_WAY_BONUS
+        ChemistryLink.NONE -> 0.0
+    }
+}

--- a/scoring-engine/src/test/kotlin/io/github/fantasywiki/scoring/ScoringTest.kt
+++ b/scoring-engine/src/test/kotlin/io/github/fantasywiki/scoring/ScoringTest.kt
@@ -1,0 +1,29 @@
+package io.github.fantasywiki.scoring
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+class ScoringTest : StringSpec({
+    val tolerance = 1e-9
+
+    "basePoints is clamped to zero at or below the floor" {
+        Scoring.basePoints(2_000.0) shouldBe (0.0 plusOrMinus tolerance)
+        Scoring.basePoints(1_000.0) shouldBe (0.0 plusOrMinus tolerance)
+    }
+
+    "basePoints follows log2 up to the kink" {
+        Scoring.basePoints(4_000.0) shouldBe (1.0 plusOrMinus tolerance)
+        Scoring.basePoints(150_000.0) shouldBe (6.2288 plusOrMinus 1e-4)
+    }
+
+    "basePoints grows linearly past the kink" {
+        Scoring.basePoints(200_000.0) shouldBe (7.23 plusOrMinus 1e-2)
+    }
+
+    "synergy scores each resolved link direction" {
+        Scoring.synergy(ChemistryLink.MUTUAL) shouldBe (1.5 plusOrMinus tolerance)
+        Scoring.synergy(ChemistryLink.ONE_WAY) shouldBe (0.5 plusOrMinus tolerance)
+        Scoring.synergy(ChemistryLink.NONE) shouldBe (0.0 plusOrMinus tolerance)
+    }
+})

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 }
 
 gitHooks {
+    preCommit {
+        tasks("ktlintCheck")
+    }
     commitMsg { conventionalCommits() }
     createHooks()
 }
@@ -12,3 +15,4 @@ rootProject.name = "FantasyWiki"
 
 include("frontend")
 include("backend")
+include("scoring-engine")


### PR DESCRIPTION
Add docs/plan-scoring-engine.md capturing the scoring user story, the
canonical scoring math (Base Points curve, additive synergy, daily/
cumulative scoring), the doc/code discrepancies, and the implementation
plan (A' POST-through-backend delivery, GitHub Actions host, Kotlin/JVM
engine) with its deliberate divergence from ADR 0004.

Reconcile two docs that still described chemistry as a percentage
multiplier, contradicting the canonical additive flat-point model
(scoring-system.md §4, CONTEXT.md, ADR 0001):
- chemistry-links.md: correct the CHEMISTRY_MULTIPLIER_BY_LEVEL "score
  multipliers" line; flag the constant as legacy/display-only.
- FantaWiki-Requirements.md: add a superseded banner to the formation
  user story's +20%/+10%/+5% multiplier list.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>