### PR TITLE
feat: add contract expiry settlement and renewal (issue #407)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,11 +1,13 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { jwt } from "hono/jwt";
+import { Temporal } from "@js-temporal/polyfill";
 import auth, { resolveFrontendUrl } from "./routes/auth";
 import session from "./routes/session";
 import leagues from "./routes/leagues";
 import notifications from "./routes/notifications";
 import player from "./routes/player";
+import type { ContractSettlementParams } from "./workflows/contractSettlement";
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -15,6 +17,7 @@ type Bindings = {
   GOOGLE_CLIENT_SECRET: string;
   JWT_SECRET: string;
   FRONTEND_URL: string;
+  CONTRACT_SETTLEMENT_WORKFLOW: Workflow<ContractSettlementParams>;
 };
 
 app.use(
@@ -57,4 +60,26 @@ app.route("/api/notifications", notifications);
 // Mount player routes
 app.route("/api/player", player);
 
-export default app;
+/**
+ * Daily settlement Cron Trigger (ADR 0003, ~05:00 UTC): kicks off the durable
+ * ContractSettlementWorkflow, which settles or renews every contract that has
+ * reached the end of its term. The handler stays thin — it only starts the
+ * Workflow instance; all the resolution logic lives in the Workflow/service.
+ */
+const scheduled: ExportedHandlerScheduledHandler<Bindings> = async (
+  _controller,
+  env,
+) => {
+  await env.CONTRACT_SETTLEMENT_WORKFLOW.create({
+    params: { today: Temporal.Now.plainDateISO().toString() },
+  });
+};
+
+// Cloudflare requires the WorkflowEntrypoint class to be exported from the
+// Worker's main module (referenced by class_name in wrangler.jsonc).
+export { ContractSettlementWorkflow } from "./workflows/contractSettlement";
+
+export default {
+  fetch: app.fetch,
+  scheduled,
+} satisfies ExportedHandler<Bindings>;

--- a/backend/src/repositories/contractRepository.ts
+++ b/backend/src/repositories/contractRepository.ts
@@ -21,6 +21,18 @@ export interface NewContract {
   purchasePrice: number;
 }
 
+/**
+ * An unsettled contract at or past its `expireDate`, enriched with the league
+ * `domain` (needed to price its live currentPrice) and the owning team's
+ * derived `teamCredits` (needed to decide whether an elected renewal is
+ * affordable) — both resolved in the sweep query so the daily settlement
+ * job needs no extra per-contract reads.
+ */
+export interface DueContract extends Contract {
+  domain: string;
+  teamCredits: number;
+}
+
 export interface ContractRepository {
   getByTeamId(teamId: string): Promise<Result<Contract[]>>;
   getById(id: string): Promise<Result<Contract | null>>;
@@ -49,4 +61,42 @@ export interface ContractRepository {
     teamId: string,
     payout: number,
   ): Promise<Result<boolean>>;
+  /**
+   * All unsettled contracts whose `expireDate` is on or before `today`, i.e.
+   * the ones the daily settlement sweep must resolve (settle or renew). Uses
+   * the `idx_contracts_settled_expire (settled, expireDate)` index and joins in
+   * the league domain + derived team credits (see {@link DueContract}).
+   */
+  getDueForSettlement(
+    today: Temporal.PlainDate,
+  ): Promise<Result<DueContract[]>>;
+  /**
+   * Settles a contract at natural expiry ("sold to system", ADR 0003) in a
+   * single guarded write: flips it to `settled=1` and persists `payout` (the
+   * full live currentPrice) into the same `salePayout` ledger column early
+   * sales use. Guarded on the row still being unsettled, so a re-run of the
+   * sweep is a no-op. Result<boolean>: true iff this call actually settled it.
+   */
+  settleExpiry(contractId: string, payout: number): Promise<Result<boolean>>;
+  /**
+   * Rolls an elected contract's window forward one tier at renewal (ADR 0003):
+   * `purchaseDate ← old expireDate`, `expireDate += tierDays`,
+   * `purchasePrice ← currentPrice + premium`, `renewalCount++`, and clears
+   * `renewalElected`. Guarded on the row being unsettled AND `renewalElected=1`,
+   * so a re-run is a no-op (the flag is cleared and the window has moved past
+   * `today`). Result<boolean>: true iff this call actually renewed it.
+   */
+  renew(
+    contractId: string,
+    newPurchaseDate: Temporal.PlainDate,
+    newExpireDate: Temporal.PlainDate,
+    newPurchasePrice: number,
+  ): Promise<Result<boolean>>;
+  /**
+   * Records the owner's intent to renew a contract at expiry by setting
+   * `renewalElected=1`. Guarded on the row being unsettled and owned by
+   * `teamId`. The renewal itself is executed later by the sweep. Result<boolean>:
+   * true iff this call flipped the flag.
+   */
+  electRenewal(contractId: string, teamId: string): Promise<Result<boolean>>;
 }

--- a/backend/src/repositories/d1/contractRepositoryD1.ts
+++ b/backend/src/repositories/d1/contractRepositoryD1.ts
@@ -3,6 +3,7 @@ import { Contract } from "../../../../model";
 import { STARTING_CREDITS } from "../../../../model/team";
 import {
   ContractRepository,
+  DueContract,
   LeagueContractRow,
   NewContract,
 } from "../contractRepository";
@@ -27,6 +28,11 @@ interface LeagueContractQueryRow extends ContractRow {
   playerName: string;
 }
 
+interface DueContractQueryRow extends ContractRow {
+  domain: string;
+  teamCredits: number;
+}
+
 function toContract(row: ContractRow): Contract {
   return {
     id: row.id,
@@ -48,6 +54,14 @@ function toLeagueContractRow(row: LeagueContractQueryRow): LeagueContractRow {
     teamCredits: row.teamCredits,
     playerId: row.playerId,
     playerName: row.playerName,
+  };
+}
+
+function toDueContract(row: DueContractQueryRow): DueContract {
+  return {
+    ...toContract(row),
+    domain: row.domain,
+    teamCredits: row.teamCredits,
   };
 }
 
@@ -203,6 +217,125 @@ export class ContractRepositoryD1 implements ContractRepository {
     } catch (error) {
       return failure(
         `Error selling contract: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  async getDueForSettlement(
+    today: Temporal.PlainDate,
+  ): Promise<Result<DueContract[]>> {
+    try {
+      // teamCredits is derived from the same ledger as getByLeagueId; domain
+      // comes from the owning team's league. The WHERE clause rides the
+      // idx_contracts_settled_expire (settled, expireDate) index.
+      const result = await this.db
+        .prepare(
+          `WITH team_credits AS (
+             SELECT teamId,
+                    ? - COALESCE(SUM(purchasePrice), 0)
+                      + COALESCE(SUM(CASE WHEN settled = 1 THEN salePayout ELSE 0 END), 0) AS credits
+             FROM contracts
+             GROUP BY teamId
+           )
+           SELECT c.*, l.domain AS domain, tc.credits AS teamCredits
+           FROM contracts c
+           JOIN teams t ON c.teamId = t.id
+           JOIN leagues l ON t.leagueId = l.id
+           JOIN team_credits tc ON tc.teamId = t.id
+           WHERE c.settled = 0 AND c.expireDate <= ?`,
+        )
+        .bind(STARTING_CREDITS, today.toString())
+        .all<DueContractQueryRow>();
+
+      return success(result.results.map(toDueContract));
+    } catch (error) {
+      return failure(
+        `Error fetching due contracts: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  async settleExpiry(
+    contractId: string,
+    payout: number,
+  ): Promise<Result<boolean>> {
+    try {
+      // Same guarded single-write shape as settleSale, but system-driven (no
+      // teamId guard needed): guarded on settled=0 so a re-run of the sweep is
+      // idempotent. The payout lands in the shared salePayout ledger column.
+      const result = await this.db
+        .prepare(
+          `UPDATE contracts SET settled = 1, salePayout = ? WHERE id = ? AND settled = 0`,
+        )
+        .bind(payout, contractId)
+        .run();
+
+      if (!result.success) {
+        return failure("Error settling contract at expiry");
+      }
+      return success(result.meta.changes > 0);
+    } catch (error) {
+      return failure(
+        `Error settling contract at expiry: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  async renew(
+    contractId: string,
+    newPurchaseDate: Temporal.PlainDate,
+    newExpireDate: Temporal.PlainDate,
+    newPurchasePrice: number,
+  ): Promise<Result<boolean>> {
+    try {
+      // Guarded on settled=0 AND renewalElected=1: once this runs, renewalElected
+      // is cleared and expireDate moves past today, so a re-run of the sweep
+      // can neither pick the row up again nor double-apply the premium.
+      const result = await this.db
+        .prepare(
+          `UPDATE contracts
+           SET purchaseDate = ?, expireDate = ?, purchasePrice = ?,
+               renewalCount = renewalCount + 1, renewalElected = 0
+           WHERE id = ? AND settled = 0 AND renewalElected = 1`,
+        )
+        .bind(
+          newPurchaseDate.toString(),
+          newExpireDate.toString(),
+          newPurchasePrice,
+          contractId,
+        )
+        .run();
+
+      if (!result.success) {
+        return failure("Error renewing contract");
+      }
+      return success(result.meta.changes > 0);
+    } catch (error) {
+      return failure(
+        `Error renewing contract: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  async electRenewal(
+    contractId: string,
+    teamId: string,
+  ): Promise<Result<boolean>> {
+    try {
+      const result = await this.db
+        .prepare(
+          `UPDATE contracts SET renewalElected = 1 WHERE id = ? AND teamId = ? AND settled = 0`,
+        )
+        .bind(contractId, teamId)
+        .run();
+
+      if (!result.success) {
+        return failure("Error electing contract renewal");
+      }
+      return success(result.meta.changes > 0);
+    } catch (error) {
+      return failure(
+        `Error electing contract renewal: ${error instanceof Error ? error.message : "Unknown error"}`,
       );
     }
   }

--- a/backend/src/routes/leagues.ts
+++ b/backend/src/routes/leagues.ts
@@ -237,6 +237,26 @@ leagues.post("/:id/my-contracts/:contractId/sell", async (c) => {
   return c.json(result.value);
 });
 
+leagues.post("/:id/my-contracts/:contractId/renew", async (c) => {
+  const leagueId = c.req.param("id");
+  const contractId = c.req.param("contractId");
+  const playerResult = await resolveCurrentPlayer(c);
+  if (!playerResult.ok) {
+    return c.json({ error: playerResult.error }, 404);
+  }
+
+  const service = new ContractService(c.env.db);
+  const result = await service.electRenewal(
+    playerResult.value.id,
+    leagueId,
+    contractId,
+  );
+  if (!result.ok) {
+    return c.json({ error: result.error }, contractErrorStatus(result.error));
+  }
+  return c.json(result.value);
+});
+
 leagues.get("/:id/contracts", async (c) => {
   const leagueId = c.req.param("id");
   const service = new ContractService(c.env.db);

--- a/backend/src/services/contract.ts
+++ b/backend/src/services/contract.ts
@@ -5,10 +5,14 @@ import {
   ContractTier,
   TIER_DAYS,
   computeContractPrice,
+  computeCurrentPrice,
   normalizedViews,
   resolveLanguageScale,
 } from "../../../model/pricing";
-import { ContractRepository } from "../repositories/contractRepository";
+import {
+  ContractRepository,
+  DueContract,
+} from "../repositories/contractRepository";
 import { ContractRepositoryD1 } from "../repositories/d1/contractRepositoryD1";
 import { LeagueRepository } from "../repositories/leagueRepository";
 import { LeagueRepositoryD1 } from "../repositories/d1/leagueRepositoryD1";
@@ -24,6 +28,8 @@ import { createWikimediaClient } from "./wikimediaClient";
 import { toRawContract } from "./rawContract";
 
 export const MAX_TEAM_CONTRACTS = 22;
+/** ADR 0003: +10% of currentPrice per consecutive renewal (anti-hoard sink). */
+export const RENEWAL_PREMIUM_RATE = 0.1;
 const VALID_TIERS: ContractTier[] = ["SHORT", "MEDIUM", "LONG"];
 
 function isContractTier(tier: string): tier is ContractTier {
@@ -407,5 +413,221 @@ export class ContractService {
         ),
       ),
     );
+  }
+
+  /**
+   * All unsettled contracts at or past their `expireDate` — the work list for
+   * the daily settlement sweep. Thin passthrough to the repository so the
+   * settlement Workflow depends only on the service layer.
+   */
+  async getDueForSettlement(
+    today: Temporal.PlainDate,
+  ): Promise<Result<DueContract[]>> {
+    return this.contractRepo.getDueForSettlement(today);
+  }
+
+  /**
+   * Records the current player's intent to renew one of their contracts at
+   * expiry (ADR 0003's final-24h right-of-first-refusal). This only flips
+   * `renewalElected` — the renewal is executed by the daily settlement sweep,
+   * which is the single money-writer, so no price is computed or charged here.
+   *
+   * The server stores dates only, so the window guard is coarse
+   * (`0 <= remainingDays <= 1`); the frontend applies the finer sub-24h gate.
+   * Affordability is deliberately not checked here — the price isn't known
+   * until expiry — so electing only records intent; the sweep does the
+   * authoritative affordability check and settles instead if it can't be met.
+   */
+  async electRenewal(
+    playerId: string,
+    leagueId: string,
+    contractId: string,
+  ): Promise<Result<RawContract>> {
+    const [teamResult, leagueResult, contractResult] = await Promise.all([
+      this.teamRepo.getByPlayerAndLeague(playerId, leagueId),
+      this.leagueRepo.getById(leagueId),
+      this.contractRepo.getById(contractId),
+    ]);
+    if (!teamResult.ok) {
+      return teamResult;
+    }
+    if (teamResult.value === null) {
+      return failure("No team found for this league");
+    }
+    const team = teamResult.value;
+
+    if (!leagueResult.ok) {
+      return leagueResult;
+    }
+    const domain = leagueResult.value.domain as Domain;
+
+    if (!contractResult.ok) {
+      return contractResult;
+    }
+    const contract = contractResult.value;
+    if (contract === null) {
+      return failure("Contract not found");
+    }
+    if (contract.teamId !== team.id) {
+      return failure("You do not own this contract");
+    }
+    if (contract.settled) {
+      return failure("Contract already settled");
+    }
+
+    const today = Temporal.Now.plainDateISO();
+    const remainingDays = today.until(contract.expireDate).days;
+    if (remainingDays < 0) {
+      return failure("Contract has already expired");
+    }
+    if (remainingDays > 1) {
+      return failure(
+        "Renewal can only be elected in the final 24 hours before expiry",
+      );
+    }
+
+    const [electResult, playerResult] = await Promise.all([
+      this.contractRepo.electRenewal(contract.id, team.id),
+      this.playerRepo.getById(playerId),
+    ]);
+    if (!electResult.ok) {
+      return electResult;
+    }
+    if (!electResult.value) {
+      return failure("Contract not found");
+    }
+
+    // Election moves no money, so credits are unchanged.
+    return success(
+      toRawContract(
+        { ...contract, renewalElected: true },
+        { id: team.id, name: team.name, credits: team.credits },
+        {
+          id: playerId,
+          name: playerResult.ok ? playerResult.value.username : "",
+        },
+        domain,
+      ),
+    );
+  }
+
+  /**
+   * Resolves a single contract that has reached the end of its term (ADR 0003
+   * "sold to system" / renewal). Called once per due contract by the daily
+   * settlement Workflow, so the durable step is a thin wrapper over this.
+   *
+   * - No renewal elected → **settle**: credit the full live `currentPrice`
+   *   (`settled=1`, payout into the salePayout ledger) and notify with the P&L.
+   * - Renewal elected AND affordable → **renew**: roll the window forward a
+   *   tier at `currentPrice + premium` and notify. "Affordable" means the
+   *   incremental capital `newPurchasePrice − purchasePrice` (the actual ledger
+   *   movement, since the old purchasePrice is already sunk) fits in the team's
+   *   derived credits.
+   * - Renewal elected but unaffordable → **settle instead**, with a message
+   *   saying the renewal failed for insufficient credits.
+   *
+   * Throws on a failed/again-missing views fetch or a DB write error so the
+   * Workflow step retries; the guarded writes make a re-run a no-op, so a
+   * contract already settled/renewed by a prior run is skipped safely.
+   */
+  async settleDueContract(contract: DueContract): Promise<void> {
+    const domain = contract.domain as Domain;
+    const tierDays = contract.purchaseDate.until(contract.expireDate).days;
+    const today = Temporal.Now.plainDateISO();
+    const articleTitle = contract.articleId.replace(/_/g, " ");
+
+    const views = await this.wikimedia.pageviews.getArticleViews(
+      domain,
+      contract.articleId,
+    );
+    // Never settle at 0 on a failed fetch (that would hand out a free/forfeited
+    // settlement). Throw so the Workflow step retries; the contract stays
+    // settled=0 and is re-picked by the next sweep.
+    if (views.averageViews30d === undefined) {
+      throw new Error(
+        `Couldn't fetch views for ${contract.articleId}; deferring settlement`,
+      );
+    }
+    const currentPrice = computeCurrentPrice(
+      views.averageViews30d,
+      domain,
+      tierDays,
+    );
+
+    if (contract.renewalElected) {
+      const premium = Math.round(
+        currentPrice * RENEWAL_PREMIUM_RATE * contract.renewalCount,
+      );
+      const newPurchasePrice = currentPrice + premium;
+      // Incremental cost is the real balance movement: the old purchasePrice is
+      // already sunk in the derived ledger. A drop in currentPrice can make
+      // this <= 0, i.e. always affordable.
+      const incrementalCost = newPurchasePrice - contract.purchasePrice;
+      if (incrementalCost <= contract.teamCredits) {
+        const newExpireDate = contract.expireDate.add({ days: tierDays });
+        const renewResult = await this.contractRepo.renew(
+          contract.id,
+          contract.expireDate, // new purchaseDate = old expireDate
+          newExpireDate,
+          newPurchasePrice,
+        );
+        if (!renewResult.ok) {
+          throw new Error(renewResult.error);
+        }
+        // Only notify when this call actually renewed the row (a re-run that
+        // finds it already renewed is a silent no-op).
+        if (renewResult.value) {
+          await this.writeSettlementNotification(
+            contract.id,
+            `Renewed ${articleTitle} for ${tierDays} more days at ${newPurchasePrice} credits (+${premium} premium)`,
+            today,
+          );
+        }
+        return;
+      }
+      // Unaffordable: fall through to settlement below.
+    }
+
+    const delta = currentPrice - contract.purchasePrice;
+    const signed = delta >= 0 ? `+${delta}` : `−${Math.abs(delta)}`;
+    const settleResult = await this.contractRepo.settleExpiry(
+      contract.id,
+      currentPrice,
+    );
+    if (!settleResult.ok) {
+      throw new Error(settleResult.error);
+    }
+    if (settleResult.value) {
+      // Reaching the settle branch with renewalElected set means the renewal
+      // was elected but couldn't be afforded.
+      const message = contract.renewalElected
+        ? `Couldn't renew ${articleTitle} (not enough credits) — settled at expiry: ${signed} credits`
+        : `${articleTitle} settled at expiry: ${signed} credits`;
+      await this.writeSettlementNotification(contract.id, message, today);
+    }
+  }
+
+  /**
+   * Best-effort settlement notification: mirrors sellContract's stance — the
+   * money write already succeeded, so a failed notification is logged, never
+   * thrown (throwing would send the Workflow step into a needless retry that
+   * re-does nothing, the settlement being idempotent).
+   */
+  private async writeSettlementNotification(
+    contractId: string,
+    message: string,
+    today: Temporal.PlainDate,
+  ): Promise<void> {
+    const result = await this.notificationRepo.create({
+      id: crypto.randomUUID(),
+      contractId,
+      message,
+      date: today.toString(),
+    });
+    if (!result.ok) {
+      console.error(
+        `Failed to create settlement notification for contract ${contractId}: ${result.error}`,
+      );
+    }
   }
 }

--- a/backend/src/services/rawContract.ts
+++ b/backend/src/services/rawContract.ts
@@ -33,5 +33,7 @@ export function toRawContract(
     startDate: `${contract.purchaseDate.toString()}T00:00:00Z`,
     duration: `P${days}D`,
     purchasePrice: contract.purchasePrice,
+    renewalCount: contract.renewalCount,
+    renewalElected: contract.renewalElected,
   };
 }

--- a/backend/src/tests/integration/contractSettlement.integration.test.ts
+++ b/backend/src/tests/integration/contractSettlement.integration.test.ts
@@ -1,0 +1,643 @@
+import { env } from "cloudflare:workers";
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, it, expect, beforeEach } from "vitest";
+import { ContractService } from "../../services/contract";
+import { NotificationService } from "../../services/notification";
+import { PlayerService } from "../../services/player";
+import { TeamRepositoryD1 } from "../../repositories/d1/teamRepositoryD1";
+import { WikimediaClient } from "../../../../external-apis/wikimedia/client";
+import { STARTING_CREDITS } from "../../../../model/team";
+import {
+  computeContractPrice,
+  normalizedViews,
+  resolveLanguageScale,
+} from "../../../../model/pricing";
+import { insertTeam } from "../utils/d1TestUtils";
+
+/**
+ * WikimediaClient stub exposing only `pageviews.getArticleViews`, the sole
+ * capability the settlement sweep exercises; everything else throws so an
+ * accidental dependency fails loudly. Mirrors the helper in
+ * contract.integration.test.ts.
+ */
+function wikimediaClientWithArticleViews(
+  getArticleViews: WikimediaClient["pageviews"]["getArticleViews"],
+): WikimediaClient {
+  const unimplemented = () => {
+    throw new Error("not implemented in stub");
+  };
+  return {
+    pageviews: {
+      getArticleViews,
+      getTopReadList: unimplemented,
+      getViewsByDomain: unimplemented,
+    },
+    article: {
+      getSummary: unimplemented,
+      getLinkedArticles: unimplemented,
+      search: unimplemented,
+    },
+  } as unknown as WikimediaClient;
+}
+
+function wikimediaWithAvg(
+  averageViews30d: number | undefined,
+): WikimediaClient {
+  return wikimediaClientWithArticleViews(async () => ({
+    latestDayViews: undefined,
+    averageViews30d,
+    weekViews: undefined,
+    previousWeekViews: undefined,
+    monthViews: undefined,
+    yearViews: undefined,
+  }));
+}
+
+function priceFor(averageViews30d: number, tierDays: number): number {
+  return computeContractPrice(
+    normalizedViews(averageViews30d, resolveLanguageScale("en")),
+    tierDays,
+  );
+}
+
+async function getDerivedCredits(
+  playerId: string,
+  leagueId: string,
+): Promise<number | null> {
+  const result = await new TeamRepositoryD1(env.db).getByPlayerAndLeague(
+    playerId,
+    leagueId,
+  );
+  if (!result.ok || result.value === null) return null;
+  return result.value.credits;
+}
+
+async function readContractRow(id: string) {
+  return env.db.prepare("SELECT * FROM contracts WHERE id = ?").bind(id).first<{
+    purchaseDate: string;
+    expireDate: string;
+    purchasePrice: number;
+    settled: number;
+    salePayout: number | null;
+    renewalCount: number;
+    renewalElected: number;
+  }>();
+}
+
+describe("ContractService settlement sweep Integration Tests", () => {
+  let playerService: PlayerService;
+  let leagueId: string;
+  let playerId: string;
+  let teamId: string;
+
+  /**
+   * Inserts an unsettled contract whose held tier is `tierDays` and whose
+   * `expireDate` is `daysPastExpiry` days before today (default 0 = due today),
+   * so it is picked up by the settlement sweep (`expireDate <= today`).
+   */
+  async function insertDueContract(opts: {
+    id: string;
+    tierDays: number;
+    purchasePrice: number;
+    daysPastExpiry?: number;
+    renewalElected?: boolean;
+    renewalCount?: number;
+    articleId?: string;
+    ownerTeamId?: string;
+  }): Promise<void> {
+    const today = Temporal.Now.plainDateISO();
+    const expireDate = today.subtract({ days: opts.daysPastExpiry ?? 0 });
+    const purchaseDate = expireDate.subtract({ days: opts.tierDays });
+    await env.db
+      .prepare(
+        `INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice, renewalElected, renewalCount)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        opts.id,
+        opts.ownerTeamId ?? teamId,
+        opts.articleId ?? "Bitcoin",
+        purchaseDate.toString(),
+        expireDate.toString(),
+        opts.purchasePrice,
+        opts.renewalElected ? 1 : 0,
+        opts.renewalCount ?? 0,
+      )
+      .run();
+  }
+
+  /** Insert a far-future unsettled contract purely to drain derived credits. */
+  async function insertCreditDrain(purchasePrice: number): Promise<void> {
+    const today = Temporal.Now.plainDateISO();
+    await env.db
+      .prepare(
+        "INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        "contract-drain",
+        teamId,
+        "Drain_Article",
+        today.toString(),
+        today.add({ days: 30 }).toString(),
+        purchasePrice,
+      )
+      .run();
+  }
+
+  /** Runs the whole sweep: fetch due contracts, settle/renew each. */
+  async function runSweep(service: ContractService): Promise<void> {
+    const today = Temporal.Now.plainDateISO();
+    const dueResult = await service.getDueForSettlement(today);
+    expect(dueResult.ok).toBe(true);
+    if (!dueResult.ok) return;
+    for (const contract of dueResult.value) {
+      await service.settleDueContract(contract);
+    }
+  }
+
+  beforeEach(async () => {
+    playerService = new PlayerService(env.db);
+
+    const playerResult = await playerService.createPlayer(
+      "settletester",
+      "settletester@example.com",
+      "account-settle-1",
+    );
+    expect(playerResult.ok).toBe(true);
+    if (!playerResult.ok) throw new Error("setup failed: player");
+    playerId = playerResult.value.id;
+
+    leagueId = "league-settle-1";
+    await env.db
+      .prepare(
+        `INSERT INTO leagues (id, name, adminId, startDate, endDate, domain, icon)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        leagueId,
+        "Settle League",
+        playerId,
+        new Date().toISOString(),
+        new Date().toISOString(),
+        "en",
+        "🏆",
+      )
+      .run();
+
+    teamId = "team-settle-1";
+    await insertTeam(env.db, {
+      id: teamId,
+      name: "Settle FC",
+      playerId,
+      leagueId,
+    });
+  });
+
+  it("settles an expired, non-renewed contract at a profit and notifies with the P&L", async () => {
+    const tierDays = 7;
+    const purchasePrice = 50;
+    await insertDueContract({
+      id: "contract-profit",
+      tierDays,
+      purchasePrice,
+      articleId: "Cristiano_Ronaldo",
+    });
+
+    const service = new ContractService(
+      env.db,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      wikimediaWithAvg(120000),
+    );
+    await runSweep(service);
+
+    const currentPrice = priceFor(120000, tierDays);
+    const delta = currentPrice - purchasePrice;
+    expect(delta).toBeGreaterThan(0);
+
+    const row = await readContractRow("contract-profit");
+    expect(row?.settled).toBe(1);
+    expect(row?.salePayout).toBe(currentPrice);
+
+    // Credits = STARTING - purchasePrice + salePayout(settled).
+    const credits = await getDerivedCredits(playerId, leagueId);
+    expect(credits).toBe(STARTING_CREDITS - purchasePrice + currentPrice);
+
+    const notifications = await new NotificationService(
+      env.db,
+    ).getMyNotifications(playerId, leagueId);
+    expect(notifications.ok).toBe(true);
+    if (!notifications.ok) return;
+    expect(notifications.value).toHaveLength(1);
+    expect(notifications.value[0].message).toBe(
+      `Cristiano Ronaldo settled at expiry: +${delta} credits`,
+    );
+    expect(notifications.value[0].contract.id).toBe("contract-profit");
+  });
+
+  it("settles an expired, non-renewed contract at a loss with a negative-signed notification", async () => {
+    const tierDays = 7;
+    const purchasePrice = 800;
+    await insertDueContract({
+      id: "contract-loss",
+      tierDays,
+      purchasePrice,
+      articleId: "Bitcoin",
+    });
+
+    const service = new ContractService(
+      env.db,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      wikimediaWithAvg(9000),
+    );
+    await runSweep(service);
+
+    const currentPrice = priceFor(9000, tierDays);
+    const delta = currentPrice - purchasePrice;
+    expect(delta).toBeLessThan(0);
+
+    const row = await readContractRow("contract-loss");
+    expect(row?.settled).toBe(1);
+    expect(row?.salePayout).toBe(currentPrice);
+
+    const notifications = await new NotificationService(
+      env.db,
+    ).getMyNotifications(playerId, leagueId);
+    expect(notifications.ok).toBe(true);
+    if (!notifications.ok) return;
+    expect(notifications.value[0].message).toBe(
+      `Bitcoin settled at expiry: −${Math.abs(delta)} credits`,
+    );
+  });
+
+  it("renews an elected, affordable contract: rolls the window, bumps count, charges the premium", async () => {
+    const tierDays = 7;
+    const purchasePrice = 100;
+    const renewalCount = 1;
+    await insertDueContract({
+      id: "contract-renew",
+      tierDays,
+      purchasePrice,
+      renewalElected: true,
+      renewalCount,
+      articleId: "Ethereum",
+    });
+    const oldRow = await readContractRow("contract-renew");
+
+    const views = 9000;
+    const service = new ContractService(
+      env.db,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      wikimediaWithAvg(views),
+    );
+    await runSweep(service);
+
+    const currentPrice = priceFor(views, tierDays);
+    const premium = Math.round(currentPrice * 0.1 * renewalCount);
+    const newPurchasePrice = currentPrice + premium;
+    // Affordability precondition for this scenario.
+    expect(newPurchasePrice - purchasePrice).toBeLessThanOrEqual(
+      STARTING_CREDITS - purchasePrice,
+    );
+
+    const row = await readContractRow("contract-renew");
+    // Not settled — the position rolls forward.
+    expect(row?.settled).toBe(0);
+    expect(row?.renewalElected).toBe(0);
+    expect(row?.renewalCount).toBe(renewalCount + 1);
+    expect(row?.purchasePrice).toBe(newPurchasePrice);
+    // Window rolled: purchaseDate <- old expireDate, expireDate += tierDays.
+    expect(row?.purchaseDate).toBe(oldRow?.expireDate);
+    expect(row?.expireDate).toBe(
+      Temporal.PlainDate.from(oldRow!.expireDate)
+        .add({ days: tierDays })
+        .toString(),
+    );
+
+    const notifications = await new NotificationService(
+      env.db,
+    ).getMyNotifications(playerId, leagueId);
+    expect(notifications.ok).toBe(true);
+    if (!notifications.ok) return;
+    expect(notifications.value[0].message).toBe(
+      `Renewed Ethereum for ${tierDays} more days at ${newPurchasePrice} credits (+${premium} premium)`,
+    );
+  });
+
+  it("settles instead of renewing when the elected renewal is unaffordable", async () => {
+    const tierDays = 7;
+    const purchasePrice = 0;
+    // Drain credits so teamCredits is tiny, making the renewal unaffordable.
+    await insertCreditDrain(STARTING_CREDITS - 10);
+    await insertDueContract({
+      id: "contract-renew-broke",
+      tierDays,
+      purchasePrice,
+      renewalElected: true,
+      renewalCount: 0,
+      articleId: "Ethereum",
+    });
+
+    const views = 120000;
+    const currentPrice = priceFor(views, tierDays);
+    // Precondition: incremental cost (currentPrice - 0) exceeds the ~10 credits left.
+    expect(currentPrice).toBeGreaterThan(10);
+
+    const service = new ContractService(
+      env.db,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      wikimediaWithAvg(views),
+    );
+    await runSweep(service);
+
+    const row = await readContractRow("contract-renew-broke");
+    // Fell through to settlement.
+    expect(row?.settled).toBe(1);
+    expect(row?.salePayout).toBe(currentPrice);
+    expect(row?.renewalElected).toBe(1); // untouched; only the sweep's settle path ran
+    expect(row?.renewalCount).toBe(0);
+
+    const delta = currentPrice - purchasePrice;
+    const notifications = await new NotificationService(
+      env.db,
+    ).getMyNotifications(playerId, leagueId);
+    expect(notifications.ok).toBe(true);
+    if (!notifications.ok) return;
+    expect(notifications.value[0].message).toBe(
+      `Couldn't renew Ethereum (not enough credits) — settled at expiry: +${delta} credits`,
+    );
+  });
+
+  it("is idempotent: a second sweep over already-settled contracts is a no-op", async () => {
+    const tierDays = 7;
+    const purchasePrice = 50;
+    await insertDueContract({
+      id: "contract-idem",
+      tierDays,
+      purchasePrice,
+    });
+
+    const service = new ContractService(
+      env.db,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      wikimediaWithAvg(120000),
+    );
+
+    await runSweep(service);
+    const creditsAfterFirst = await getDerivedCredits(playerId, leagueId);
+
+    // Second sweep: getDueForSettlement no longer returns the settled row.
+    const secondDue = await service.getDueForSettlement(
+      Temporal.Now.plainDateISO(),
+    );
+    expect(secondDue.ok).toBe(true);
+    if (secondDue.ok) {
+      expect(secondDue.value.map((c) => c.id)).not.toContain("contract-idem");
+    }
+    await runSweep(service);
+
+    const creditsAfterSecond = await getDerivedCredits(playerId, leagueId);
+    expect(creditsAfterSecond).toBe(creditsAfterFirst);
+
+    // No duplicate notification.
+    const notifications = await new NotificationService(
+      env.db,
+    ).getMyNotifications(playerId, leagueId);
+    expect(notifications.ok).toBe(true);
+    if (notifications.ok) {
+      expect(notifications.value).toHaveLength(1);
+    }
+  });
+
+  it("re-picks (does not settle) a contract whose views fetch fails, so the sweep can retry later", async () => {
+    await insertDueContract({
+      id: "contract-noviews",
+      tierDays: 7,
+      purchasePrice: 50,
+    });
+
+    const service = new ContractService(
+      env.db,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      wikimediaWithAvg(undefined),
+    );
+
+    const today = Temporal.Now.plainDateISO();
+    const due = await service.getDueForSettlement(today);
+    expect(due.ok).toBe(true);
+    if (!due.ok) return;
+    const contract = due.value.find((c) => c.id === "contract-noviews");
+    expect(contract).toBeDefined();
+
+    // Throws so the Workflow step retries; the row stays unsettled.
+    await expect(service.settleDueContract(contract!)).rejects.toThrow();
+
+    const row = await readContractRow("contract-noviews");
+    expect(row?.settled).toBe(0);
+  });
+});
+
+describe("ContractService.electRenewal Integration Tests", () => {
+  let playerService: PlayerService;
+  let leagueId: string;
+  let playerId: string;
+  let teamId: string;
+
+  async function insertContractExpiringIn(opts: {
+    id: string;
+    remainingDays: number;
+    settled?: boolean;
+    ownerTeamId?: string;
+  }): Promise<void> {
+    const today = Temporal.Now.plainDateISO();
+    const tierDays = 7;
+    const expireDate = today.add({ days: opts.remainingDays });
+    const purchaseDate = expireDate.subtract({ days: tierDays });
+    await env.db
+      .prepare(
+        `INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice, settled)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        opts.id,
+        opts.ownerTeamId ?? teamId,
+        "Bitcoin",
+        purchaseDate.toString(),
+        expireDate.toString(),
+        100,
+        opts.settled ? 1 : 0,
+      )
+      .run();
+  }
+
+  beforeEach(async () => {
+    playerService = new PlayerService(env.db);
+
+    const playerResult = await playerService.createPlayer(
+      "electtester",
+      "electtester@example.com",
+      "account-elect-1",
+    );
+    expect(playerResult.ok).toBe(true);
+    if (!playerResult.ok) throw new Error("setup failed: player");
+    playerId = playerResult.value.id;
+
+    leagueId = "league-elect-1";
+    await env.db
+      .prepare(
+        `INSERT INTO leagues (id, name, adminId, startDate, endDate, domain, icon)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        leagueId,
+        "Elect League",
+        playerId,
+        new Date().toISOString(),
+        new Date().toISOString(),
+        "en",
+        "🏆",
+      )
+      .run();
+
+    teamId = "team-elect-1";
+    await insertTeam(env.db, {
+      id: teamId,
+      name: "Elect FC",
+      playerId,
+      leagueId,
+    });
+  });
+
+  it("elects renewal for a contract inside the final-24h window", async () => {
+    await insertContractExpiringIn({
+      id: "contract-elect-ok",
+      remainingDays: 1,
+    });
+
+    const service = new ContractService(env.db);
+    const result = await service.electRenewal(
+      playerId,
+      leagueId,
+      "contract-elect-ok",
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.renewalElected).toBe(true);
+
+    const row = await env.db
+      .prepare("SELECT renewalElected FROM contracts WHERE id = ?")
+      .bind("contract-elect-ok")
+      .first<{ renewalElected: number }>();
+    expect(row?.renewalElected).toBe(1);
+  });
+
+  it("rejects election that is too early (outside the final-24h window)", async () => {
+    await insertContractExpiringIn({
+      id: "contract-elect-early",
+      remainingDays: 3,
+    });
+
+    const service = new ContractService(env.db);
+    const result = await service.electRenewal(
+      playerId,
+      leagueId,
+      "contract-elect-early",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Renewal can only be elected in the final 24 hours before expiry",
+    });
+  });
+
+  it("rejects election for an already-expired contract", async () => {
+    await insertContractExpiringIn({
+      id: "contract-elect-expired",
+      remainingDays: -1,
+    });
+
+    const service = new ContractService(env.db);
+    const result = await service.electRenewal(
+      playerId,
+      leagueId,
+      "contract-elect-expired",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Contract has already expired",
+    });
+  });
+
+  it("rejects electing a contract owned by another team", async () => {
+    const otherPlayer = await playerService.createPlayer(
+      "electother",
+      "electother@example.com",
+      "account-elect-other-1",
+    );
+    expect(otherPlayer.ok).toBe(true);
+    if (!otherPlayer.ok) return;
+    const otherTeamId = "team-elect-other-1";
+    await insertTeam(env.db, {
+      id: otherTeamId,
+      name: "Other Elect FC",
+      playerId: otherPlayer.value.id,
+      leagueId,
+    });
+    await insertContractExpiringIn({
+      id: "contract-elect-other",
+      remainingDays: 1,
+      ownerTeamId: otherTeamId,
+    });
+
+    const service = new ContractService(env.db);
+    const result = await service.electRenewal(
+      playerId,
+      leagueId,
+      "contract-elect-other",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "You do not own this contract",
+    });
+  });
+
+  it("rejects electing an already-settled contract", async () => {
+    await insertContractExpiringIn({
+      id: "contract-elect-settled",
+      remainingDays: 1,
+      settled: true,
+    });
+
+    const service = new ContractService(env.db);
+    const result = await service.electRenewal(
+      playerId,
+      leagueId,
+      "contract-elect-settled",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Contract already settled",
+    });
+  });
+});

--- a/backend/src/workflows/contractSettlement.ts
+++ b/backend/src/workflows/contractSettlement.ts
@@ -1,0 +1,106 @@
+import {
+  WorkflowEntrypoint,
+  WorkflowEvent,
+  WorkflowStep,
+} from "cloudflare:workers";
+import { Temporal } from "@js-temporal/polyfill";
+import { ContractService } from "../services/contract";
+import { DueContract } from "../repositories/contractRepository";
+
+export type ContractSettlementParams = {
+  /** ISO date (YYYY-MM-DD) the sweep resolves contracts as of. */
+  today: string;
+};
+
+type Env = {
+  db: D1Database;
+};
+
+/**
+ * A DueContract flattened to a JSON-serializable shape so it can cross the
+ * boundary between the `fetch-due` step and each per-contract `settle-*` step
+ * (Temporal.PlainDate isn't serializable). `teamCredits` is the derived
+ * balance at the start of the sweep — a fine basis for the daily settlement
+ * job, which is the single money-writer.
+ */
+type SerializedDueContract = {
+  id: string;
+  teamId: string;
+  articleId: string;
+  purchaseDate: string;
+  expireDate: string;
+  purchasePrice: number;
+  settled: boolean;
+  renewalCount: number;
+  renewalElected: boolean;
+  domain: string;
+  teamCredits: number;
+};
+
+function serialize(contract: DueContract): SerializedDueContract {
+  return {
+    id: contract.id,
+    teamId: contract.teamId,
+    articleId: contract.articleId,
+    purchaseDate: contract.purchaseDate.toString(),
+    expireDate: contract.expireDate.toString(),
+    purchasePrice: contract.purchasePrice,
+    settled: contract.settled,
+    renewalCount: contract.renewalCount,
+    renewalElected: contract.renewalElected,
+    domain: contract.domain,
+    teamCredits: contract.teamCredits,
+  };
+}
+
+function deserialize(contract: SerializedDueContract): DueContract {
+  return {
+    id: contract.id,
+    teamId: contract.teamId,
+    articleId: contract.articleId,
+    purchaseDate: Temporal.PlainDate.from(contract.purchaseDate),
+    expireDate: Temporal.PlainDate.from(contract.expireDate),
+    purchasePrice: contract.purchasePrice,
+    settled: contract.settled,
+    renewalCount: contract.renewalCount,
+    renewalElected: contract.renewalElected,
+    domain: contract.domain,
+    teamCredits: contract.teamCredits,
+  };
+}
+
+/**
+ * Daily settlement sweep (ADR 0003), run as a durable Workflow so each
+ * contract is resolved in its own retryable step: a flaky Wikimedia call or a
+ * transient D1 error retries that one contract with backoff without re-doing
+ * the others, and the guarded writes in ContractService make every step
+ * idempotent. The Workflow stays thin — all business logic lives in
+ * `ContractService.settleDueContract`, which the integration tests exercise
+ * directly.
+ */
+export class ContractSettlementWorkflow extends WorkflowEntrypoint<
+  Env,
+  ContractSettlementParams
+> {
+  async run(
+    event: WorkflowEvent<ContractSettlementParams>,
+    step: WorkflowStep,
+  ): Promise<void> {
+    const today = Temporal.PlainDate.from(event.payload.today);
+    const service = new ContractService(this.env.db);
+
+    const due = await step.do("fetch-due", async () => {
+      const result = await service.getDueForSettlement(today);
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      return result.value.map(serialize);
+    });
+
+    for (const contract of due) {
+      await step.do(`settle-${contract.id}`, async () => {
+        await service.settleDueContract(deserialize(contract));
+      });
+    }
+  }
+}

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -13,6 +13,16 @@
           "database_id": "640d7014-0bf9-44f6-8026-15bf2a18cdda",
         },
       ],
+      "workflows": [
+        {
+          "binding": "CONTRACT_SETTLEMENT_WORKFLOW",
+          "name": "contract-settlement",
+          "class_name": "ContractSettlementWorkflow",
+        },
+      ],
+      "triggers": {
+        "crons": ["0 5 * * *"],
+      },
     },
     "preview": {
       "name": "backend-preview",
@@ -23,6 +33,16 @@
           "database_id": "cd2e57f5-b1c1-47f4-ac3a-70b4621043c8",
         },
       ],
+      "workflows": [
+        {
+          "binding": "CONTRACT_SETTLEMENT_WORKFLOW",
+          "name": "contract-settlement-preview",
+          "class_name": "ContractSettlementWorkflow",
+        },
+      ],
+      "triggers": {
+        "crons": ["0 5 * * *"],
+      },
     },
     "local": {
       "d1_databases": [
@@ -32,6 +52,16 @@
           "database_id": "640d7014-0bf9-44f6-8026-15bf2a18cdda",
         },
       ],
+      "workflows": [
+        {
+          "binding": "CONTRACT_SETTLEMENT_WORKFLOW",
+          "name": "contract-settlement-local",
+          "class_name": "ContractSettlementWorkflow",
+        },
+      ],
+      "triggers": {
+        "crons": ["0 5 * * *"],
+      },
       "vars": {
         "frontend_url": "https://dev.fantasywiki.pages.dev",
         "vite_backend_url": "https://backend-preview.luca0patrignani.workers.dev",

--- a/dto/contractDTO.ts
+++ b/dto/contractDTO.ts
@@ -14,6 +14,16 @@ export type RawContract = {
   startDate: string;
   duration: string | Record<string, unknown>;
   purchasePrice: number;
+  /**
+   * Consecutive renewals so far — drives the +10%-per-renewal premium.
+   * Optional on the wire for backward compatibility; defaults to 0.
+   */
+  renewalCount?: number;
+  /**
+   * Whether the owner has elected to renew this contract at expiry.
+   * Optional on the wire for backward compatibility; defaults to false.
+   */
+  renewalElected?: boolean;
 };
 
 
@@ -24,15 +34,19 @@ export class ContractDTO {
   startDate: Temporal.Instant;
   duration: Temporal.Duration;
   purchasePrice: number;
+  renewalCount: number;
+  renewalElected: boolean;
 
 
-  constructor(id: string, team: TeamDTO, article: ArticleDTO, startDate: Temporal.Instant, duration: Temporal.Duration, purchasePrice: number) {
+  constructor(id: string, team: TeamDTO, article: ArticleDTO, startDate: Temporal.Instant, duration: Temporal.Duration, purchasePrice: number, renewalCount: number = 0, renewalElected: boolean = false) {
     this.id = id;
     this.team = team;
     this.article = article;
     this.startDate = startDate;
     this.duration = duration;
     this.purchasePrice = purchasePrice;
+    this.renewalCount = renewalCount;
+    this.renewalElected = renewalElected;
   }
 
   /**
@@ -48,7 +62,9 @@ export class ContractDTO {
       raw.article,
       Temporal.Instant.from(raw.startDate),
       Temporal.Duration.from(raw.duration),
-      raw.purchasePrice
+      raw.purchasePrice,
+      raw.renewalCount,
+      raw.renewalElected
     );
   }
 

--- a/frontend/src/components/articleDetail/ArticleActions.vue
+++ b/frontend/src/components/articleDetail/ArticleActions.vue
@@ -15,10 +15,17 @@
         expand="block"
         color="primary"
         class="action-primary"
+        :disabled="renewDisabled"
         @click="emit('renew', contract)"
       >
         <ion-icon slot="start" :icon="refreshOutline" class="action-icon" />
-        {{ $t("articleDetail.actions.renewContract") }}
+        {{
+          model.renewalElected
+            ? $t("articleDetail.actions.renewElected")
+            : $t("articleDetail.actions.renewFor", {
+                price: model.renewalPrice,
+              })
+        }}
       </ion-button>
 
       <ion-button
@@ -110,6 +117,21 @@ const buyDisabled = computed(() => {
     (o) => o.tier === props.selectedTier
   );
   return !option || option.price > props.model.viewerCredits;
+});
+
+/**
+ * Renewal can only be elected in the final 24h of the term (ADR 0003), and only
+ * once — so the button is disabled outside that window, while the live price is
+ * still loading, or if renewal has already been elected. `expiresIn` is
+ * negative once past expiry, so the `> 0` guard also closes it after the term.
+ */
+const renewDisabled = computed(() => {
+  const m = props.model;
+  if (!m || m.availability !== "owned-by-viewer") return true;
+  if (props.isLoadingViews) return true;
+  if (m.renewalElected) return true;
+  const hoursLeft = m.expiresIn.total("hours");
+  return !(hoursLeft > 0 && hoursLeft <= 24);
 });
 </script>
 

--- a/frontend/src/components/teamDashboard/NeededAttention.vue
+++ b/frontend/src/components/teamDashboard/NeededAttention.vue
@@ -133,6 +133,7 @@
     :article="selectedContract.article"
     :isOpen="isModalOpen"
     @close="closeDetail"
+    @renew="onRenew"
   />
 </template>
 
@@ -167,6 +168,8 @@ import {
 import ArticleDetail from "@/components/ArticleDetail.vue";
 import { ContractDTO } from "../../../../dto/contractDTO";
 import { formatDuration } from "@/types/models";
+import { useLeagueStore } from "@/stores/league";
+import { useRenewContract } from "@/composables/useRenewContract";
 
 // ── Props ──────────────────────────────────────────────────────────────────
 // urgentContract is pre-filtered by the parent. This component does not
@@ -177,6 +180,9 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+
+const leagueStore = useLeagueStore();
+const { renewContract } = useRenewContract();
 
 // ── Local modal state ──────────────────────────────────────────────────────
 const selectedContract = ref<ContractDTO | null>(null);
@@ -205,9 +211,11 @@ function getTierColor(tier: string): string {
   }
 }
 
-function onRenew(contract: ContractDTO) {
-  // TODO: call renewal API via useMutation when the endpoint is ready
-  console.log("Renew contract", contract.id);
+async function onRenew(contract: ContractDTO) {
+  const league = leagueStore.currentLeague;
+  if (!league) return;
+  await renewContract(league.id, contract.id);
+  closeDetail();
 }
 
 function onDismiss(/*contract: Contract*/) {

--- a/frontend/src/composables/useRenewContract.ts
+++ b/frontend/src/composables/useRenewContract.ts
@@ -1,0 +1,46 @@
+import { useQueryClient } from "@tanstack/vue-query";
+import { useI18n } from "vue-i18n";
+import { useLeagueStore } from "@/stores/league";
+import { useToast } from "@/composables/useToast";
+import { leaguesApi } from "@/services/api";
+
+/**
+ * Shared "elect renewal" action, used by both the market's ArticleDetail modal
+ * and the dashboard's Needed-Attention list. Elects renewal for a contract,
+ * shows a toast, and refreshes every view the change touches (team context,
+ * market ownership badges, bench, dashboard, inbox) — the same invalidation set
+ * as the sell flow, since renewal likewise writes a notification and shifts
+ * derived credits/holdings.
+ */
+export function useRenewContract() {
+  const queryClient = useQueryClient();
+  const leagueStore = useLeagueStore();
+  const { showSuccess, showError } = useToast();
+  const { t } = useI18n();
+
+  /** Returns true on success, false if the request failed (a toast is shown either way). */
+  async function renewContract(
+    leagueId: string,
+    contractId: string
+  ): Promise<boolean> {
+    try {
+      await leaguesApi.renewMyContract(leagueId, contractId);
+      showSuccess(t("market.renewSuccess"));
+      await Promise.all([
+        leagueStore.fetchCurrentTeamContext(),
+        queryClient.invalidateQueries({
+          queryKey: ["league-contracts", leagueId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["team-lineup", leagueId] }),
+        queryClient.invalidateQueries({ queryKey: ["dashboard", leagueId] }),
+        queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+      ]);
+      return true;
+    } catch (e) {
+      showError(e instanceof Error ? e.message : t("market.renewError"));
+      return false;
+    }
+  }
+
+  return { renewContract };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -218,7 +218,8 @@
   "articleDetail": {
     "actions": {
       "buy": "Buy",
-      "renewContract": "Renew Contract",
+      "renewFor": "Renew · {price} cr",
+      "renewElected": "Renewal Elected ✓",
       "swapArticle": "Swap Article",
       "sell": "Sell Contract",
       "requestTrade": "Request Trade"
@@ -355,6 +356,8 @@
     "buySuccess": "Contract purchased",
     "buyError": "Couldn't buy this article",
     "sellSuccess": "Contract sold",
-    "sellError": "Couldn't sell this contract"
+    "sellError": "Couldn't sell this contract",
+    "renewSuccess": "Renewal elected",
+    "renewError": "Couldn't renew this contract"
   }
 }

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -218,7 +218,8 @@
   "articleDetail": {
     "actions": {
       "buy": "Acquista",
-      "renewContract": "Rinnova contratto",
+      "renewFor": "Rinnova · {price} cr",
+      "renewElected": "Rinnovo scelto ✓",
       "swapArticle": "Scambia articolo",
       "sell": "Vendi contratto",
       "requestTrade": "Proponi scambio"
@@ -355,6 +356,8 @@
     "buySuccess": "Contratto acquistato",
     "buyError": "Impossibile acquistare questo articolo",
     "sellSuccess": "Contratto venduto",
-    "sellError": "Impossibile vendere questo contratto"
+    "sellError": "Impossibile vendere questo contratto",
+    "renewSuccess": "Rinnovo scelto",
+    "renewError": "Impossibile rinnovare questo contratto"
   }
 }

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -248,6 +248,32 @@ export const handlers = [
     }
   ),
 
+  http.post(
+    "*/api/leagues/:leagueId/my-contracts/:contractId/renew",
+    ({ params }) => {
+      const team = getMyTeam(params.leagueId as string);
+      if (!team)
+        return HttpResponse.json(
+          { error: "No team found for this league" },
+          { status: 404 }
+        );
+      const contract = contracts.find((c) => c.id === params.contractId);
+      if (!contract)
+        return HttpResponse.json(
+          { error: "Contract not found" },
+          { status: 404 }
+        );
+      if (contract.team.id !== team.id)
+        return HttpResponse.json(
+          { error: "You do not own this contract" },
+          { status: 400 }
+        );
+      // Election only sets the flag; the sweep rolls the window at expiry.
+      contract.renewalElected = true;
+      return HttpResponse.json(contract);
+    }
+  ),
+
   http.get("*/api/leagues/:leagueId/contracts", ({ params }) => {
     const league = leagues.find((l) => l.id === params.leagueId);
     if (!league) return HttpResponse.json([]);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -135,6 +135,17 @@ export const leaguesApi = {
       `/leagues/${leagueId}/my-contracts/${contractId}/sell`,
       { method: "POST" }
     ).then((c) => ContractDTO.fromRaw(c)),
+
+  /**
+   * Elect to renew one of the current player's contracts at expiry (only valid
+   * in the final-24h window). Sets the renewal flag; the daily settlement sweep
+   * executes the roll-forward at expiry.
+   */
+  renewMyContract: (leagueId: string, contractId: string) =>
+    apiRequest<RawContract>(
+      `/leagues/${leagueId}/my-contracts/${contractId}/renew`,
+      { method: "POST" }
+    ).then((c) => ContractDTO.fromRaw(c)),
 };
 
 // ── Teams ─────────────────────────────────────────────────────────────────────

--- a/frontend/src/tests/MarketPage.spec.ts
+++ b/frontend/src/tests/MarketPage.spec.ts
@@ -150,7 +150,7 @@ describe("MarketPage.vue", () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain("Sell Contract");
-    expect(wrapper.text()).toContain("Renew Contract");
+    expect(wrapper.text()).toContain("Renew");
   });
 
   it("opens ArticleDetail as locked-by-other when the clicked row's contract belongs to another team", async () => {

--- a/frontend/src/tests/articleDetail/ArticleDetail.spec.ts
+++ b/frontend/src/tests/articleDetail/ArticleDetail.spec.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { Temporal } from "@js-temporal/polyfill";
 import { createPinia, setActivePinia } from "pinia";
 import { ref } from "vue";
 import ArticleDetail from "@/components/ArticleDetail.vue";
 import { ContractDTO } from "../../../../dto/contractDTO";
 import { useLeagueStore } from "@/stores/league";
+import { computeCurrentPrice, TIER_DAYS } from "../../../../model/pricing";
 import type { TeamDTO } from "../../../../dto/teamDTO";
 import type { LeagueDTO } from "../../../../dto/leagueDTO";
 import type { ArticleDTO } from "../../../../dto/articleDTO";
+
+const MOCK_AVG_VIEWS = 9000;
 
 vi.mock("@/composables/useArticleSummary", () => ({
   useArticleSummary: () => ({
@@ -19,6 +22,20 @@ vi.mock("@/composables/useArticleSummary", () => ({
     }),
     isLoading: ref(false),
     error: ref(null),
+  }),
+}));
+
+// Pin the live views so currentPrice (and the renewal premium derived from it)
+// are deterministic, and so isLoadingViews is false (the renew gate is disabled
+// while views load).
+vi.mock("@/composables/useArticleViews", () => ({
+  useArticleViews: () => ({
+    views: ref({
+      averageViews30d: 9000,
+      weekViews: 100,
+      previousWeekViews: 90,
+    }),
+    isLoading: ref(false),
   }),
 }));
 
@@ -74,6 +91,45 @@ function makeContract(team: TeamDTO, purchasePrice = 800): ContractDTO {
   );
 }
 
+const TIER_DURATION_DAYS = 7;
+
+/**
+ * A viewer-owned MEDIUM (7-day) contract with exactly `hoursLeft` remaining, so
+ * the final-24h renewal window can be exercised precisely regardless of run time.
+ */
+function makeContractExpiringInHours(
+  team: TeamDTO,
+  hoursLeft: number,
+  opts: { renewalCount?: number; renewalElected?: boolean } = {}
+): ContractDTO {
+  const startDate = Temporal.Now.instant()
+    .add({ hours: hoursLeft })
+    .subtract({ hours: 24 * TIER_DURATION_DAYS });
+  return new ContractDTO(
+    `contract-${team.id}`,
+    team,
+    article,
+    startDate,
+    Temporal.Duration.from({ days: TIER_DURATION_DAYS }),
+    800,
+    opts.renewalCount ?? 0,
+    opts.renewalElected ?? false
+  );
+}
+
+function findRenewButton(wrapper: ReturnType<typeof mountWithStores>) {
+  return wrapper.findAll("ion-button").find((b) => b.text().includes("Renew"));
+}
+
+/** ion-button reflects `disabled` as a DOM property, not an attribute. */
+function isRenewDisabled(
+  wrapper: ReturnType<typeof mountWithStores>
+): boolean | undefined {
+  const btn = findRenewButton(wrapper);
+  return (btn?.element as unknown as { disabled?: boolean } | undefined)
+    ?.disabled;
+}
+
 interface MountOptions {
   currentTeam?: TeamDTO | null;
   isTeamLoading?: boolean;
@@ -111,7 +167,7 @@ describe("ArticleDetail.vue", () => {
       currentTeam: viewerTeam,
     });
 
-    expect(wrapper.text()).toContain("Renew Contract");
+    expect(wrapper.text()).toContain("Renew");
     expect(wrapper.text()).toContain("Swap Article");
     expect(wrapper.text()).toContain("Sell Contract");
     expect(wrapper.text()).not.toContain("Request Trade");
@@ -122,6 +178,52 @@ describe("ArticleDetail.vue", () => {
     expect(wikipediaLink.attributes("href")).toContain(
       "https://en.wikipedia.org/wiki/ChatGPT"
     );
+  });
+
+  it("disables the renew action outside the final-24h window", async () => {
+    const wrapper = mountWithStores(
+      makeContractExpiringInHours(viewerTeam, 48),
+      { currentTeam: viewerTeam }
+    );
+    await flushPromises();
+
+    const renewBtn = findRenewButton(wrapper);
+    expect(renewBtn).toBeDefined();
+    expect(isRenewDisabled(wrapper)).toBe(true);
+  });
+
+  it("enables the renew action inside the final-24h window and shows the premium-adjusted price", async () => {
+    const renewalCount = 2;
+    const wrapper = mountWithStores(
+      makeContractExpiringInHours(viewerTeam, 12, { renewalCount }),
+      { currentTeam: viewerTeam }
+    );
+    await flushPromises();
+
+    const renewBtn = findRenewButton(wrapper);
+    expect(renewBtn).toBeDefined();
+    expect(isRenewDisabled(wrapper)).toBe(false);
+
+    // renewalPrice = currentPrice + round(currentPrice × 0.10 × renewalCount).
+    const currentPrice = computeCurrentPrice(
+      MOCK_AVG_VIEWS,
+      "en",
+      TIER_DAYS.MEDIUM
+    );
+    const renewalPrice =
+      currentPrice + Math.round(currentPrice * 0.1 * renewalCount);
+    expect(renewBtn!.text()).toContain(String(renewalPrice));
+  });
+
+  it("shows an elected state and disables the button once renewal is elected", async () => {
+    const wrapper = mountWithStores(
+      makeContractExpiringInHours(viewerTeam, 12, { renewalElected: true }),
+      { currentTeam: viewerTeam }
+    );
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Renewal Elected");
+    expect(isRenewDisabled(wrapper)).toBe(true);
   });
 
   it("shows a tier picker and buy action for a free-agent article", () => {

--- a/frontend/src/tests/renewContract.spec.ts
+++ b/frontend/src/tests/renewContract.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { leaguesApi } from "@/services/api";
+
+/**
+ * End-to-end (service → MSW handler) coverage for the renewal-election flow.
+ * In the mock data the current player (player-1) owns team-1 in the "italy"
+ * league, which holds ctr-13; team-6 (not the player's) holds ctr-16 in "global".
+ */
+describe("leaguesApi.renewMyContract (MSW)", () => {
+  it("elects renewal on an owned contract and returns it with renewalElected set", async () => {
+    const contract = await leaguesApi.renewMyContract("italy", "ctr-13");
+    expect(contract.id).toBe("ctr-13");
+    expect(contract.renewalElected).toBe(true);
+  });
+
+  it("rejects renewing a contract owned by another team", async () => {
+    await expect(
+      leaguesApi.renewMyContract("global", "ctr-16")
+    ).rejects.toThrow(/do not own/i);
+  });
+});

--- a/frontend/src/types/articleDetail.ts
+++ b/frontend/src/types/articleDetail.ts
@@ -44,6 +44,14 @@ export interface OwnedByViewerDetail extends ArticleDetailBase {
   expiresIn: Temporal.Duration;
   ownerTeamName: string;
   purchasePrice: number;
+  /** Consecutive renewals so far — drives the +10%-per-renewal premium. */
+  renewalCount: number;
+  /** Whether renewal has already been elected for this contract's expiry. */
+  renewalElected: boolean;
+  /** currentPrice × 0.10 × renewalCount — the anti-hoard premium (ADR 0003). */
+  renewalPremium: number;
+  /** What renewing would cost: currentPrice + renewalPremium. */
+  renewalPrice: number;
 }
 
 export interface OwnedByOtherDetail extends ArticleDetailBase {
@@ -109,6 +117,9 @@ export function buildArticleDetail(input: ArticleDetailInput): ArticleDetail {
   const ownerTeamName = contract.team.name;
 
   if (viewerTeamId && contract.team.id === viewerTeamId) {
+    const renewalPremium = Math.round(
+      currentPrice * 0.1 * contract.renewalCount
+    );
     return {
       availability: "owned-by-viewer",
       article,
@@ -118,6 +129,10 @@ export function buildArticleDetail(input: ArticleDetailInput): ArticleDetail {
       ownerTeamName,
       currentPrice,
       purchasePrice: contract.purchasePrice,
+      renewalCount: contract.renewalCount,
+      renewalElected: contract.renewalElected,
+      renewalPremium,
+      renewalPrice: currentPrice + renewalPremium,
     };
   }
 

--- a/frontend/src/views/MarketPage.vue
+++ b/frontend/src/views/MarketPage.vue
@@ -380,6 +380,7 @@
       @close="closeDetail"
       @buy="onBuy"
       @sell="onSell"
+      @renew="onRenew"
       @request-trade="onRequestTrade"
     />
   </nav-bar>
@@ -428,6 +429,7 @@ import {
   type StatusFilter,
 } from "@/composables/useMarket";
 import { useToast } from "@/composables/useToast";
+import { useRenewContract } from "@/composables/useRenewContract";
 import type { MarketArticle } from "@/types/market";
 import type { ArticleDTO } from "../../../dto/articleDTO";
 import type { ContractDTO } from "../../../dto/contractDTO";
@@ -533,6 +535,7 @@ function closeDetail() {
 }
 
 const { showSuccess, showError } = useToast();
+const { renewContract } = useRenewContract();
 
 async function onBuy(tier: ContractTier) {
   const league = currentLeague.value;
@@ -582,6 +585,16 @@ async function onSell(contractId: string) {
     ]);
   } catch (e) {
     showError(e instanceof Error ? e.message : t("market.sellError"));
+  }
+}
+
+async function onRenew(contract: ContractDTO) {
+  const league = currentLeague.value;
+  if (!league) return;
+  const ok = await renewContract(league.id, contract.id);
+  if (ok) {
+    closeDetail();
+    await refetch();
   }
 }
 


### PR DESCRIPTION
Implements the daily Expiry Settlement sweep and final-24h renewal election for article contracts (ADR 0003).

## Backend
- A Cloudflare Cron Trigger (05:00 UTC) starts a durable `ContractSettlementWorkflow` that resolves every unsettled contract past its `expireDate`: it settles at the live `currentPrice` ("sold to system") or, when renewal was elected and affordable, rolls the window forward a tier at a +10%-per-renewal premium. Guarded writes keep the sweep idempotent (re-runs are no-ops).
- Renewal is elected via `POST /leagues/:id/my-contracts/:contractId/renew`, which only sets `renewalElected` inside the final-24h window; the sweep executes the roll-forward and stays the single money-writer. An elected renewal the team can't afford (incremental cost > derived credits) settles instead.
- New `ContractRepository` methods (`getDueForSettlement`, `settleExpiry`, `renew`, `electRenewal`) and `ContractService` methods (`electRenewal`, `settleDueContract`); expose `renewalCount`/`renewalElected` on the contract DTO.

## Frontend
- "Renew" action in the article-detail modal and the dashboard's Needed-Attention list, enabled only in the final-24h window and showing the premium-adjusted price; shared `useRenewContract` composable, MSW renew handler, and i18n keys.

## Tests
- Backend integration: profit/loss settlement, renewal, unaffordable renewal fallback, re-run idempotency, views-fetch retry, and the renew-endpoint window/ownership guards.
- Frontend: renew gate / premium / elected states and the renew flow through MSW.

---

Split out of the combined `dev` → `master` PR (#435) so the settlement work lands as its own commit, separate from the follow-up review fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2eBZRro3vc6e4ty5Xwkot