### PR TITLE
refactor(frontend): consolidate navbar chrome into a settings menu

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,38 +5,20 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, provide, ref } from "vue";
+import { onMounted, onUnmounted } from "vue";
 import { IonApp, IonRouterOutlet } from "@ionic/vue";
+import { useAppStore } from "@/stores/app";
 
-// Global state that can be accessed by all components
-const isDark = ref(false);
-const isLoggedIn = ref(false);
+// The store applies the resolved theme when it is created; all we own here is
+// the OS-preference listener, which lives as long as the app does.
+const appStore = useAppStore();
+let unfollowSystemTheme: (() => void) | undefined;
 
-// Provide global state to all child components
-provide("isDark", isDark);
-provide("isLoggedIn", isLoggedIn);
-
-// Initialize theme on mount
 onMounted(() => {
-  const savedTheme = localStorage.getItem("theme");
-  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
-
-  if (savedTheme) {
-    isDark.value = savedTheme === "dark";
-  } else {
-    isDark.value = prefersDark.matches;
-  }
-
-  document.body.classList.toggle("ion-palette-dark", isDark.value);
-
-  // Listen for system theme changes
-  prefersDark.addEventListener("change", (e) => {
-    if (!localStorage.getItem("theme")) {
-      isDark.value = e.matches;
-      document.body.classList.toggle("ion-palette-dark", e.matches);
-    }
-  });
+  unfollowSystemTheme = appStore.followSystemTheme();
 });
+
+onUnmounted(() => unfollowSystemTheme?.());
 </script>
 
 <style></style>

--- a/frontend/src/components/SettingsMenu.vue
+++ b/frontend/src/components/SettingsMenu.vue
@@ -1,0 +1,212 @@
+<template>
+  <!-- Rendered inside an ion-popover on desktop and an ion-modal sheet on
+       mobile, so it owns no chrome of its own — just the rows. -->
+  <ion-list lines="none" class="settings-menu ion-no-padding">
+    <template v-if="view === 'root'">
+      <ion-item
+        v-if="appStore.isAuthenticated"
+        class="account-row"
+        lines="full"
+      >
+        <ion-avatar slot="start" class="account-avatar" aria-hidden="true">
+          <img
+            v-if="picture"
+            :src="picture"
+            alt=""
+            referrerpolicy="no-referrer"
+          />
+          <ion-icon v-else :icon="personCircleOutline" />
+        </ion-avatar>
+        <ion-label>
+          <h3 class="account-name">{{ appStore.currentUser?.name }}</h3>
+          <p class="account-email">{{ appStore.currentUser?.email }}</p>
+        </ion-label>
+      </ion-item>
+
+      <ion-item :button="true" :detail="true" @click="view = 'language'">
+        <ion-icon :icon="globeOutline" slot="start" aria-hidden="true" />
+        <ion-label>{{ $t("menu.language") }}</ion-label>
+        <ion-note slot="end">{{ appStore.currentLanguage.fullName }}</ion-note>
+      </ion-item>
+
+      <!-- Theme is a binary, so it toggles in place: a submenu for two states
+           would cost a click and teach nothing. -->
+      <ion-item>
+        <ion-icon
+          :icon="appStore.isDarkMode ? moonOutline : sunnyOutline"
+          slot="start"
+          aria-hidden="true"
+        />
+        <ion-toggle
+          :checked="appStore.isDarkMode"
+          @ion-change="appStore.setDarkMode($event.detail.checked)"
+        >
+          {{ $t("menu.darkMode") }}
+        </ion-toggle>
+      </ion-item>
+
+      <ion-item
+        :button="true"
+        :detail="false"
+        :href="USER_GUIDE_URL"
+        target="_blank"
+        rel="noopener"
+        @click="emit('close')"
+      >
+        <ion-icon :icon="bookOutline" slot="start" aria-hidden="true" />
+        <ion-label>{{ $t("menu.userGuide") }}</ion-label>
+        <ion-icon
+          :icon="openOutline"
+          slot="end"
+          class="external-icon"
+          aria-hidden="true"
+        />
+      </ion-item>
+
+      <ion-item
+        :button="true"
+        :detail="false"
+        lines="full"
+        class="auth-row"
+        @click="onAuth"
+      >
+        <ion-icon
+          :icon="appStore.isAuthenticated ? logOutOutline : logInOutline"
+          slot="start"
+          aria-hidden="true"
+        />
+        <ion-label>
+          {{ appStore.isAuthenticated ? $t("nav.signOut") : $t("nav.signIn") }}
+        </ion-label>
+      </ion-item>
+    </template>
+
+    <template v-else>
+      <ion-item
+        :button="true"
+        :detail="false"
+        lines="full"
+        @click="view = 'root'"
+      >
+        <ion-icon :icon="chevronBackOutline" slot="start" aria-hidden="true" />
+        <ion-label>{{ $t("menu.language") }}</ion-label>
+      </ion-item>
+
+      <ion-item
+        v-for="lang in appStore.availableLanguages"
+        :key="lang.code"
+        :button="true"
+        :detail="false"
+        @click="selectLanguage(lang.code)"
+      >
+        <ion-label>{{ lang.label }} {{ lang.fullName }}</ion-label>
+        <ion-icon
+          v-if="appStore.isLanguage(lang.code)"
+          :icon="checkmarkOutline"
+          slot="end"
+          aria-hidden="true"
+        />
+      </ion-item>
+    </template>
+  </ion-list>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import {
+  IonAvatar,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonToggle,
+} from "@ionic/vue";
+import {
+  bookOutline,
+  checkmarkOutline,
+  chevronBackOutline,
+  globeOutline,
+  logInOutline,
+  logOutOutline,
+  moonOutline,
+  openOutline,
+  personCircleOutline,
+  sunnyOutline,
+} from "ionicons/icons";
+import { useAppStore } from "@/stores/app";
+
+const USER_GUIDE_URL =
+  "https://github.com/FantasyWiki/FantasyWiki/tree/master/docs";
+
+const emit = defineEmits<{ close: [] }>();
+
+const appStore = useAppStore();
+
+// A nested list rather than an inline segment: adding a locale to
+// AVAILABLE_LANGUAGES then costs no layout work here.
+const view = ref<"root" | "language">("root");
+
+const picture = computed(() => appStore.currentUser?.picture);
+
+function selectLanguage(code: string) {
+  appStore.setLanguage(code);
+  view.value = "root";
+  emit("close");
+}
+
+// The menu closes first: both modals are siblings of the popover/sheet, and
+// Ionic will not stack them reliably if the trigger is still open.
+function onAuth() {
+  emit("close");
+  if (appStore.isAuthenticated) {
+    appStore.openLogoutModal();
+  } else {
+    appStore.openLoginModal();
+  }
+}
+</script>
+
+<style scoped>
+.settings-menu ion-item {
+  font-size: 0.875rem;
+  --min-height: 44px;
+}
+
+.account-row {
+  --min-height: 60px;
+}
+
+.account-avatar {
+  width: 2rem;
+  height: 2rem;
+  color: var(--ion-color-medium);
+}
+
+.account-avatar ion-icon {
+  font-size: 2rem;
+}
+
+.account-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.account-email {
+  font-size: 0.75rem;
+  color: var(--ion-color-medium);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.external-icon {
+  font-size: 0.875rem;
+  color: var(--ion-color-medium);
+}
+
+.auth-row {
+  --border-width: 1px 0 0 0;
+}
+</style>

--- a/frontend/src/components/homePage/CTASection.vue
+++ b/frontend/src/components/homePage/CTASection.vue
@@ -22,7 +22,7 @@
           </ion-text>
 
           <div class="ion-margin-bottom">
-            <ion-button size="large" color="light">
+            <ion-button size="large" color="light" @click="startPlaying">
               {{ $t("home.cta.createAccount") }}
               <ion-icon slot="end" :icon="arrowForward" />
             </ion-button>
@@ -40,6 +40,9 @@
 <script setup lang="ts">
 import { IonButton, IonChip, IonIcon, IonLabel, IonText } from "@ionic/vue";
 import { sparklesOutline, arrowForward } from "ionicons/icons";
+import { useAuthCta } from "@/composables/useAuthCta";
+
+const { startPlaying } = useAuthCta();
 </script>
 
 <style scoped src="src/components/homePage/home-page.css"></style>

--- a/frontend/src/components/homePage/HeroSection.vue
+++ b/frontend/src/components/homePage/HeroSection.vue
@@ -22,8 +22,9 @@
           {{ $t("home.hero.description") }}
         </p>
         <ion-button
-          class="ion-text-capitalize ion-padding-horizontal"
+          class="hero-cta ion-text-capitalize ion-padding-horizontal"
           size="large"
+          @click="startPlaying"
         >
           <ion-text>{{ $t("home.hero.getStarted") }}</ion-text>
           <ion-icon slot="end" :icon="arrowForwardOutline"></ion-icon>
@@ -53,6 +54,9 @@ import {
 import { arrowForwardOutline, flashOutline } from "ionicons/icons";
 import AppStats from "./AppStats.vue";
 import ArticleLeaderboard from "./ArticleLeaderboard.vue";
+import { useAuthCta } from "@/composables/useAuthCta";
+
+const { startPlaying } = useAuthCta();
 </script>
 
 <style scoped src="src/components/homePage/home-page.css"></style>

--- a/frontend/src/composables/useAuthCta.ts
+++ b/frontend/src/composables/useAuthCta.ts
@@ -1,0 +1,24 @@
+import { useRouter } from "vue-router";
+import { useAppStore } from "@/stores/app";
+
+/**
+ * Shared behaviour for the landing page's primary calls to action ("Get
+ * started", "Create account"): send a signed-in visitor straight to their
+ * dashboard, and prompt everyone else to log in. The login modal is owned by
+ * the app store precisely so these buttons can reach it from inside the
+ * NavBar's content slot.
+ */
+export function useAuthCta() {
+  const router = useRouter();
+  const appStore = useAppStore();
+
+  function startPlaying() {
+    if (appStore.isAuthenticated) {
+      router.push("/dashboard");
+    } else {
+      appStore.openLoginModal();
+    }
+  }
+
+  return { startPlaying };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -9,6 +9,12 @@
     "signIn": "Sign In with Google",
     "signOut": "Sign Out"
   },
+  "menu": {
+    "open": "Open menu",
+    "language": "Language",
+    "darkMode": "Dark mode",
+    "userGuide": "User guide"
+  },
   "footer": {
     "technicalDocs": "Technical documentation",
     "userGuide": "User guide",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -9,6 +9,12 @@
     "signIn": "Accedi con Google",
     "signOut": "Esci"
   },
+  "menu": {
+    "open": "Apri il menu",
+    "language": "Lingua",
+    "darkMode": "Tema scuro",
+    "userGuide": "Guida utente"
+  },
   "footer": {
     "technicalDocs": "Documentazione tecnica",
     "userGuide": "Guida utente",

--- a/frontend/src/layout/NavBar.vue
+++ b/frontend/src/layout/NavBar.vue
@@ -79,79 +79,58 @@
             </ion-list>
           </ion-popover>
 
-          <!-- Language Selector -->
+          <!-- Sign in stays a first-class button while logged out: it is the
+               only action an anonymous visitor is here to take, and the space
+               is free because there is no league selector yet. -->
           <ion-button
-            fill="solid"
-            size="small"
-            shape="round"
-            @click="openLangPopover($event)"
-          >
-            <ion-icon :icon="globeOutline" />
-            <ion-text class="ion-hide-md-down">
-              {{ appStore.currentLanguage.label }}
-              {{ appStore.currentLanguage.code }}
-            </ion-text>
-          </ion-button>
-          <ion-popover
-            :is-open="langPopoverOpen"
-            :event="langPopoverEvent"
-            side="bottom"
-            alignment="end"
-            @did-dismiss="langPopoverOpen = false"
-          >
-            <ion-list lines="none" class="ion-no-margin">
-              <ion-item
-                class="ion-no-margin"
-                :detail="false"
-                v-for="lang in appStore.availableLanguages"
-                :key="lang.code"
-                :button="true"
-                @click="selectLanguage(lang.code)"
-              >
-                <ion-label>{{ lang.label }} {{ lang.fullName }}</ion-label>
-              </ion-item>
-            </ion-list>
-          </ion-popover>
-
-          <!-- Theme Toggle -->
-          <ion-button
-            fill="solid"
-            size="small"
-            shape="round"
-            @click="toggleTheme"
-          >
-            <ion-icon
-              :icon="appStore.isDarkMode ? moonOutline : sunnyOutline"
-            />
-          </ion-button>
-
-          <!-- Sign In / Out -->
-          <ion-button
-            v-if="appStore.isAuthenticated"
-            fill="clear"
-            color="dark"
-            class="ion-hide-sm-down signout-button"
-            @click="handleAuth"
-          >
-            <ion-avatar
-              v-if="profilePicture"
-              slot="start"
-              class="profile-avatar"
-              aria-hidden="true"
-            >
-              <img :src="profilePicture" alt="" referrerpolicy="no-referrer" />
-            </ion-avatar>
-            {{ $t("nav.signOut") }}
-          </ion-button>
-          <ion-button
-            v-else
+            v-if="!appStore.isAuthenticated"
             color="primary"
             fill="solid"
-            class="ion-hide-sm-down"
-            @click="handleAuth"
+            size="small"
+            shape="round"
+            class="ion-hide-md-down"
+            @click="appStore.openLoginModal()"
           >
             {{ $t("nav.signIn") }}
           </ion-button>
+
+          <!-- One trigger in both auth states: the avatar slot holds a person
+               glyph while logged out and fills with the Google photo after
+               login. The button never changes identity or position, so the
+               menu stays findable. Mobile reaches the same menu from the
+               bottom nav, so this is desktop-only. -->
+          <ion-button
+            id="settings-menu-trigger"
+            fill="clear"
+            color="dark"
+            size="small"
+            shape="round"
+            class="ion-hide-md-down settings-trigger"
+            :aria-label="$t('menu.open')"
+            @click="openSettingsPopover($event)"
+          >
+            <ion-avatar class="profile-avatar" aria-hidden="true">
+              <img
+                v-if="profilePicture"
+                :src="profilePicture"
+                alt=""
+                referrerpolicy="no-referrer"
+              />
+              <ion-icon v-else :icon="personCircleOutline" />
+            </ion-avatar>
+            <ion-icon :icon="chevronDownOutline" class="trigger-chevron" />
+          </ion-button>
+
+          <ion-popover
+            :is-open="settingsPopoverOpen"
+            :event="settingsPopoverEvent"
+            side="bottom"
+            alignment="end"
+            class="settings-popover"
+            @did-dismiss="settingsPopoverOpen = false"
+          >
+            <settings-menu @close="settingsPopoverOpen = false" />
+          </ion-popover>
         </div>
       </ion-toolbar>
     </ion-header>
@@ -160,18 +139,32 @@
       <slot></slot>
       <info-footer></info-footer>
       <ion-modal
-        :is-open="isLoginOpen"
+        :is-open="appStore.isLoginModalOpen"
         css-class="login-modal"
-        @did-dismiss="isLoginOpen = false"
+        @did-dismiss="appStore.closeLoginModal()"
       >
         <login-page />
       </ion-modal>
       <ion-modal
-        :is-open="isLogoutOpen"
+        :is-open="appStore.isLogoutModalOpen"
         css-class="login-modal"
         @did-dismiss="onLogoutDismiss"
       >
         <logout-confirm-page />
+      </ion-modal>
+
+      <!-- Mobile reaches the settings menu as a bottom sheet: it is anchored to
+           the bottom nav, where the thumb already is. Auto-height rather than a
+           breakpoint, so the sheet is exactly as tall as its rows instead of
+           leaving dead space below them. -->
+      <ion-modal
+        :is-open="settingsSheetOpen"
+        class="settings-sheet"
+        @did-dismiss="settingsSheetOpen = false"
+      >
+        <div class="sheet-inner">
+          <settings-menu @close="settingsSheetOpen = false" />
+        </div>
       </ion-modal>
     </ion-content>
 
@@ -194,7 +187,13 @@
           >
             <ion-icon :icon="link.icon" />
           </ion-button>
-          <ion-button fill="clear" @click="handleAuth">
+          <!-- Was an auth toggle; now the entry point to the same settings menu
+               the desktop avatar opens. Sign in/out is a row inside it. -->
+          <ion-button
+            fill="clear"
+            :aria-label="$t('menu.open')"
+            @click="settingsSheetOpen = true"
+          >
             <ion-avatar
               v-if="profilePicture"
               class="profile-avatar"
@@ -202,10 +201,7 @@
             >
               <img :src="profilePicture" alt="" referrerpolicy="no-referrer" />
             </ion-avatar>
-            <ion-icon
-              v-else
-              :icon="appStore.isAuthenticated ? logOutOutline : logInOutline"
-            />
+            <ion-icon v-else :icon="personCircleOutline" />
           </ion-button>
         </div>
       </ion-toolbar>
@@ -231,21 +227,18 @@ import {
   IonList,
   IonPage,
   IonPopover,
-  IonText,
   IonToolbar,
 } from "@ionic/vue";
 import {
-  globeOutline,
+  chevronDownOutline,
   gridOutline,
-  logInOutline,
-  logOutOutline,
-  moonOutline,
+  personCircleOutline,
   storefrontOutline,
-  sunnyOutline,
   trophyOutline,
 } from "ionicons/icons";
 
 import AppLogo from "@/components/AppLogo.vue";
+import SettingsMenu from "@/components/SettingsMenu.vue";
 import InfoFooter from "@/layout/InfoFooter.vue";
 import LoginPage from "@/views/auth/LoginPage.vue";
 import LogoutConfirmPage from "@/views/auth/LogoutConfirmPage.vue";
@@ -257,8 +250,6 @@ import { LeagueDTO } from "../../../dto/leagueDTO";
 const router = useRouter();
 const route = useRoute();
 const { t } = useI18n();
-const isLoginOpen = ref(false);
-const isLogoutOpen = ref(false);
 
 // State
 const appStore = useAppStore();
@@ -277,27 +268,25 @@ const { unreadCount, unreadCountByLeague } = useNotifications();
 
 const leaguePopoverOpen = ref(false);
 const leaguePopoverEvent = ref<MouseEvent | undefined>(undefined);
-const langPopoverOpen = ref(false);
-const langPopoverEvent = ref<MouseEvent | undefined>(undefined);
+const settingsPopoverOpen = ref(false);
+const settingsPopoverEvent = ref<MouseEvent | undefined>(undefined);
+
+// Mobile opens the same menu as a bottom sheet from the bottom nav.
+const settingsSheetOpen = ref(false);
 
 function openLeaguePopover(e: MouseEvent) {
   leaguePopoverEvent.value = e;
   leaguePopoverOpen.value = true;
 }
 
-function openLangPopover(e: MouseEvent) {
-  langPopoverEvent.value = e;
-  langPopoverOpen.value = true;
+function openSettingsPopover(e: MouseEvent) {
+  settingsPopoverEvent.value = e;
+  settingsPopoverOpen.value = true;
 }
 
 function selectLeague(lg: LeagueDTO) {
   leagueStore.setCurrentLeague(lg);
   leaguePopoverOpen.value = false;
-}
-
-function selectLanguage(code: string) {
-  appStore.setLanguage(code);
-  langPopoverOpen.value = false;
 }
 
 // Google profile picture from the session; shown in the auth buttons so a
@@ -314,27 +303,11 @@ const navLinks = computed(() => [
 
 const isActive = (href: string) => route.path === href;
 
-const toggleTheme = () => {
-  appStore.toggleDarkMode();
-  document.body.classList.toggle("ion-palette-dark", appStore.isDarkMode);
-  localStorage.setItem("theme", appStore.isDarkMode ? "dark" : "light");
-};
-
 // Signing out asks for confirmation in a modal (same style as the login
 // one); the store is only touched when the modal is dismissed with the
 // "confirm" role.
-const handleAuth = () => {
-  if (appStore.isAuthenticated) {
-    isLogoutOpen.value = true;
-  } else {
-    // No route change: "/signin" was never a real route and would now hit
-    // the 404 catch-all; the modal simply opens over the current page.
-    isLoginOpen.value = true;
-  }
-};
-
 const onLogoutDismiss = (event: CustomEvent) => {
-  isLogoutOpen.value = false;
+  appStore.closeLogoutModal();
   if (event.detail.role === "confirm") {
     appStore.logout();
     router.push("/");
@@ -392,6 +365,15 @@ ion-toolbar {
   --padding-end: 16px;
 }
 
+/* Keep the bar full-width, just stop the logo and the actions sitting right on
+   the screen edge once there is room to breathe. */
+@media (min-width: 768px) {
+  ion-toolbar {
+    --padding-start: 32px;
+    --padding-end: 32px;
+  }
+}
+
 .transparent-top-layer {
   background: rgba(var(--ion-background-color-rgb), 0.8);
   backdrop-filter: blur(12px);
@@ -429,18 +411,50 @@ ion-footer {
 .profile-avatar {
   width: 1.75rem;
   height: 1.75rem;
+  color: var(--ion-color-medium);
 }
 
-.signout-button {
-  font-weight: 500;
-  text-transform: none;
+.profile-avatar ion-icon {
+  font-size: 1.75rem;
 }
 
-.signout-button .profile-avatar {
-  margin-inline-end: 0.5rem;
+/* The chevron is the whole affordance: it says "this opens" without a gear
+   claiming the menu is only settings. */
+.settings-trigger {
+  --padding-start: 4px;
+  --padding-end: 4px;
+}
+
+.trigger-chevron {
+  font-size: 0.75rem;
+  margin-inline-start: 0.25rem;
+  color: var(--ion-color-medium);
+}
+
+.settings-popover {
+  --width: 17rem;
 }
 
 ion-modal {
   --backdrop-opacity: 100%;
+}
+
+/* The sheet is a surface, not a dialog — it should not black out the page
+   behind it the way the login modal does. --height: auto makes it hug its
+   rows; align-items pins it to the bottom, where the trigger is. */
+ion-modal.settings-sheet {
+  --backdrop-opacity: 0.3;
+  --height: auto;
+  --width: 100%;
+  --border-radius: 16px 16px 0 0;
+  align-items: flex-end;
+}
+
+ion-modal.settings-sheet .sheet-inner {
+  /* Auto-height modals size to their content, so the scroll cap has to live
+     here — otherwise a long menu would grow past the viewport. */
+  max-height: 80vh;
+  overflow-y: auto;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 </style>

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -20,16 +20,36 @@ const AVAILABLE_LANGUAGES: LanguageOption[] = [
   { code: "it", label: "🇮🇹", fullName: "Italiano" },
 ];
 
+// Theme is persisted under "theme" ("dark" | "light"). Absence of the key means
+// the user never chose, so we follow the OS preference and keep following it.
+const THEME_KEY = "theme";
+const DARK_CLASS = "ion-palette-dark";
+
+function prefersDarkQuery(): MediaQueryList {
+  return window.matchMedia("(prefers-color-scheme: dark)");
+}
+
+function resolveInitialDarkMode(): boolean {
+  const saved = localStorage.getItem(THEME_KEY);
+  return saved ? saved === "dark" : prefersDarkQuery().matches;
+}
+
 /**
  * Global application store for settings that persist across navigation
- * Manages: language, theme, and other app-wide preferences
+ * Manages: language, theme, auth-modal visibility and other app-wide preferences
  */
 export const useAppStore = defineStore("app", () => {
   // ========== STATE ==========
   // Same resolver the i18n instance booted with, so store and i18n agree.
   const languageCode = ref<string>(resolveInitialLocale());
 
-  const isDarkMode = ref<boolean>(localStorage.getItem("darkMode") === "true");
+  const isDarkMode = ref<boolean>(resolveInitialDarkMode());
+
+  // Auth modals live here rather than in NavBar so that anything on the page —
+  // the landing CTAs, the settings menu — can open them without prop drilling
+  // through the layout slot.
+  const isLoginModalOpen = ref<boolean>(false);
+  const isLogoutModalOpen = ref<boolean>(false);
 
   // State - no initial user data since we need to check with server
   const isAuthenticated = ref<boolean>(false);
@@ -107,16 +127,55 @@ export const useAppStore = defineStore("app", () => {
     setLanguage(AVAILABLE_LANGUAGES[nextIndex].code);
   }
 
-  function toggleDarkMode() {
-    isDarkMode.value = !isDarkMode.value;
-    localStorage.setItem("darkMode", isDarkMode.value.toString());
-    document.body.classList.toggle("dark", isDarkMode.value);
+  function applyDarkMode() {
+    document.body.classList.toggle(DARK_CLASS, isDarkMode.value);
   }
 
+  /**
+   * Set the theme and remember the choice. Once called, the OS preference is
+   * no longer followed — an explicit choice outranks it.
+   */
   function setDarkMode(value: boolean) {
     isDarkMode.value = value;
-    localStorage.setItem("darkMode", value.toString());
-    document.body.classList.toggle("dark", value);
+    localStorage.setItem(THEME_KEY, value ? "dark" : "light");
+    applyDarkMode();
+  }
+
+  function toggleDarkMode() {
+    setDarkMode(!isDarkMode.value);
+  }
+
+  /**
+   * Track the OS theme until the user picks one explicitly. Returns the
+   * listener's teardown so App.vue can drop it on unmount.
+   */
+  function followSystemTheme(): () => void {
+    const query = prefersDarkQuery();
+    const onChange = (event: MediaQueryListEvent) => {
+      if (localStorage.getItem(THEME_KEY)) {
+        return;
+      }
+      isDarkMode.value = event.matches;
+      applyDarkMode();
+    };
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }
+
+  function openLoginModal() {
+    isLoginModalOpen.value = true;
+  }
+
+  function closeLoginModal() {
+    isLoginModalOpen.value = false;
+  }
+
+  function openLogoutModal() {
+    isLogoutModalOpen.value = true;
+  }
+
+  function closeLogoutModal() {
+    isLogoutModalOpen.value = false;
   }
 
   function setUserFromData(userData: Session) {
@@ -132,9 +191,7 @@ export const useAppStore = defineStore("app", () => {
   }
 
   // Initialize on store creation
-  if (isDarkMode.value) {
-    document.body.classList.add("dark");
-  }
+  applyDarkMode();
   document.documentElement.lang = languageCode.value;
 
   // Return public API
@@ -142,6 +199,8 @@ export const useAppStore = defineStore("app", () => {
     // State
     languageCode,
     isDarkMode,
+    isLoginModalOpen,
+    isLogoutModalOpen,
     isAuthenticated,
     currentUser,
     // Getters
@@ -154,6 +213,11 @@ export const useAppStore = defineStore("app", () => {
     cycleLanguage,
     toggleDarkMode,
     setDarkMode,
+    followSystemTheme,
+    openLoginModal,
+    closeLoginModal,
+    openLogoutModal,
+    closeLogoutModal,
     setUserFromData,
     logout,
   };

--- a/frontend/src/tests/NavBar.spec.ts
+++ b/frontend/src/tests/NavBar.spec.ts
@@ -85,4 +85,38 @@ describe("NavBar.vue", () => {
     const leagueSelector = wrapper.find("#league-selector");
     expect(leagueSelector.exists()).toBe(true);
   });
+
+  // The settings menu trigger must keep its identity across auth states: only
+  // the picture inside it changes, so the menu never appears to move or vanish.
+  it("shows the settings menu trigger whether or not the user is authenticated", async () => {
+    await router.push("/");
+    await router.isReady();
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+
+    const appStore = useAppStore();
+    appStore.isAuthenticated = false;
+
+    const wrapper = mount(NavBar, {
+      global: {
+        plugins: [router, pinia, [VueQueryPlugin, { queryClient }]],
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.find("#settings-menu-trigger").exists()).toBe(true);
+
+    appStore.isAuthenticated = true;
+    appStore.currentUser = {
+      sub: "test-user",
+      name: "Test User",
+      email: "test@example.com",
+      picture: "https://example.com/avatar.png",
+    };
+    await flushPromises();
+
+    expect(wrapper.find("#settings-menu-trigger").exists()).toBe(true);
+  });
 });

--- a/frontend/src/tests/SettingsMenu.spec.ts
+++ b/frontend/src/tests/SettingsMenu.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, Pinia, setActivePinia } from "pinia";
+import SettingsMenu from "@/components/SettingsMenu.vue";
+import { useAppStore } from "@/stores/app";
+
+function mountMenu(pinia: Pinia) {
+  return mount(SettingsMenu, { global: { plugins: [pinia] } });
+}
+
+describe("SettingsMenu.vue", () => {
+  let pinia: Pinia;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    localStorage.clear();
+  });
+
+  it("opens the login modal from the auth row when signed out", async () => {
+    const appStore = useAppStore();
+    appStore.isAuthenticated = false;
+
+    const wrapper = mountMenu(pinia);
+    await wrapper.get(".auth-row").trigger("click");
+
+    expect(appStore.isLoginModalOpen).toBe(true);
+    expect(appStore.isLogoutModalOpen).toBe(false);
+    // The menu asks to be dismissed first — Ionic will not stack a modal
+    // reliably over a popover that is still open.
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+
+  it("opens the logout modal from the auth row when signed in", async () => {
+    const appStore = useAppStore();
+    appStore.isAuthenticated = true;
+
+    const wrapper = mountMenu(pinia);
+    await wrapper.get(".auth-row").trigger("click");
+
+    expect(appStore.isLogoutModalOpen).toBe(true);
+    expect(appStore.isLoginModalOpen).toBe(false);
+  });
+
+  it("shows the account row only when signed in", async () => {
+    const appStore = useAppStore();
+    appStore.isAuthenticated = false;
+    expect(mountMenu(pinia).find(".account-row").exists()).toBe(false);
+
+    appStore.isAuthenticated = true;
+    appStore.currentUser = {
+      sub: "test-user",
+      name: "Test User",
+      email: "test@example.com",
+      picture: "https://example.com/avatar.png",
+    };
+    expect(mountMenu(pinia).find(".account-row").exists()).toBe(true);
+  });
+
+  it("switches language from the sub-menu and returns to the root view", async () => {
+    const appStore = useAppStore();
+    const wrapper = mountMenu(pinia);
+
+    const rows = () => wrapper.findAll("ion-item");
+    // Root view: account row is absent (signed out), so language is first.
+    await rows()[0].trigger("click");
+
+    // Sub-menu: a back row followed by one row per available language.
+    expect(rows()).toHaveLength(1 + appStore.availableLanguages.length);
+
+    const italian = rows().find((row) => row.text().includes("Italiano"));
+    await italian!.trigger("click");
+
+    expect(appStore.languageCode).toBe("it");
+    expect(localStorage.getItem("language")).toBe("it");
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+});

--- a/frontend/src/tests/homePage/HeroSection.spec.ts
+++ b/frontend/src/tests/homePage/HeroSection.spec.ts
@@ -1,13 +1,12 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
+import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
 import router from "@/router/index";
-import CTASection from "@/components/homePage/CTASection.vue";
+import HeroSection from "@/components/homePage/HeroSection.vue";
 import { useAppStore } from "@/stores/app";
 
-// The store is resolved *after* mounting: installing a Pinia makes it the
-// active one, and the global test setup installs its own, so reading the store
-// before mount would seed a different instance than the component holds.
-describe("home-page/CTASection.vue", () => {
+// The store is resolved *after* mounting — see CTASection.spec.ts for why.
+describe("home-page/HeroSection.vue", () => {
   beforeEach(async () => {
     await router.push("/");
     await router.isReady();
@@ -16,12 +15,13 @@ describe("home-page/CTASection.vue", () => {
   afterEach(() => vi.restoreAllMocks());
 
   function mountSection() {
-    return mount(CTASection, { global: { plugins: [router] } });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+    return mount(HeroSection, {
+      global: { plugins: [router, [VueQueryPlugin, { queryClient }]] },
+    });
   }
-
-  it("should mount without any console errors or warnings", () => {
-    expect(mountSection().exists()).toBe(true);
-  });
 
   it("opens the login modal when the visitor is signed out", async () => {
     const push = vi.spyOn(router, "push");
@@ -29,7 +29,7 @@ describe("home-page/CTASection.vue", () => {
     const appStore = useAppStore();
     appStore.isAuthenticated = false;
 
-    await wrapper.get("ion-button").trigger("click");
+    await wrapper.get(".hero-cta").trigger("click");
 
     expect(appStore.isLoginModalOpen).toBe(true);
     expect(push).not.toHaveBeenCalled();
@@ -41,7 +41,7 @@ describe("home-page/CTASection.vue", () => {
     const appStore = useAppStore();
     appStore.isAuthenticated = true;
 
-    await wrapper.get("ion-button").trigger("click");
+    await wrapper.get(".hero-cta").trigger("click");
 
     expect(push).toHaveBeenCalledWith("/dashboard");
     expect(appStore.isLoginModalOpen).toBe(false);

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,9 +1,28 @@
-import { beforeAll, afterEach, afterAll } from "vitest";
+import { beforeAll, afterEach, afterAll, vi } from "vitest";
 import { config } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
 import { server } from "@/mocks/server";
 import i18n from "@/i18n";
+
+// ── jsdom gaps ────────────────────────────────────────────────────────────────
+// jsdom ships no matchMedia. The app store reads it on creation to fall back to
+// the OS theme when the user has never chosen one, so without this every test
+// that touches a store throws. Reports "light" so tests get a deterministic
+// theme regardless of the machine running them.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+});
 
 // ── MSW ───────────────────────────────────────────────────────────────────────
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));

--- a/frontend/src/tests/stores/appTheme.spec.ts
+++ b/frontend/src/tests/stores/appTheme.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useAppStore } from "@/stores/app";
+
+// Theme used to live in three places at once (App.vue, the store, and NavBar),
+// under two localStorage keys and two CSS classes, so the icon could disagree
+// with the page. These lock in the single owner: key "theme", class
+// "ion-palette-dark".
+describe("app store — theme", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.classList.remove("ion-palette-dark");
+    setActivePinia(createPinia());
+  });
+
+  it("applies the saved theme on creation", () => {
+    localStorage.setItem("theme", "dark");
+
+    const appStore = useAppStore();
+
+    expect(appStore.isDarkMode).toBe(true);
+    expect(document.body.classList.contains("ion-palette-dark")).toBe(true);
+  });
+
+  it("falls back to the OS preference when the user never chose", () => {
+    // setup.ts stubs matchMedia to report a light OS preference.
+    const appStore = useAppStore();
+
+    expect(appStore.isDarkMode).toBe(false);
+    expect(localStorage.getItem("theme")).toBeNull();
+  });
+
+  it("persists an explicit choice and toggles the palette class", () => {
+    const appStore = useAppStore();
+
+    appStore.toggleDarkMode();
+
+    expect(appStore.isDarkMode).toBe(true);
+    expect(localStorage.getItem("theme")).toBe("dark");
+    expect(document.body.classList.contains("ion-palette-dark")).toBe(true);
+
+    appStore.toggleDarkMode();
+
+    expect(appStore.isDarkMode).toBe(false);
+    expect(localStorage.getItem("theme")).toBe("light");
+    expect(document.body.classList.contains("ion-palette-dark")).toBe(false);
+  });
+});


### PR DESCRIPTION
Theme and language are set-once preferences but occupied the same
visual weight as the league selector, which carries live gameplay
context. Collapse them, the user guide, and sign in/out into one menu
behind an avatar-pill trigger: an ion-popover on desktop, a bottom
sheet from the existing bottom-nav avatar on mobile. The trigger is
present in both auth states and only its picture changes, so it never
swaps identity; logged-out visitors keep a first-class Sign in button.

Dark mode was tracked in three places under two localStorage keys
("theme", "darkMode") and two CSS classes, one of which ("dark") no
stylesheet targets — so the toggle icon and the page could disagree
after a reload. The app store now owns it: one key, one class, OS
preference as fallback.

Wire the landing CTAs, which had no click handler at all, leaving the
navbar as the app's only working sign-in path. They now open the login
modal when signed out and route to the dashboard when signed in; this
is why the auth modal state moves into the store, as the CTAs render
inside NavBar's content slot.

Closes #437