### PR TITLE
feat: in-app problem reporting, behind a consolidated settings menu

### DIFF
--- a/.github/workflows/deploy-target.yml
+++ b/.github/workflows/deploy-target.yml
@@ -31,6 +31,11 @@ on:
         required: true
       JWT_SECRET:
         required: true
+      # The GitHub App private key that lets the Worker file problem reports as
+      # FantasyWiki[bot]. Optional so a deploy still succeeds before it is set —
+      # the report form just answers 502 until then.
+      GH_APP_PRIVATE_KEY:
+        required: false
 
 jobs:
   deploy-backend:
@@ -49,11 +54,13 @@ jobs:
             GOOGLE_CLIENT_ID
             GOOGLE_CLIENT_SECRET
             JWT_SECRET
+            GH_APP_PRIVATE_KEY
           command: deploy --env=${{ inputs.environment }} --var FRONTEND_URL:${{ inputs.frontend_url }}
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   deploy-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID_PRODUCTION }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET_PRODUCTION }}
       JWT_SECRET: ${{ secrets.JWT_SECRET_PRODUCTION }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   deploy-preview:
     if: github.ref_name == 'dev'
@@ -38,3 +39,4 @@ jobs:
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID_PREVIEW }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET_PREVIEW }}
       JWT_SECRET: ${{ secrets.JWT_SECRET_PREVIEW }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import session from "./routes/session";
 import leagues from "./routes/leagues";
 import notifications from "./routes/notifications";
 import player from "./routes/player";
+import reports from "./routes/reports";
 import type { ContractSettlementParams } from "./workflows/contractSettlement";
 
 const app = new Hono<{ Bindings: Bindings }>();
@@ -17,6 +18,14 @@ type Bindings = {
   GOOGLE_CLIENT_SECRET: string;
   JWT_SECRET: string;
   FRONTEND_URL: string;
+  GH_APP_ID: string;
+  GH_APP_INSTALLATION_ID: string;
+  GH_APP_PRIVATE_KEY: string;
+  GITHUB_REPO: string;
+  ENVIRONMENT: string;
+  REPORT_RATE_LIMITER: {
+    limit(o: { key: string }): Promise<{ success: boolean }>;
+  };
   CONTRACT_SETTLEMENT_WORKFLOW: Workflow<ContractSettlementParams>;
 };
 
@@ -59,6 +68,9 @@ app.route("/api/notifications", notifications);
 
 // Mount player routes
 app.route("/api/player", player);
+
+// Mount problem report routes
+app.route("/api/reports", reports);
 
 /**
  * Daily settlement Cron Trigger (ADR 0003, ~05:00 UTC): kicks off the durable

--- a/backend/src/routes/helpers.ts
+++ b/backend/src/routes/helpers.ts
@@ -5,8 +5,6 @@ import { PLAYER_ERRORS } from "../repositories/playerRepository";
 import { Player } from "../../../model";
 import { Result } from "../repositories/result";
 
-type Bindings = { db: D1Database };
-
 /**
  * A session whose player genuinely doesn't exist is a 404; any other failure
  * (a D1 outage, say) is ours and must not be dressed up as a missing player.
@@ -18,8 +16,11 @@ export function playerErrorStatus(error: string): 404 | 500 {
     : 500;
 }
 
-export async function resolveCurrentPlayer(
-  c: Context<{ Bindings: Bindings }>,
+// Generic over the bindings so routes that need more than `db` (reports needs
+// the GitHub credentials and the rate limiter) can still call this: Hono's
+// Context is invariant, so a fixed binding type would reject them.
+export async function resolveCurrentPlayer<B extends { db: D1Database }>(
+  c: Context<{ Bindings: B }>,
   playerService: Pick<
     PlayerService,
     "getPlayerByGoogleAccountId"

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -1,0 +1,94 @@
+import { Hono } from "hono";
+import { CreateProblemReportRequest } from "../../../dto/problemReportDTO";
+import { GitHubAppClient } from "../services/githubClient";
+import { REPORT_ERRORS, ProblemReportService } from "../services/problemReport";
+import { playerErrorStatus, resolveCurrentPlayer } from "./helpers";
+
+/**
+ * Cloudflare's rate limiting binding. The platform only supports a 10s or 60s
+ * period, so this guards against bursts (double submits, a script) rather than
+ * imposing a daily quota — a daily cap would need storage, and the repository
+ * is publicly writable anyway, so the form adds convenience, not a new abuse
+ * surface. What this really protects is the shared PAT, which is what GitHub's
+ * secondary limits would punish.
+ */
+interface RateLimiter {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+type Bindings = {
+  db: D1Database;
+  /**
+   * GitHub App credentials. The App is what makes issues appear as
+   * `FantasyWiki[bot]` instead of under a maintainer's own account, and it
+   * removes the expiring-PAT rotation entirely. The private key is a secret;
+   * the ids are plain vars. Names avoid the `GITHUB_` prefix, which GitHub
+   * reserves and refuses to let you use for an Actions secret.
+   */
+  GH_APP_ID: string;
+  GH_APP_INSTALLATION_ID: string;
+  GH_APP_PRIVATE_KEY: string;
+  GITHUB_REPO: string;
+  ENVIRONMENT: string;
+  REPORT_RATE_LIMITER: RateLimiter;
+};
+
+const reports = new Hono<{ Bindings: Bindings }>();
+
+const VALIDATION_ERRORS: string[] = [
+  REPORT_ERRORS.INVALID_CATEGORY,
+  REPORT_ERRORS.TITLE_REQUIRED,
+  REPORT_ERRORS.TITLE_TOO_LONG,
+  REPORT_ERRORS.BODY_REQUIRED,
+];
+
+reports.post("/", async (c) => {
+  // Identity comes from the session, never from the body (api-naming-rules).
+  const playerResult = await resolveCurrentPlayer(c);
+  if (!playerResult.ok) {
+    return c.json(
+      { error: playerResult.error },
+      playerErrorStatus(playerResult.error),
+    );
+  }
+  const player = playerResult.value;
+
+  const { success } = await c.env.REPORT_RATE_LIMITER.limit({
+    key: player.id,
+  });
+  if (!success) {
+    return c.json({ error: "REPORT_RATE_LIMITED" }, 429);
+  }
+
+  let request: CreateProblemReportRequest;
+  try {
+    request = await c.req.json<CreateProblemReportRequest>();
+  } catch {
+    return c.json({ error: REPORT_ERRORS.MALFORMED_BODY }, 400);
+  }
+
+  const service = new ProblemReportService(
+    new GitHubAppClient({
+      appId: c.env.GH_APP_ID,
+      installationId: c.env.GH_APP_INSTALLATION_ID,
+      privateKeyPem: c.env.GH_APP_PRIVATE_KEY,
+      repo: c.env.GITHUB_REPO,
+    }),
+  );
+  const result = await service.submit(request, {
+    playerId: player.id,
+    environment: c.env.ENVIRONMENT,
+  });
+
+  if (!result.ok) {
+    // A validation failure is the client's fault; a GitHub outage is not, and
+    // the frontend answers 502 by offering the pre-filled GitHub issue link so
+    // the reporter never loses what they typed.
+    const status = VALIDATION_ERRORS.includes(result.error) ? 400 : 502;
+    return c.json({ error: result.error }, status);
+  }
+
+  return c.json(result.value, 201);
+});
+
+export default reports;

--- a/backend/src/services/githubClient.ts
+++ b/backend/src/services/githubClient.ts
@@ -1,0 +1,206 @@
+import { Result, failure, success } from "../repositories/result";
+
+export const GITHUB_ERRORS = {
+  REQUEST_FAILED: "GITHUB_REQUEST_FAILED",
+  AUTH_FAILED: "GITHUB_AUTH_FAILED",
+} as const;
+
+export interface CreateIssueInput {
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+export interface CreatedIssue {
+  issueNumber: number;
+  issueUrl: string;
+}
+
+/**
+ * The seam the report service depends on. It exists so tests can substitute a
+ * stub: the Workers test pool silently ignores `vi.mock`, so the only reliable
+ * way to keep a test off the network is to inject the collaborator.
+ */
+export interface GitHubClient {
+  createIssue(input: CreateIssueInput): Promise<Result<CreatedIssue>>;
+}
+
+export interface GitHubAppCredentials {
+  appId: string;
+  installationId: string;
+  /** PKCS#8 PEM. GitHub hands out PKCS#1 — see docs/architecture/problem-reports.md. */
+  privateKeyPem: string;
+  /** "owner/repo", e.g. "FantasyWiki/FantasyWiki". */
+  repo: string;
+}
+
+interface GitHubIssueResponse {
+  number: number;
+  html_url: string;
+}
+
+interface InstallationTokenResponse {
+  token: string;
+  expires_at: string;
+}
+
+const GITHUB_API = "https://api.github.com";
+
+// GitHub rejects requests without a User-Agent.
+const BASE_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "FantasyWiki",
+};
+
+/**
+ * Files issues as the GitHub App, so they are authored by `FantasyWiki[bot]`
+ * rather than by whichever maintainer's token was used. Installation tokens are
+ * minted on demand and live an hour, so there is no expiring PAT to rotate.
+ */
+export class GitHubAppClient implements GitHubClient {
+  /**
+   * Cached per isolate. Worth doing because a token exchange is a whole extra
+   * round trip to GitHub on every report, and the token is valid for an hour.
+   */
+  private cachedToken?: { token: string; expiresAt: number };
+
+  constructor(private readonly credentials: GitHubAppCredentials) {}
+
+  async createIssue(input: CreateIssueInput): Promise<Result<CreatedIssue>> {
+    const token = await this.installationToken();
+    if (!token.ok) {
+      return token;
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(
+        `${GITHUB_API}/repos/${this.credentials.repo}/issues`,
+        {
+          method: "POST",
+          headers: {
+            ...BASE_HEADERS,
+            Authorization: `Bearer ${token.value}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(input),
+        },
+      );
+    } catch {
+      return failure(GITHUB_ERRORS.REQUEST_FAILED);
+    }
+
+    if (!response.ok) {
+      return failure(GITHUB_ERRORS.REQUEST_FAILED);
+    }
+
+    const issue = (await response.json()) as GitHubIssueResponse;
+    return success({ issueNumber: issue.number, issueUrl: issue.html_url });
+  }
+
+  private async installationToken(): Promise<Result<string>> {
+    const now = Date.now();
+    if (this.cachedToken && this.cachedToken.expiresAt > now + 60_000) {
+      return success(this.cachedToken.token);
+    }
+
+    let appJwt: string;
+    try {
+      appJwt = await signAppJwt(
+        this.credentials.appId,
+        this.credentials.privateKeyPem,
+      );
+    } catch {
+      // A malformed or PKCS#1 private key lands here.
+      return failure(GITHUB_ERRORS.AUTH_FAILED);
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(
+        `${GITHUB_API}/app/installations/${this.credentials.installationId}/access_tokens`,
+        {
+          method: "POST",
+          headers: { ...BASE_HEADERS, Authorization: `Bearer ${appJwt}` },
+        },
+      );
+    } catch {
+      return failure(GITHUB_ERRORS.AUTH_FAILED);
+    }
+
+    if (!response.ok) {
+      return failure(GITHUB_ERRORS.AUTH_FAILED);
+    }
+
+    const body = (await response.json()) as InstallationTokenResponse;
+    this.cachedToken = {
+      token: body.token,
+      expiresAt: Date.parse(body.expires_at),
+    };
+    return success(body.token);
+  }
+}
+
+// ── App JWT signing ──────────────────────────────────────────────────────────
+// Workers ship WebCrypto, so no library is needed. GitHub requires RS256 and
+// rejects an `exp` more than 10 minutes out.
+
+function base64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function encodeJson(value: object): string {
+  return base64url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function pemToPkcs8(pem: string): ArrayBuffer {
+  // Wrangler secrets are single-line, so a PEM arrives with escaped newlines.
+  const body = pem
+    .replace(/\\n/g, "\n")
+    .replace(/-----(BEGIN|END)[^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  const binary = atob(body);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+export async function signAppJwt(
+  appId: string,
+  privateKeyPem: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToPkcs8(privateKeyPem),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    // Backdated by a minute to absorb clock skew between us and GitHub.
+    iat: now - 60,
+    exp: now + 540,
+    iss: appId,
+  };
+
+  const signingInput = `${encodeJson({ alg: "RS256", typ: "JWT" })}.${encodeJson(payload)}`;
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+
+  return `${signingInput}.${base64url(new Uint8Array(signature))}`;
+}

--- a/backend/src/services/problemReport.ts
+++ b/backend/src/services/problemReport.ts
@@ -1,0 +1,146 @@
+import {
+  CreateProblemReportRequest,
+  ProblemReportCreatedDTO,
+  REPORT_TITLE_MAX_LENGTH,
+  ReportCategory,
+  ReportDiagnosticsDTO,
+  isReportCategory,
+} from "../../../dto/problemReportDTO";
+import { Result, failure, success } from "../repositories/result";
+import { GitHubClient } from "./githubClient";
+
+export const REPORT_ERRORS = {
+  MALFORMED_BODY: "REPORT_MALFORMED_BODY",
+  INVALID_CATEGORY: "REPORT_INVALID_CATEGORY",
+  TITLE_REQUIRED: "REPORT_TITLE_REQUIRED",
+  TITLE_TOO_LONG: "REPORT_TITLE_TOO_LONG",
+  BODY_REQUIRED: "REPORT_BODY_REQUIRED",
+  SUBMISSION_FAILED: "REPORT_SUBMISSION_FAILED",
+} as const;
+
+/** Applied to every report, so maintainers can filter their own issues out. */
+export const USER_REPORT_LABEL = "user-report";
+/** Marks the reporter as willing to be contacted about this report. */
+export const CONTACT_CONSENT_LABEL = "contact-ok";
+/** Keeps QA noise from the preview Worker filterable and bulk-deletable. */
+export const PREVIEW_LABEL = "preview";
+
+const CATEGORY_LABELS: Record<ReportCategory, string[]> = {
+  broken: ["bug"],
+  visual: ["bug", "visual"],
+  idea: ["feature"],
+  // A locale request is a feature, but one with a very different shape of work,
+  // so it stays filterable on its own.
+  language: ["feature", "language"],
+  rules: ["question"],
+  other: [],
+};
+
+export interface ProblemReportContext {
+  /** Opaque players.id. Published in the issue; the email never is. */
+  playerId: string;
+  /** Anything other than "production" adds the preview label. */
+  environment: string;
+}
+
+export class ProblemReportService {
+  constructor(private readonly github: GitHubClient) {}
+
+  async submit(
+    request: CreateProblemReportRequest,
+    context: ProblemReportContext,
+  ): Promise<Result<ProblemReportCreatedDTO>> {
+    const validation = validate(request);
+    if (!validation.ok) {
+      return validation;
+    }
+
+    const result = await this.github.createIssue({
+      title: request.title.trim(),
+      body: buildIssueBody(request, context),
+      labels: buildLabels(request, context),
+    });
+
+    // The client's error is not the caller's business: the route only needs to
+    // know the report did not get filed, so it can offer the GitHub fallback.
+    return result.ok
+      ? success(result.value)
+      : failure(REPORT_ERRORS.SUBMISSION_FAILED);
+  }
+}
+
+function validate(request: CreateProblemReportRequest): Result<true> {
+  if (!isReportCategory(request.category)) {
+    return failure(REPORT_ERRORS.INVALID_CATEGORY);
+  }
+
+  const title = request.title?.trim() ?? "";
+  if (title.length === 0) {
+    return failure(REPORT_ERRORS.TITLE_REQUIRED);
+  }
+  if (title.length > REPORT_TITLE_MAX_LENGTH) {
+    return failure(REPORT_ERRORS.TITLE_TOO_LONG);
+  }
+
+  // #439 left the description optional. A title-only report costs a round trip
+  // we usually cannot make — the reporter is pseudonymous — so it is required.
+  if ((request.body?.trim() ?? "").length === 0) {
+    return failure(REPORT_ERRORS.BODY_REQUIRED);
+  }
+
+  return success(true);
+}
+
+export function buildLabels(
+  request: CreateProblemReportRequest,
+  context: ProblemReportContext,
+): string[] {
+  const labels = [USER_REPORT_LABEL, ...CATEGORY_LABELS[request.category]];
+  if (request.contactConsent) {
+    labels.push(CONTACT_CONSENT_LABEL);
+  }
+  if (context.environment !== "production") {
+    labels.push(PREVIEW_LABEL);
+  }
+  return labels;
+}
+
+/**
+ * The diagnostics block is collapsed so it does not bury the reporter's own
+ * words, and carries only the opaque player id — the repository is public, so
+ * an email here would be permanently indexed and harvested. To reply, look the
+ * id up against google_accounts server-side.
+ */
+export function buildIssueBody(
+  request: CreateProblemReportRequest,
+  context: ProblemReportContext,
+): string {
+  const diagnostics = request.diagnostics ?? {};
+  const lines = [
+    request.body.trim(),
+    "",
+    "<details><summary>Diagnostics</summary>",
+    "",
+    ...diagnosticLines(diagnostics),
+    `- Reporter: player \`${context.playerId}\``,
+    `- Contact consent: ${request.contactConsent ? "yes" : "no"}`,
+    `- Environment: ${context.environment}`,
+    "",
+    "</details>",
+    "",
+    "_Filed from the in-app report form._",
+  ];
+  return lines.join("\n");
+}
+
+function diagnosticLines(diagnostics: ReportDiagnosticsDTO): string[] {
+  const entries: [string, string | undefined][] = [
+    ["Route", diagnostics.route],
+    ["Locale", diagnostics.locale],
+    ["Viewport", diagnostics.viewport],
+    ["User agent", diagnostics.userAgent],
+  ];
+  return entries
+    .filter(([, value]) => value)
+    .map(([label, value]) => `- ${label}: ${value}`);
+}

--- a/backend/src/tests/integration/problemReport.integration.test.ts
+++ b/backend/src/tests/integration/problemReport.integration.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { ProblemReportService } from "../../services/problemReport";
+import {
+  CreateIssueInput,
+  CreatedIssue,
+  GITHUB_ERRORS,
+  GitHubClient,
+} from "../../services/githubClient";
+import { REPORT_ERRORS } from "../../services/problemReport";
+import { Result, failure, success } from "../../repositories/result";
+import { CreateProblemReportRequest } from "../../../../dto/problemReportDTO";
+
+// The client is injected rather than module-mocked: the Workers pool silently
+// ignores vi.mock, so a stub is the only reliable way to stay off the network.
+class StubGitHubClient implements GitHubClient {
+  calls: CreateIssueInput[] = [];
+
+  constructor(
+    private readonly response: Result<CreatedIssue> = success({
+      issueNumber: 42,
+      issueUrl: "https://github.com/FantasyWiki/FantasyWiki/issues/42",
+    }),
+  ) {}
+
+  async createIssue(input: CreateIssueInput): Promise<Result<CreatedIssue>> {
+    this.calls.push(input);
+    return this.response;
+  }
+}
+
+function aRequest(
+  overrides: Partial<CreateProblemReportRequest> = {},
+): CreateProblemReportRequest {
+  return {
+    category: "broken",
+    title: "Market page never loads",
+    body: "It spins forever after I buy a contract.",
+    contactConsent: false,
+    ...overrides,
+  };
+}
+
+const CONTEXT = { playerId: "player-123", environment: "production" };
+
+describe("ProblemReportService", () => {
+  it("files an issue and returns its number and url", async () => {
+    const github = new StubGitHubClient();
+    const service = new ProblemReportService(github);
+
+    const result = await service.submit(aRequest(), CONTEXT);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected success");
+    expect(result.value).toEqual({
+      issueNumber: 42,
+      issueUrl: "https://github.com/FantasyWiki/FantasyWiki/issues/42",
+    });
+    expect(github.calls).toHaveLength(1);
+    expect(github.calls[0].title).toBe("Market page never loads");
+  });
+
+  it("labels every report user-report plus its category", async () => {
+    const github = new StubGitHubClient();
+    const service = new ProblemReportService(github);
+
+    await service.submit(aRequest({ category: "visual" }), CONTEXT);
+
+    expect(github.calls[0].labels).toEqual(["user-report", "bug", "visual"]);
+  });
+
+  // A locale request is a feature, but a distinctly shaped one, so it carries
+  // its own label on top of `feature`.
+  it("labels a language request as both feature and language", async () => {
+    const github = new StubGitHubClient();
+    const service = new ProblemReportService(github);
+
+    await service.submit(aRequest({ category: "language" }), CONTEXT);
+
+    expect(github.calls[0].labels).toEqual([
+      "user-report",
+      "feature",
+      "language",
+    ]);
+  });
+
+  it("adds contact-ok only when the reporter consented", async () => {
+    const github = new StubGitHubClient();
+    const service = new ProblemReportService(github);
+
+    await service.submit(aRequest({ contactConsent: true }), CONTEXT);
+
+    expect(github.calls[0].labels).toContain("contact-ok");
+  });
+
+  it("labels non-production reports preview so QA noise stays filterable", async () => {
+    const github = new StubGitHubClient();
+    const service = new ProblemReportService(github);
+
+    await service.submit(aRequest(), { ...CONTEXT, environment: "preview" });
+
+    expect(github.calls[0].labels).toContain("preview");
+  });
+
+  // The repository is public: an email here would be permanently indexed and
+  // harvested. The opaque player id is what lets us reply, via our own DB.
+  it("publishes the pseudonymous player id and never an email", async () => {
+    const github = new StubGitHubClient();
+    const service = new ProblemReportService(github);
+
+    await service.submit(
+      aRequest({
+        contactConsent: true,
+        diagnostics: { route: "/market", locale: "it", viewport: "390x844" },
+      }),
+      CONTEXT,
+    );
+
+    const body = github.calls[0].body;
+    expect(body).toContain("player-123");
+    expect(body).not.toMatch(/@[\w.]+\.\w+/);
+    expect(body).toContain("<details><summary>Diagnostics</summary>");
+    expect(body).toContain("- Route: /market");
+    expect(body).toContain("It spins forever after I buy a contract.");
+  });
+
+  it("omits diagnostics that the client did not send", async () => {
+    const github = new StubGitHubClient();
+    const service = new ProblemReportService(github);
+
+    await service.submit(
+      aRequest({ diagnostics: { route: "/market" } }),
+      CONTEXT,
+    );
+
+    expect(github.calls[0].body).not.toContain("- Locale:");
+  });
+
+  it.each([
+    [
+      "an unknown category",
+      { category: "nonsense" as never },
+      REPORT_ERRORS.INVALID_CATEGORY,
+    ],
+    ["a blank title", { title: "   " }, REPORT_ERRORS.TITLE_REQUIRED],
+    [
+      "an overlong title",
+      { title: "x".repeat(121) },
+      REPORT_ERRORS.TITLE_TOO_LONG,
+    ],
+    ["a blank body", { body: "  " }, REPORT_ERRORS.BODY_REQUIRED],
+  ])(
+    "rejects %s without calling GitHub",
+    async (_name, overrides, expected) => {
+      const github = new StubGitHubClient();
+      const service = new ProblemReportService(github);
+
+      const result = await service.submit(aRequest(overrides), CONTEXT);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.error).toBe(expected);
+      expect(github.calls).toHaveLength(0);
+    },
+  );
+
+  it("reports a submission failure when GitHub is unreachable", async () => {
+    const github = new StubGitHubClient(failure(GITHUB_ERRORS.REQUEST_FAILED));
+    const service = new ProblemReportService(github);
+
+    const result = await service.submit(aRequest(), CONTEXT);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toBe(REPORT_ERRORS.SUBMISSION_FAILED);
+  });
+});

--- a/backend/src/tests/integration/reportsRoute.integration.test.ts
+++ b/backend/src/tests/integration/reportsRoute.integration.test.ts
@@ -1,0 +1,203 @@
+import { env } from "cloudflare:test";
+import { Hono } from "hono";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import reports from "../../routes/reports";
+import { PlayerService } from "../../services/player";
+
+// The route builds a real GitHubAppClient, so the only way to keep it off the
+// network is to replace global fetch — this pool ignores vi.mock and does not
+// expose fetchMock. A genuine RSA key is generated so the App JWT is really
+// signed: that path uses WebCrypto and is exactly the part most likely to break.
+const realFetch = globalThis.fetch;
+let issueRequests: Request[] = [];
+let tokenRequests: Request[] = [];
+
+beforeAll(async () => {
+  const pair = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const pkcs8 = (await crypto.subtle.exportKey(
+    "pkcs8",
+    pair.privateKey,
+  )) as ArrayBuffer;
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+
+  Object.assign(env, {
+    GH_APP_ID: "123456",
+    GH_APP_INSTALLATION_ID: "7654321",
+    GH_APP_PRIVATE_KEY: `-----BEGIN PRIVATE KEY-----\n${base64}\n-----END PRIVATE KEY-----`,
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  issueRequests = [];
+  tokenRequests = [];
+  vi.restoreAllMocks();
+});
+
+/**
+ * Answers both calls the App flow makes: exchange the signed JWT for an
+ * installation token, then create the issue with it.
+ */
+function interceptGitHub(issueStatus: number, issueBody: unknown) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input as RequestInfo, init);
+
+    if (request.url.includes("/access_tokens")) {
+      tokenRequests.push(request);
+      return Response.json({
+        token: "ghs_installation_token",
+        expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+      });
+    }
+
+    issueRequests.push(request);
+    return new Response(JSON.stringify(issueBody), {
+      status: issueStatus,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+/** Mounts the route behind a stand-in for the JWT middleware. */
+function appFor(googleAccountId: string) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("jwtPayload", { sub: googleAccountId });
+    await next();
+  });
+  app.route("/api/reports", reports);
+  return app;
+}
+
+function post(app: Hono, body: unknown) {
+  return app.request(
+    "/api/reports",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+const VALID_REPORT = {
+  category: "broken",
+  title: "Market never loads",
+  body: "It spins forever after I buy a contract.",
+  contactConsent: false,
+};
+
+describe("POST /api/reports", () => {
+  let app: Hono;
+
+  beforeEach(async () => {
+    // A fresh account per test: the rate limiter keys on the player, and it is
+    // real (not stubbed) in this pool, so reusing an id leaks quota across tests.
+    const accountId = `account-report-${crypto.randomUUID()}`;
+    const player = await new PlayerService(env.db).createPlayer(
+      `reporter-${crypto.randomUUID()}`,
+      "reporter@example.com",
+      accountId,
+    );
+    expect(player.ok).toBe(true);
+    app = appFor(accountId);
+  });
+
+  it("returns 201 with the created issue, filed as the app", async () => {
+    interceptGitHub(201, {
+      number: 7,
+      html_url: "https://github.com/FantasyWiki/FantasyWiki/issues/7",
+    });
+
+    const response = await post(app, VALID_REPORT);
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({
+      issueNumber: 7,
+      issueUrl: "https://github.com/FantasyWiki/FantasyWiki/issues/7",
+    });
+
+    // The App JWT was exchanged for an installation token, and the issue was
+    // created with that token — this is what makes the author FantasyWiki[bot].
+    expect(tokenRequests).toHaveLength(1);
+    expect(tokenRequests[0].url).toBe(
+      "https://api.github.com/app/installations/7654321/access_tokens",
+    );
+    expect(tokenRequests[0].headers.get("Authorization")).toMatch(
+      /^Bearer eyJ/,
+    );
+
+    expect(issueRequests).toHaveLength(1);
+    expect(issueRequests[0].url).toBe(
+      "https://api.github.com/repos/FantasyWiki/FantasyWiki/issues",
+    );
+    expect(issueRequests[0].headers.get("Authorization")).toBe(
+      "Bearer ghs_installation_token",
+    );
+
+    // The labels have to actually reach GitHub: they are what keeps user
+    // reports filterable out of the maintainers' own board.
+    const sent = (await issueRequests[0].json()) as { labels: string[] };
+    expect(sent.labels).toEqual(["user-report", "bug"]);
+  });
+
+  it("returns 400 on a validation failure without calling GitHub", async () => {
+    interceptGitHub(201, {});
+
+    const response = await post(app, { ...VALID_REPORT, body: "  " });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "REPORT_BODY_REQUIRED" });
+    expect(issueRequests).toHaveLength(0);
+    expect(tokenRequests).toHaveLength(0);
+  });
+
+  // 502 is what tells the frontend to offer the pre-filled GitHub link, so the
+  // reporter never loses what they typed. Getting this status wrong silently
+  // removes that escape hatch.
+  it("returns 502 when GitHub rejects the request", async () => {
+    interceptGitHub(401, { message: "Bad credentials" });
+
+    const response = await post(app, VALID_REPORT);
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: "REPORT_SUBMISSION_FAILED",
+    });
+  });
+
+  it("returns 429 once the burst limit is exhausted", async () => {
+    interceptGitHub(201, {
+      number: 1,
+      html_url: "https://github.com/FantasyWiki/FantasyWiki/issues/1",
+    });
+
+    // The binding allows 3 per 60s per player.
+    for (let i = 0; i < 3; i++) {
+      expect((await post(app, VALID_REPORT)).status).toBe(201);
+    }
+
+    const response = await post(app, VALID_REPORT);
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toEqual({ error: "REPORT_RATE_LIMITED" });
+  });
+});

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -20,8 +20,33 @@
           "class_name": "ContractSettlementWorkflow",
         },
       ],
+      // Guards the shared GitHub PAT behind the problem-report form. The
+      // platform only supports a 10s or 60s period, so this catches bursts —
+      // a daily quota would need storage, and the repository is publicly
+      // writable anyway, so the form adds convenience, not a new abuse surface.
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "REPORT_RATE_LIMITER",
+            "type": "ratelimit",
+            // Namespace ids only have to be unique within the Worker.
+            "namespace_id": "1001",
+            "simple": { "limit": 3, "period": 60 },
+          },
+        ],
+      },
       "triggers": {
         "crons": ["0 5 * * *"],
+      },
+      "vars": {
+        "GITHUB_REPO": "FantasyWiki/FantasyWiki",
+        // Anything but "production" adds the `preview` label to filed issues.
+        "ENVIRONMENT": "production",
+        // GitHub App identity for the problem report form. Neither value is a
+        // secret (the private key is, and is a Wrangler secret). Fill both in
+        // after creating the App and installing it on the org.
+        "GH_APP_ID": "4298123",
+        "GH_APP_INSTALLATION_ID": "146572827",
       },
     },
     "preview": {
@@ -40,8 +65,29 @@
           "class_name": "ContractSettlementWorkflow",
         },
       ],
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "REPORT_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1001",
+            "simple": { "limit": 3, "period": 60 },
+          },
+        ],
+      },
       "triggers": {
         "crons": ["0 5 * * *"],
+      },
+      "vars": {
+        // QA files real issues on the real tracker, but labelled `preview` so
+        // the noise stays filterable and bulk-deletable.
+        "GITHUB_REPO": "FantasyWiki/FantasyWiki",
+        "ENVIRONMENT": "preview",
+        // GitHub App identity for the problem report form. Neither value is a
+        // secret (the private key is, and is a Wrangler secret). Fill both in
+        // after creating the App and installing it on the org.
+        "GH_APP_ID": "4298123",
+        "GH_APP_INSTALLATION_ID": "146572827",
       },
     },
     "local": {
@@ -59,6 +105,16 @@
           "class_name": "ContractSettlementWorkflow",
         },
       ],
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "REPORT_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1001",
+            "simple": { "limit": 3, "period": 60 },
+          },
+        ],
+      },
       "triggers": {
         "crons": ["0 5 * * *"],
       },
@@ -69,6 +125,13 @@
         "frontend_deploy_branch": "dev",
         "d1_database_name": "db-preview",
         "GOOGLE_CLIENT_ID": "457796621894-7krpa8n09mekpj2cdd952jjkf1c3ookt.apps.googleusercontent.com",
+        "GITHUB_REPO": "FantasyWiki/FantasyWiki",
+        "ENVIRONMENT": "local",
+        // GitHub App identity for the problem report form. Neither value is a
+        // secret (the private key is, and is a Wrangler secret). Fill both in
+        // after creating the App and installing it on the org.
+        "GH_APP_ID": "4298123",
+        "GH_APP_INSTALLATION_ID": "146572827",
       },
     },
   },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,9 @@
 import com.github.gradle.node.npm.task.NpmTask
 import groovy.json.JsonSlurper
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+import org.gradle.api.tasks.options.Option
+import org.gradle.process.ExecOperations
 
 plugins {
     alias(libs.plugins.gitSemVer)
@@ -50,6 +54,164 @@ tasks.register("fix") {
         ":frontend:fix",
         ":backend:fix",
     )
+}
+
+/**
+ * Resolves the player behind a problem report. A report's GitHub issue carries
+ * only the opaque `players.id` — never an email, because the repository is
+ * public — so identifying the reporter means querying our own D1.
+ *
+ * Defaults to production. Reports filed from QA carry the `preview` label and
+ * live in the preview database; pass `--preview` for those. Pointing at the
+ * wrong one returns no rows rather than the wrong person.
+ *
+ *   ./gradlew who --player=3f2a9c1e-...
+ *   ./gradlew who --player=3f2a9c1e-... --preview
+ */
+abstract class WhoTask : DefaultTask() {
+
+    @get:Input
+    @get:Optional
+    @get:Option(
+        option = "player",
+        description = "The players.id from the issue's Diagnostics block",
+    )
+    abstract val player: Property<String>
+
+    @get:Input
+    @get:Option(
+        option = "preview",
+        description = "Query the QA database (db-preview) instead of production",
+    )
+    abstract val preview: Property<Boolean>
+
+    @get:Internal
+    abstract val backendDir: DirectoryProperty
+
+    @get:Inject
+    abstract val execOps: ExecOperations
+
+    init {
+        preview.convention(false)
+    }
+
+    @TaskAction
+    fun lookUp() {
+        val playerId = player.orNull
+            ?: throw GradleException(
+                "Missing --player. Usage: ./gradlew who --player=<uuid> [--preview]",
+            )
+
+        // The id is interpolated into SQL, so it must be a UUID and nothing else.
+        require(playerId.matches(Regex("[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}"))) {
+            "Not a player uuid: '$playerId'. Copy it from the issue's Diagnostics " +
+                "block, without the surrounding backticks."
+        }
+
+        // `db` is the *binding*, identical in both environments; only --env
+        // decides which database it resolves to. The database names themselves
+        // (db / db-preview) are not addressable, because wrangler.jsonc declares
+        // d1_databases per-env and nothing at the top level.
+        val environment = if (preview.get()) "preview" else "production"
+        // One line on purpose: wrangler splits --command on newlines, so a
+        // pretty-printed query runs as several broken statements.
+        val sql = "SELECT p.username, ga.email, p.created_at FROM players p " +
+            "JOIN google_accounts ga ON ga.id = p.accountId WHERE p.id = '$playerId';"
+
+        // Wrangler only draws its table when stdout is a TTY; under Gradle it is
+        // a pipe, so it emits JSON instead. We capture that and draw the table
+        // ourselves. Its warnings go to stderr and stream through untouched.
+        val stdout = ByteArrayOutputStream()
+        val isWindows = System.getProperty("os.name").lowercase().contains("win")
+        val result = execOps.exec {
+            workingDir = backendDir.get().asFile
+            commandLine(
+                if (isWindows) "npx.cmd" else "npx",
+                "wrangler", "d1", "execute", "db",
+                "--env", environment,
+                "--remote", "--json", "--command", sql,
+            )
+            standardOutput = stdout
+            isIgnoreExitValue = true
+        }
+
+        val output = stdout.toString()
+        if (result.exitValue != 0) {
+            throw GradleException("wrangler failed:\n$output")
+        }
+
+        val rows = parseRows(output)
+        logger.lifecycle("")
+        if (rows.isEmpty()) {
+            logger.lifecycle("No player '$playerId' in the $environment database.")
+            if (!preview.get()) {
+                logger.lifecycle(
+                    "Is the issue labelled `preview`? If so, re-run with --preview.",
+                )
+            }
+            return
+        }
+
+        renderTable(rows).forEach { logger.lifecycle(it) }
+        logger.lifecycle(
+            "\nOnly contact them if the issue carries the `contact-ok` label - that " +
+                "label is the only record that they agreed to be contacted.",
+        )
+    }
+
+    /**
+     * Wrangler prints warnings before its JSON, so the payload is read from the
+     * first bracket rather than by parsing the whole stream.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun parseRows(output: String): List<Map<String, Any?>> {
+        val start = output.indexOfFirst { it == '[' || it == '{' }
+        if (start < 0) return emptyList()
+
+        val parsed = JsonSlurper().parseText(output.substring(start))
+        val envelopes = if (parsed is List<*>) parsed else listOf(parsed)
+        return envelopes.flatMap { envelope ->
+            val results = (envelope as? Map<*, *>)?.get("results") as? List<*> ?: emptyList<Any?>()
+            results.mapNotNull { it as? Map<String, Any?> }
+        }
+    }
+
+    private fun renderTable(rows: List<Map<String, Any?>>): List<String> {
+        val columns = rows.first().keys.toList()
+        val widths = columns.associateWith { column ->
+            maxOf(
+                column.length,
+                rows.maxOf { (it[column]?.toString() ?: "").length },
+            )
+        }
+
+        // ASCII on purpose: Gradle writes through the JVM's default charset,
+        // which on a Windows console is cp1252 — box-drawing characters come out
+        // as literal question marks there.
+        fun rule() =
+            columns.joinToString("+", "+", "+") { "-".repeat(widths.getValue(it) + 2) }
+
+        fun cells(values: List<String>) =
+            values.mapIndexed { index, value ->
+                " " + value.padEnd(widths.getValue(columns[index])) + " "
+            }.joinToString("|", "|", "|")
+
+        return buildList {
+            add(rule())
+            add(cells(columns))
+            add(rule())
+            rows.forEach { row ->
+                add(cells(columns.map { row[it]?.toString() ?: "" }))
+            }
+            add(rule())
+        }
+    }
+}
+
+tasks.register<WhoTask>("who") {
+    group = "help"
+    description = "Identify the player who filed a problem report: --player=<uuid> [--preview]"
+    backendDir.set(layout.projectDirectory.dir("backend"))
 }
 
 group = "io.github.FantasyWiki"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    # Fail only when total coverage drops below the fixed minimum.
+    project:
+      default:
+        target: 70%
+        threshold: 0%
+    # Never gate on coverage of the changed lines alone.
+    patch: off

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Seams, layers, and modules. The rules they implement live in `domain/`.
 | [Chemistry Links Rendering](./architecture/chemistry-links-rendering.md) | `computeChemistryLinks` + the SVG overlay |
 | [Lineup Editing](./architecture/lineup-editing.md) | The `DraftLineup` seam and its pure mutations |
 | [Article Ownership Resolution](./architecture/article-ownership-resolution.md) | `buildArticleDetail` + the async team-context seam |
+| [Problem Reports](./architecture/problem-reports.md) | How `/report` files a GitHub issue, and what it never publishes |
 | [Wikimedia Client Architecture](./architecture/wikimedia-client-architecture.md) | Composition root and capability modules |
 | [Wikimedia Client Behavior Extension](./architecture/wikimedia-client-behavior-extension.md) | How to add a capability |
 | [Wikimedia Client Terminology](./architecture/wikimedia-client-terminology-hierarchy.md) | Naming and hierarchy rules |

--- a/docs/architecture/problem-reports.md
+++ b/docs/architecture/problem-reports.md
@@ -1,0 +1,140 @@
+---
+title: Problem Reports
+type: architecture
+tags: [reports, github, privacy, rate-limiting]
+---
+
+# Problem Reports
+
+Signed-in players file a problem from `/report`. The backend opens a **GitHub issue** on
+`FantasyWiki/FantasyWiki` on their behalf and returns the issue number and URL.
+
+There is no `problem_report` table. GitHub is the store of record: it assigns the id, the
+timestamp and the permanent URL, and returns `html_url` in the create response.
+
+## The pieces
+
+| Layer | Module | Responsibility |
+| --- | --- | --- |
+| Route | `backend/src/routes/reports.ts` | `POST /api/reports`. Resolves the player from the session, checks the rate limiter, maps failures to status codes. |
+| Service | `backend/src/services/problemReport.ts` | Validates, builds the issue title/body/labels. |
+| Client | `backend/src/services/githubClient.ts` | `GitHubClient` interface + `GitHubApiClient`. Injected, so tests substitute a stub. |
+| Composable | `frontend/src/composables/useProblemReport.ts` | Form state, submission, cooldown, fallback URL. |
+| View | `frontend/src/views/ReportProblemPage.vue` | Bindings over the composable. |
+
+The reporter is never taken from the request body — the route resolves them from the JWT, per
+[API Naming Rules](../development/api-naming-rules.md).
+
+## What goes into the issue
+
+The body is the reporter's own text, followed by a collapsed `<details>` block holding the route
+they came from, locale, viewport, user agent, and the opaque `players.id`.
+
+**The email is never published.** The repository is public, so an address in an issue body would
+be indexed and harvested permanently. To reply to a reporter, resolve their id server-side —
+there is no tooling for this, it is a hand-run query:
+
+```sql
+SELECT ga.email
+FROM players p JOIN google_accounts ga ON ga.id = p.accountId
+WHERE p.id = '<uuid from the issue body>';
+```
+
+The consent checkbox covers **this report only** ("You can contact me about this report") and adds
+the `contact-ok` label. It is not a marketing opt-in.
+
+## Labels
+
+Every report gets `user-report`, so maintainers can filter player reports out of their own board
+with `-label:user-report`. Outside production, reports also get `preview`, keeping QA noise
+filterable and bulk-deletable.
+
+| Category (what the player picks) | Labels |
+| --- | --- |
+| Something is broken | `bug` |
+| Something looks wrong | `bug`, `visual` |
+| Propose a new functionality | `feature` |
+| Request a new language | `feature`, `language` |
+| I don't understand a rule | `question` |
+| Something else | — |
+
+Categories name the problem in the player's words, not by subsystem — a player should not need to
+know the architecture to file a bug. Maintainers add any further labels at triage.
+
+## Rate limiting
+
+A Cloudflare rate-limit binding (`REPORT_RATE_LIMITER`) allows **3 submissions per 60s per
+player**. The platform only supports a 10s or 60s period, so there is no daily cap. The binding
+counts *attempts*, not successes: a GitHub outage consumes quota.
+
+The client also disables the form for 60s after a submission via `localStorage`. That is a
+courtesy to stop double-clicks, not a security control — the binding is the real limit.
+
+## Failure handling
+
+| Condition | Status | What the player sees |
+| --- | --- | --- |
+| Invalid payload | `400` | Inline validation message. |
+| Rate limited | `429` | A cooldown message. **No** GitHub link — that would defeat the limit. |
+| GitHub unreachable | `502` | The form keeps their text, plus a link to GitHub's own pre-filled `issues/new` form. |
+
+A fallback issue filed through that link arrives **unlabelled and authored by the reporter's own
+GitHub account** (`labels` in the query string is ignored for users without triage rights), so it
+will not match the `user-report` filter.
+
+## Screenshots
+
+The form does not upload images. GitHub has no public API for attaching a file to an issue, so
+the success screen links the created issue and invites the reporter to drag their screenshot in
+there — GitHub's own uploader handles it.
+
+## Authentication: a GitHub App, not a token
+
+Issues are filed by a **GitHub App**, so they are authored by `FantasyWiki[bot]`. A personal
+access token would author every player report under the maintainer who minted it, and would
+expire (366 days maximum) — failing silently, since an expired token simply turns every
+submission into a `502`.
+
+On each report the Worker signs a short-lived **RS256 JWT** with the App's private key
+(WebCrypto — no library), exchanges it at `/app/installations/{id}/access_tokens` for an
+installation token, and creates the issue with that. Installation tokens last an hour and are
+cached per isolate, so the exchange is not paid on every request. Nothing needs rotating.
+
+### Setting it up
+
+1. Create a GitHub App under the **FantasyWiki org** (*Org Settings → Developer settings → GitHub
+   Apps → New*). Repository permissions: **Issues: Read and write**. No webhook, no user
+   authorization.
+2. **Install** it on the org, granting it only `FantasyWiki/FantasyWiki`.
+3. Note the **App ID** and the **Installation ID** — the latter is the trailing number in the URL
+   of *Org Settings → GitHub Apps → Configure*. Neither is secret; both go in `wrangler.jsonc`
+   under `GH_APP_ID` and `GH_APP_INSTALLATION_ID`, in **all three** environments.
+4. Generate a private key. GitHub hands you a **PKCS#1** PEM (`BEGIN RSA PRIVATE KEY`), which
+   WebCrypto cannot import. Convert it once:
+
+   ```bash
+   openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
+     -in fantasywiki.private-key.pem -out fantasywiki.pkcs8.pem
+   ```
+
+   The result starts `-----BEGIN PRIVATE KEY-----`.
+5. Store that PKCS#8 PEM as the GitHub **Actions secret** `GH_APP_PRIVATE_KEY` (one key serves
+   both environments). The deploy workflow pushes it to the Worker as a secret on every deploy,
+   the same way `JWT_SECRET` flows.
+
+The binding is deliberately **not** named `GITHUB_APP_PRIVATE_KEY`: GitHub reserves the `GITHUB_`
+prefix and refuses to create an Actions secret that uses it.
+
+## Prerequisite: the labels must exist
+
+`user-report`, `visual`, `preview`, `contact-ok` and `language` must exist on the repository. GitHub **drops
+unknown labels from a create-issue call and still returns `201`**, so a missing label fails
+silently — the issue is filed, just unlabelled, and the `-label:user-report` filter that keeps the
+maintainers' board clean quietly matches nothing.
+
+## Related
+
+- [Local Development Setup](../development/local-dev-setup.md) — where `GITHUB_TOKEN` goes.
+- [API Naming Rules](../development/api-naming-rules.md) — why the reporter comes from the session.
+- [Backend Architecture](./backend-architecture.md) — the Routes → Services layering this follows.
+- [Backend Error Constants](./backend-error-constants.md) — the `REPORT_ERRORS` convention.

--- a/docs/architecture/problem-reports.md
+++ b/docs/architecture/problem-reports.md
@@ -31,14 +31,28 @@ The body is the reporter's own text, followed by a collapsed `<details>` block h
 they came from, locale, viewport, user agent, and the opaque `players.id`.
 
 **The email is never published.** The repository is public, so an address in an issue body would
-be indexed and harvested permanently. To reply to a reporter, resolve their id server-side —
-there is no tooling for this, it is a hand-run query:
+be indexed and harvested permanently. To find out who filed a report, resolve their id against
+our own database:
+
+```bash
+./gradlew who --player=<uuid from the issue body>   # production
+./gradlew who --player=<uuid> --preview             # QA (issues labelled `preview`)
+```
+
+Under the hood that runs the join below through `wrangler d1 execute db --env <environment>`.
+Note the argument is the **binding** `db`, not the database name: `wrangler.jsonc` declares
+`d1_databases` per-environment and nothing at the top level, so `db-preview` is not addressable —
+only `--env` selects the database.
 
 ```sql
-SELECT ga.email
-FROM players p JOIN google_accounts ga ON ga.id = p.accountId
-WHERE p.id = '<uuid from the issue body>';
+SELECT p.username, ga.email, p.created_at
+  FROM players p JOIN google_accounts ga ON ga.id = p.accountId
+ WHERE p.id = '<uuid from the issue body>';
 ```
+
+**Only contact a reporter whose issue carries `contact-ok`.** That label is the sole record that
+they agreed to it — the email is in our database because they signed in with Google, not because
+they offered it for support.
 
 The consent checkbox covers **this report only** ("You can contact me about this report") and adds
 the `contact-ok` label. It is not a marketing opt-in.

--- a/docs/development/local-dev-setup.md
+++ b/docs/development/local-dev-setup.md
@@ -35,6 +35,7 @@ GOOGLE_CLIENT_ID=457796621894-7krpa8n09mekpj2cdd952jjkf1c3ookt.apps.googleuserco
 GOOGLE_CLIENT_SECRET=<ask a team member>
 JWT_SECRET=<any random string, at least 32 characters>
 FRONTEND_URL=localhost:5173
+GH_APP_PRIVATE_KEY=<optional; only needed to exercise the problem report form>
 ```
 
 **Notes:**
@@ -48,6 +49,19 @@ FRONTEND_URL=localhost:5173
   ```
 - `GOOGLE_CLIENT_SECRET` is sensitive — ask a team member or find it in the
   Google Cloud Console under the OAuth 2.0 client for this project.
+- `GH_APP_PRIVATE_KEY` backs the in-app problem report form (`/report`), which opens an
+  issue on `FantasyWiki/FantasyWiki` as `FantasyWiki[bot]`. **Leave it unset unless you are
+  working on that form** — every submission with a valid key files a **real** issue (labelled
+  `preview` outside production, so it stays filterable and bulk-deletable).
+
+  It is the GitHub App's private key, converted to **PKCS#8** (GitHub gives you PKCS#1, which
+  WebCrypto cannot import), with newlines escaped as `\n` so it fits on one line. See
+  [Problem Reports](../architecture/problem-reports.md) for how to create the App and convert
+  the key. `GH_APP_ID`, `GH_APP_INSTALLATION_ID`, `GITHUB_REPO` and `ENVIRONMENT` are plain
+  vars and already live in `wrangler.jsonc`.
+
+  In CI it is a **GitHub Actions secret** of the same name, pushed to the Worker by the deploy
+  workflow — not a `wrangler secret put`.
 
 ---
 

--- a/dto/problemReportDTO.ts
+++ b/dto/problemReportDTO.ts
@@ -1,0 +1,55 @@
+/**
+ * A problem report filed from inside the app. It becomes a GitHub issue on the
+ * project repository — see docs/adr for why reports live in the issue tracker
+ * rather than in D1, and why the reporter is identified pseudonymously.
+ */
+
+/**
+ * User-facing categories. They describe the kind of problem in the player's own
+ * words, deliberately not the subsystem it belongs to — a player should not have
+ * to know the architecture to file a bug. Maintainers add subsystem labels
+ * (contract-flow, etc.) during triage.
+ */
+export const REPORT_CATEGORIES = [
+  "broken",
+  "visual",
+  "idea",
+  "language",
+  "rules",
+  "other",
+] as const;
+
+export type ReportCategory = (typeof REPORT_CATEGORIES)[number];
+
+export function isReportCategory(value: unknown): value is ReportCategory {
+  return REPORT_CATEGORIES.includes(value as ReportCategory);
+}
+
+export const REPORT_TITLE_MAX_LENGTH = 120;
+
+/**
+ * Context collected by the client, not typed by the player. Everything here is
+ * safe to publish: the reporter is referenced by their opaque player id, never
+ * by email.
+ */
+export interface ReportDiagnosticsDTO {
+  /** The route the reporter was on before opening the report form. */
+  route?: string;
+  locale?: string;
+  viewport?: string;
+  userAgent?: string;
+}
+
+export interface CreateProblemReportRequest {
+  category: ReportCategory;
+  title: string;
+  body: string;
+  /** Consent to be contacted about *this report*. Never a marketing opt-in. */
+  contactConsent: boolean;
+  diagnostics?: ReportDiagnosticsDTO;
+}
+
+export interface ProblemReportCreatedDTO {
+  issueNumber: number;
+  issueUrl: string;
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,38 +5,20 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, provide, ref } from "vue";
+import { onMounted, onUnmounted } from "vue";
 import { IonApp, IonRouterOutlet } from "@ionic/vue";
+import { useAppStore } from "@/stores/app";
 
-// Global state that can be accessed by all components
-const isDark = ref(false);
-const isLoggedIn = ref(false);
+// The store applies the resolved theme when it is created; all we own here is
+// the OS-preference listener, which lives as long as the app does.
+const appStore = useAppStore();
+let unfollowSystemTheme: (() => void) | undefined;
 
-// Provide global state to all child components
-provide("isDark", isDark);
-provide("isLoggedIn", isLoggedIn);
-
-// Initialize theme on mount
 onMounted(() => {
-  const savedTheme = localStorage.getItem("theme");
-  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
-
-  if (savedTheme) {
-    isDark.value = savedTheme === "dark";
-  } else {
-    isDark.value = prefersDark.matches;
-  }
-
-  document.body.classList.toggle("ion-palette-dark", isDark.value);
-
-  // Listen for system theme changes
-  prefersDark.addEventListener("change", (e) => {
-    if (!localStorage.getItem("theme")) {
-      isDark.value = e.matches;
-      document.body.classList.toggle("ion-palette-dark", e.matches);
-    }
-  });
+  unfollowSystemTheme = appStore.followSystemTheme();
 });
+
+onUnmounted(() => unfollowSystemTheme?.());
 </script>
 
 <style></style>

--- a/frontend/src/components/SettingsMenu.vue
+++ b/frontend/src/components/SettingsMenu.vue
@@ -1,0 +1,212 @@
+<template>
+  <!-- Rendered inside an ion-popover on desktop and an ion-modal sheet on
+       mobile, so it owns no chrome of its own — just the rows. -->
+  <ion-list lines="none" class="settings-menu ion-no-padding">
+    <template v-if="view === 'root'">
+      <ion-item
+        v-if="appStore.isAuthenticated"
+        class="account-row"
+        lines="full"
+      >
+        <ion-avatar slot="start" class="account-avatar" aria-hidden="true">
+          <img
+            v-if="picture"
+            :src="picture"
+            alt=""
+            referrerpolicy="no-referrer"
+          />
+          <ion-icon v-else :icon="personCircleOutline" />
+        </ion-avatar>
+        <ion-label>
+          <h3 class="account-name">{{ appStore.currentUser?.name }}</h3>
+          <p class="account-email">{{ appStore.currentUser?.email }}</p>
+        </ion-label>
+      </ion-item>
+
+      <ion-item :button="true" :detail="true" @click="view = 'language'">
+        <ion-icon :icon="globeOutline" slot="start" aria-hidden="true" />
+        <ion-label>{{ $t("menu.language") }}</ion-label>
+        <ion-note slot="end">{{ appStore.currentLanguage.fullName }}</ion-note>
+      </ion-item>
+
+      <!-- Theme is a binary, so it toggles in place: a submenu for two states
+           would cost a click and teach nothing. -->
+      <ion-item>
+        <ion-icon
+          :icon="appStore.isDarkMode ? moonOutline : sunnyOutline"
+          slot="start"
+          aria-hidden="true"
+        />
+        <ion-toggle
+          :checked="appStore.isDarkMode"
+          @ion-change="appStore.setDarkMode($event.detail.checked)"
+        >
+          {{ $t("menu.darkMode") }}
+        </ion-toggle>
+      </ion-item>
+
+      <ion-item
+        :button="true"
+        :detail="false"
+        :href="USER_GUIDE_URL"
+        target="_blank"
+        rel="noopener"
+        @click="emit('close')"
+      >
+        <ion-icon :icon="bookOutline" slot="start" aria-hidden="true" />
+        <ion-label>{{ $t("menu.userGuide") }}</ion-label>
+        <ion-icon
+          :icon="openOutline"
+          slot="end"
+          class="external-icon"
+          aria-hidden="true"
+        />
+      </ion-item>
+
+      <ion-item
+        :button="true"
+        :detail="false"
+        lines="full"
+        class="auth-row"
+        @click="onAuth"
+      >
+        <ion-icon
+          :icon="appStore.isAuthenticated ? logOutOutline : logInOutline"
+          slot="start"
+          aria-hidden="true"
+        />
+        <ion-label>
+          {{ appStore.isAuthenticated ? $t("nav.signOut") : $t("nav.signIn") }}
+        </ion-label>
+      </ion-item>
+    </template>
+
+    <template v-else>
+      <ion-item
+        :button="true"
+        :detail="false"
+        lines="full"
+        @click="view = 'root'"
+      >
+        <ion-icon :icon="chevronBackOutline" slot="start" aria-hidden="true" />
+        <ion-label>{{ $t("menu.language") }}</ion-label>
+      </ion-item>
+
+      <ion-item
+        v-for="lang in appStore.availableLanguages"
+        :key="lang.code"
+        :button="true"
+        :detail="false"
+        @click="selectLanguage(lang.code)"
+      >
+        <ion-label>{{ lang.label }} {{ lang.fullName }}</ion-label>
+        <ion-icon
+          v-if="appStore.isLanguage(lang.code)"
+          :icon="checkmarkOutline"
+          slot="end"
+          aria-hidden="true"
+        />
+      </ion-item>
+    </template>
+  </ion-list>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import {
+  IonAvatar,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonToggle,
+} from "@ionic/vue";
+import {
+  bookOutline,
+  checkmarkOutline,
+  chevronBackOutline,
+  globeOutline,
+  logInOutline,
+  logOutOutline,
+  moonOutline,
+  openOutline,
+  personCircleOutline,
+  sunnyOutline,
+} from "ionicons/icons";
+import { useAppStore } from "@/stores/app";
+
+const USER_GUIDE_URL =
+  "https://github.com/FantasyWiki/FantasyWiki/tree/master/docs";
+
+const emit = defineEmits<{ close: [] }>();
+
+const appStore = useAppStore();
+
+// A nested list rather than an inline segment: adding a locale to
+// AVAILABLE_LANGUAGES then costs no layout work here.
+const view = ref<"root" | "language">("root");
+
+const picture = computed(() => appStore.currentUser?.picture);
+
+function selectLanguage(code: string) {
+  appStore.setLanguage(code);
+  view.value = "root";
+  emit("close");
+}
+
+// The menu closes first: both modals are siblings of the popover/sheet, and
+// Ionic will not stack them reliably if the trigger is still open.
+function onAuth() {
+  emit("close");
+  if (appStore.isAuthenticated) {
+    appStore.openLogoutModal();
+  } else {
+    appStore.openLoginModal();
+  }
+}
+</script>
+
+<style scoped>
+.settings-menu ion-item {
+  font-size: 0.875rem;
+  --min-height: 44px;
+}
+
+.account-row {
+  --min-height: 60px;
+}
+
+.account-avatar {
+  width: 2rem;
+  height: 2rem;
+  color: var(--ion-color-medium);
+}
+
+.account-avatar ion-icon {
+  font-size: 2rem;
+}
+
+.account-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.account-email {
+  font-size: 0.75rem;
+  color: var(--ion-color-medium);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.external-icon {
+  font-size: 0.875rem;
+  color: var(--ion-color-medium);
+}
+
+.auth-row {
+  --border-width: 1px 0 0 0;
+}
+</style>

--- a/frontend/src/components/SettingsMenu.vue
+++ b/frontend/src/components/SettingsMenu.vue
@@ -45,6 +45,19 @@
         </ion-toggle>
       </ion-item>
 
+      <!-- Signed-out visitors keep the footer's link straight to GitHub Issues;
+           the in-app form needs a session to attribute the report. -->
+      <ion-item
+        v-if="appStore.isAuthenticated"
+        :button="true"
+        :detail="false"
+        class="report-row"
+        @click="goToReport"
+      >
+        <ion-icon :icon="bugOutline" slot="start" aria-hidden="true" />
+        <ion-label>{{ $t("menu.reportProblem") }}</ion-label>
+      </ion-item>
+
       <ion-item
         :button="true"
         :detail="false"
@@ -113,6 +126,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
 import {
   IonAvatar,
   IonIcon,
@@ -124,6 +138,7 @@ import {
 } from "@ionic/vue";
 import {
   bookOutline,
+  bugOutline,
   checkmarkOutline,
   chevronBackOutline,
   globeOutline,
@@ -141,7 +156,13 @@ const USER_GUIDE_URL =
 
 const emit = defineEmits<{ close: [] }>();
 
+const router = useRouter();
 const appStore = useAppStore();
+
+function goToReport() {
+  emit("close");
+  router.push("/report");
+}
 
 // A nested list rather than an inline segment: adding a locale to
 // AVAILABLE_LANGUAGES then costs no layout work here.

--- a/frontend/src/components/homePage/CTASection.vue
+++ b/frontend/src/components/homePage/CTASection.vue
@@ -22,7 +22,7 @@
           </ion-text>
 
           <div class="ion-margin-bottom">
-            <ion-button size="large" color="light">
+            <ion-button size="large" color="light" @click="startPlaying">
               {{ $t("home.cta.createAccount") }}
               <ion-icon slot="end" :icon="arrowForward" />
             </ion-button>
@@ -40,6 +40,9 @@
 <script setup lang="ts">
 import { IonButton, IonChip, IonIcon, IonLabel, IonText } from "@ionic/vue";
 import { sparklesOutline, arrowForward } from "ionicons/icons";
+import { useAuthCta } from "@/composables/useAuthCta";
+
+const { startPlaying } = useAuthCta();
 </script>
 
 <style scoped src="src/components/homePage/home-page.css"></style>

--- a/frontend/src/components/homePage/HeroSection.vue
+++ b/frontend/src/components/homePage/HeroSection.vue
@@ -22,8 +22,9 @@
           {{ $t("home.hero.description") }}
         </p>
         <ion-button
-          class="ion-text-capitalize ion-padding-horizontal"
+          class="hero-cta ion-text-capitalize ion-padding-horizontal"
           size="large"
+          @click="startPlaying"
         >
           <ion-text>{{ $t("home.hero.getStarted") }}</ion-text>
           <ion-icon slot="end" :icon="arrowForwardOutline"></ion-icon>
@@ -53,6 +54,9 @@ import {
 import { arrowForwardOutline, flashOutline } from "ionicons/icons";
 import AppStats from "./AppStats.vue";
 import ArticleLeaderboard from "./ArticleLeaderboard.vue";
+import { useAuthCta } from "@/composables/useAuthCta";
+
+const { startPlaying } = useAuthCta();
 </script>
 
 <style scoped src="src/components/homePage/home-page.css"></style>

--- a/frontend/src/composables/useAuthCta.ts
+++ b/frontend/src/composables/useAuthCta.ts
@@ -1,0 +1,24 @@
+import { useRouter } from "vue-router";
+import { useAppStore } from "@/stores/app";
+
+/**
+ * Shared behaviour for the landing page's primary calls to action ("Get
+ * started", "Create account"): send a signed-in visitor straight to their
+ * dashboard, and prompt everyone else to log in. The login modal is owned by
+ * the app store precisely so these buttons can reach it from inside the
+ * NavBar's content slot.
+ */
+export function useAuthCta() {
+  const router = useRouter();
+  const appStore = useAppStore();
+
+  function startPlaying() {
+    if (appStore.isAuthenticated) {
+      router.push("/dashboard");
+    } else {
+      appStore.openLoginModal();
+    }
+  }
+
+  return { startPlaying };
+}

--- a/frontend/src/composables/useProblemReport.ts
+++ b/frontend/src/composables/useProblemReport.ts
@@ -1,0 +1,135 @@
+import { computed, onUnmounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import { ApiError, reportsApi } from "@/services/api";
+import type {
+  ProblemReportCreatedDTO,
+  ReportCategory,
+} from "../../../dto/problemReportDTO";
+
+const REPO_URL = "https://github.com/FantasyWiki/FantasyWiki";
+const COOLDOWN_KEY = "report:lastSubmittedAt";
+
+/**
+ * Mirrors the server's 60s rate-limit window. This is a courtesy, not a control
+ * — it stops double-clicks and impulsive repeats. The Cloudflare rate-limit
+ * binding is what actually protects the shared GitHub token.
+ */
+export const COOLDOWN_SECONDS = 60;
+
+/**
+ * Form state and submission for the problem report page (issue #439). Lives in
+ * a composable so the submit/fallback logic is testable without driving Ionic's
+ * web components through jsdom.
+ */
+export function useProblemReport() {
+  const { t, locale } = useI18n();
+  const router = useRouter();
+
+  const category = ref<ReportCategory | undefined>();
+  const title = ref("");
+  const body = ref("");
+  const contactConsent = ref(false);
+
+  const isSubmitting = ref(false);
+  const errorMessage = ref("");
+  const fallbackUrl = ref("");
+  const created = ref<ProblemReportCreatedDTO | null>(null);
+
+  // The route the reporter came from is the most useful thing in the
+  // diagnostics, and it is lost the moment they navigate to /report.
+  const back = router.options.history.state.back;
+  const previousRoute = typeof back === "string" ? back : "";
+
+  const cooldownRemaining = ref(0);
+  const cooldownTimer = setInterval(refreshCooldown, 1000);
+  refreshCooldown();
+  onUnmounted(() => clearInterval(cooldownTimer));
+
+  function refreshCooldown() {
+    const last = Number(localStorage.getItem(COOLDOWN_KEY) ?? 0);
+    const elapsed = (Date.now() - last) / 1000;
+    cooldownRemaining.value = Math.max(
+      0,
+      Math.ceil(COOLDOWN_SECONDS - elapsed)
+    );
+  }
+
+  const canSubmit = computed(
+    () =>
+      Boolean(category.value) &&
+      title.value.trim().length > 0 &&
+      body.value.trim().length > 0 &&
+      cooldownRemaining.value === 0
+  );
+
+  /**
+   * GitHub's web form accepts a pre-filled issue via query params, so a backend
+   * outage never costs the reporter their words. `labels` is ignored for users
+   * without triage rights, so a fallback issue arrives unlabelled and authored
+   * by the reporter — it will not match the `user-report` filter.
+   */
+  function buildFallbackUrl(): string {
+    const params = new URLSearchParams({
+      title: title.value.trim(),
+      body: body.value.trim(),
+    });
+    return `${REPO_URL}/issues/new?${params.toString()}`;
+  }
+
+  async function submit() {
+    if (!canSubmit.value || !category.value) return;
+
+    isSubmitting.value = true;
+    errorMessage.value = "";
+    fallbackUrl.value = "";
+
+    try {
+      created.value = await reportsApi.create({
+        category: category.value,
+        title: title.value.trim(),
+        body: body.value.trim(),
+        contactConsent: contactConsent.value,
+        diagnostics: {
+          route: previousRoute || undefined,
+          locale: locale.value,
+          viewport: `${window.innerWidth}x${window.innerHeight}`,
+          userAgent: navigator.userAgent,
+        },
+      });
+      localStorage.setItem(COOLDOWN_KEY, String(Date.now()));
+      refreshCooldown();
+    } catch (error) {
+      const status = error instanceof ApiError ? error.status : 0;
+
+      if (status === 429) {
+        // Our own limiter said no. Deliberately no GitHub bypass here — that
+        // would defeat the throttle we just applied.
+        errorMessage.value = t("report.errors.rateLimited");
+        localStorage.setItem(COOLDOWN_KEY, String(Date.now()));
+        refreshCooldown();
+      } else if (status === 400) {
+        errorMessage.value = t("report.errors.invalid");
+      } else {
+        errorMessage.value = t("report.errors.submissionFailed");
+        fallbackUrl.value = buildFallbackUrl();
+      }
+    } finally {
+      isSubmitting.value = false;
+    }
+  }
+
+  return {
+    category,
+    title,
+    body,
+    contactConsent,
+    isSubmitting,
+    errorMessage,
+    fallbackUrl,
+    created,
+    cooldownRemaining,
+    canSubmit,
+    submit,
+  };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -9,6 +9,12 @@
     "signIn": "Sign In with Google",
     "signOut": "Sign Out"
   },
+  "menu": {
+    "open": "Open menu",
+    "language": "Language",
+    "darkMode": "Dark mode",
+    "userGuide": "User guide"
+  },
   "footer": {
     "technicalDocs": "Technical documentation",
     "userGuide": "User guide",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -13,7 +13,8 @@
     "open": "Open menu",
     "language": "Language",
     "darkMode": "Dark mode",
-    "userGuide": "User guide"
+    "userGuide": "User guide",
+    "reportProblem": "Report a problem"
   },
   "footer": {
     "technicalDocs": "Technical documentation",
@@ -22,6 +23,42 @@
     "legal": "Legal & privacy",
     "madeBy": "made by",
     "and": "and"
+  },
+  "report": {
+    "title": "Report a problem",
+    "intro": "Tell us what went wrong and we'll open an issue on GitHub for you.",
+    "privacyNote": "Your report is filed as a public GitHub issue. Your email is never published — we identify you by an internal id only.",
+    "submit": "Send report",
+    "cooldown": "You just sent a report. You can send another in {seconds}s.",
+    "categories": {
+      "broken": "Something is broken",
+      "visual": "Something looks wrong",
+      "idea": "Propose a new functionality",
+      "language": "Request a new language",
+      "rules": "I don't understand a rule",
+      "other": "Something else"
+    },
+    "fields": {
+      "category": "What kind of problem is it?",
+      "categoryPlaceholder": "Choose a category",
+      "titleLabel": "Title",
+      "titlePlaceholder": "Summarise it in one line",
+      "bodyLabel": "Description",
+      "bodyPlaceholder": "What happened, and what did you expect instead?",
+      "contactConsent": "You can contact me about this report"
+    },
+    "success": {
+      "title": "Thanks — your report is filed",
+      "body": "We opened issue {issue} on GitHub.",
+      "screenshotHint": "Have a screenshot? Open the issue and drag the image straight into it.",
+      "openIssue": "Open the issue"
+    },
+    "errors": {
+      "rateLimited": "You just sent a report. Give it a minute before sending another.",
+      "invalid": "Please choose a category and fill in both the title and the description.",
+      "submissionFailed": "We couldn't reach GitHub, so the report wasn't filed. Your text is still here.",
+      "fallbackLink": "File it on GitHub yourself"
+    }
   },
   "notFound": {
     "title": "404: Page not found",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -13,7 +13,8 @@
     "open": "Apri il menu",
     "language": "Lingua",
     "darkMode": "Tema scuro",
-    "userGuide": "Guida utente"
+    "userGuide": "Guida utente",
+    "reportProblem": "Segnala un problema"
   },
   "footer": {
     "technicalDocs": "Documentazione tecnica",
@@ -22,6 +23,42 @@
     "legal": "Note legali e privacy",
     "madeBy": "creato da",
     "and": "e"
+  },
+  "report": {
+    "title": "Segnala un problema",
+    "intro": "Raccontaci cosa non ha funzionato e apriremo una issue su GitHub per te.",
+    "privacyNote": "La segnalazione diventa una issue pubblica su GitHub. La tua email non viene mai pubblicata: ti identifichiamo solo con un id interno.",
+    "submit": "Invia segnalazione",
+    "cooldown": "Hai appena inviato una segnalazione. Puoi inviarne un'altra tra {seconds}s.",
+    "categories": {
+      "broken": "Qualcosa non funziona",
+      "visual": "Qualcosa si vede male",
+      "idea": "Proponi una nuova funzionalità",
+      "language": "Richiedi una nuova lingua",
+      "rules": "Non capisco una regola",
+      "other": "Altro"
+    },
+    "fields": {
+      "category": "Che tipo di problema è?",
+      "categoryPlaceholder": "Scegli una categoria",
+      "titleLabel": "Titolo",
+      "titlePlaceholder": "Riassumilo in una riga",
+      "bodyLabel": "Descrizione",
+      "bodyPlaceholder": "Cosa è successo e cosa ti aspettavi invece?",
+      "contactConsent": "Potete contattarmi riguardo a questa segnalazione"
+    },
+    "success": {
+      "title": "Grazie — segnalazione inviata",
+      "body": "Abbiamo aperto la issue {issue} su GitHub.",
+      "screenshotHint": "Hai uno screenshot? Apri la issue e trascina l'immagine direttamente al suo interno.",
+      "openIssue": "Apri la issue"
+    },
+    "errors": {
+      "rateLimited": "Hai appena inviato una segnalazione. Aspetta un minuto prima di inviarne un'altra.",
+      "invalid": "Scegli una categoria e compila sia il titolo sia la descrizione.",
+      "submissionFailed": "Non siamo riusciti a contattare GitHub, quindi la segnalazione non è stata inviata. Il tuo testo è ancora qui.",
+      "fallbackLink": "Aprila tu su GitHub"
+    }
   },
   "notFound": {
     "title": "404: Pagina non trovata",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -9,6 +9,12 @@
     "signIn": "Accedi con Google",
     "signOut": "Esci"
   },
+  "menu": {
+    "open": "Apri il menu",
+    "language": "Lingua",
+    "darkMode": "Tema scuro",
+    "userGuide": "Guida utente"
+  },
   "footer": {
     "technicalDocs": "Documentazione tecnica",
     "userGuide": "Guida utente",

--- a/frontend/src/layout/InfoFooter.vue
+++ b/frontend/src/layout/InfoFooter.vue
@@ -16,7 +16,13 @@
         GitHub
       </a>
       <span aria-hidden="true">·</span>
-      <a :href="`${REPO_URL}/issues`" target="_blank" rel="noopener">
+      <!-- Signed-in players get the in-app form, which files the issue for them
+           and labels it. Anonymous visitors have no session to attribute a
+           report to, so they keep the direct link to the issue tracker. -->
+      <router-link v-if="appStore.isAuthenticated" to="/report">
+        {{ $t("footer.reportProblem") }}
+      </router-link>
+      <a v-else :href="`${REPO_URL}/issues`" target="_blank" rel="noopener">
         {{ $t("footer.reportProblem") }}
       </a>
       <span aria-hidden="true">·</span>
@@ -43,8 +49,11 @@
 <script setup lang="ts">
 import { IonIcon } from "@ionic/vue";
 import { logoGithub } from "ionicons/icons";
+import { useAppStore } from "@/stores/app";
 
 const REPO_URL = "https://github.com/FantasyWiki/FantasyWiki";
+
+const appStore = useAppStore();
 </script>
 
 <style scoped>

--- a/frontend/src/layout/NavBar.vue
+++ b/frontend/src/layout/NavBar.vue
@@ -79,79 +79,58 @@
             </ion-list>
           </ion-popover>
 
-          <!-- Language Selector -->
+          <!-- Sign in stays a first-class button while logged out: it is the
+               only action an anonymous visitor is here to take, and the space
+               is free because there is no league selector yet. -->
           <ion-button
-            fill="solid"
-            size="small"
-            shape="round"
-            @click="openLangPopover($event)"
-          >
-            <ion-icon :icon="globeOutline" />
-            <ion-text class="ion-hide-md-down">
-              {{ appStore.currentLanguage.label }}
-              {{ appStore.currentLanguage.code }}
-            </ion-text>
-          </ion-button>
-          <ion-popover
-            :is-open="langPopoverOpen"
-            :event="langPopoverEvent"
-            side="bottom"
-            alignment="end"
-            @did-dismiss="langPopoverOpen = false"
-          >
-            <ion-list lines="none" class="ion-no-margin">
-              <ion-item
-                class="ion-no-margin"
-                :detail="false"
-                v-for="lang in appStore.availableLanguages"
-                :key="lang.code"
-                :button="true"
-                @click="selectLanguage(lang.code)"
-              >
-                <ion-label>{{ lang.label }} {{ lang.fullName }}</ion-label>
-              </ion-item>
-            </ion-list>
-          </ion-popover>
-
-          <!-- Theme Toggle -->
-          <ion-button
-            fill="solid"
-            size="small"
-            shape="round"
-            @click="toggleTheme"
-          >
-            <ion-icon
-              :icon="appStore.isDarkMode ? moonOutline : sunnyOutline"
-            />
-          </ion-button>
-
-          <!-- Sign In / Out -->
-          <ion-button
-            v-if="appStore.isAuthenticated"
-            fill="clear"
-            color="dark"
-            class="ion-hide-sm-down signout-button"
-            @click="handleAuth"
-          >
-            <ion-avatar
-              v-if="profilePicture"
-              slot="start"
-              class="profile-avatar"
-              aria-hidden="true"
-            >
-              <img :src="profilePicture" alt="" referrerpolicy="no-referrer" />
-            </ion-avatar>
-            {{ $t("nav.signOut") }}
-          </ion-button>
-          <ion-button
-            v-else
+            v-if="!appStore.isAuthenticated"
             color="primary"
             fill="solid"
-            class="ion-hide-sm-down"
-            @click="handleAuth"
+            size="small"
+            shape="round"
+            class="ion-hide-md-down"
+            @click="appStore.openLoginModal()"
           >
             {{ $t("nav.signIn") }}
           </ion-button>
+
+          <!-- One trigger in both auth states: the avatar slot holds a person
+               glyph while logged out and fills with the Google photo after
+               login. The button never changes identity or position, so the
+               menu stays findable. Mobile reaches the same menu from the
+               bottom nav, so this is desktop-only. -->
+          <ion-button
+            id="settings-menu-trigger"
+            fill="clear"
+            color="dark"
+            size="small"
+            shape="round"
+            class="ion-hide-md-down settings-trigger"
+            :aria-label="$t('menu.open')"
+            @click="openSettingsPopover($event)"
+          >
+            <ion-avatar class="profile-avatar" aria-hidden="true">
+              <img
+                v-if="profilePicture"
+                :src="profilePicture"
+                alt=""
+                referrerpolicy="no-referrer"
+              />
+              <ion-icon v-else :icon="personCircleOutline" />
+            </ion-avatar>
+            <ion-icon :icon="chevronDownOutline" class="trigger-chevron" />
+          </ion-button>
+
+          <ion-popover
+            :is-open="settingsPopoverOpen"
+            :event="settingsPopoverEvent"
+            side="bottom"
+            alignment="end"
+            class="settings-popover"
+            @did-dismiss="settingsPopoverOpen = false"
+          >
+            <settings-menu @close="settingsPopoverOpen = false" />
+          </ion-popover>
         </div>
       </ion-toolbar>
     </ion-header>
@@ -160,18 +139,32 @@
       <slot></slot>
       <info-footer></info-footer>
       <ion-modal
-        :is-open="isLoginOpen"
+        :is-open="appStore.isLoginModalOpen"
         css-class="login-modal"
-        @did-dismiss="isLoginOpen = false"
+        @did-dismiss="appStore.closeLoginModal()"
       >
         <login-page />
       </ion-modal>
       <ion-modal
-        :is-open="isLogoutOpen"
+        :is-open="appStore.isLogoutModalOpen"
         css-class="login-modal"
         @did-dismiss="onLogoutDismiss"
       >
         <logout-confirm-page />
+      </ion-modal>
+
+      <!-- Mobile reaches the settings menu as a bottom sheet: it is anchored to
+           the bottom nav, where the thumb already is. Auto-height rather than a
+           breakpoint, so the sheet is exactly as tall as its rows instead of
+           leaving dead space below them. -->
+      <ion-modal
+        :is-open="settingsSheetOpen"
+        class="settings-sheet"
+        @did-dismiss="settingsSheetOpen = false"
+      >
+        <div class="sheet-inner">
+          <settings-menu @close="settingsSheetOpen = false" />
+        </div>
       </ion-modal>
     </ion-content>
 
@@ -194,7 +187,13 @@
           >
             <ion-icon :icon="link.icon" />
           </ion-button>
-          <ion-button fill="clear" @click="handleAuth">
+          <!-- Was an auth toggle; now the entry point to the same settings menu
+               the desktop avatar opens. Sign in/out is a row inside it. -->
+          <ion-button
+            fill="clear"
+            :aria-label="$t('menu.open')"
+            @click="settingsSheetOpen = true"
+          >
             <ion-avatar
               v-if="profilePicture"
               class="profile-avatar"
@@ -202,10 +201,7 @@
             >
               <img :src="profilePicture" alt="" referrerpolicy="no-referrer" />
             </ion-avatar>
-            <ion-icon
-              v-else
-              :icon="appStore.isAuthenticated ? logOutOutline : logInOutline"
-            />
+            <ion-icon v-else :icon="personCircleOutline" />
           </ion-button>
         </div>
       </ion-toolbar>
@@ -231,21 +227,18 @@ import {
   IonList,
   IonPage,
   IonPopover,
-  IonText,
   IonToolbar,
 } from "@ionic/vue";
 import {
-  globeOutline,
+  chevronDownOutline,
   gridOutline,
-  logInOutline,
-  logOutOutline,
-  moonOutline,
+  personCircleOutline,
   storefrontOutline,
-  sunnyOutline,
   trophyOutline,
 } from "ionicons/icons";
 
 import AppLogo from "@/components/AppLogo.vue";
+import SettingsMenu from "@/components/SettingsMenu.vue";
 import InfoFooter from "@/layout/InfoFooter.vue";
 import LoginPage from "@/views/auth/LoginPage.vue";
 import LogoutConfirmPage from "@/views/auth/LogoutConfirmPage.vue";
@@ -257,8 +250,6 @@ import { LeagueDTO } from "../../../dto/leagueDTO";
 const router = useRouter();
 const route = useRoute();
 const { t } = useI18n();
-const isLoginOpen = ref(false);
-const isLogoutOpen = ref(false);
 
 // State
 const appStore = useAppStore();
@@ -277,27 +268,25 @@ const { unreadCount, unreadCountByLeague } = useNotifications();
 
 const leaguePopoverOpen = ref(false);
 const leaguePopoverEvent = ref<MouseEvent | undefined>(undefined);
-const langPopoverOpen = ref(false);
-const langPopoverEvent = ref<MouseEvent | undefined>(undefined);
+const settingsPopoverOpen = ref(false);
+const settingsPopoverEvent = ref<MouseEvent | undefined>(undefined);
+
+// Mobile opens the same menu as a bottom sheet from the bottom nav.
+const settingsSheetOpen = ref(false);
 
 function openLeaguePopover(e: MouseEvent) {
   leaguePopoverEvent.value = e;
   leaguePopoverOpen.value = true;
 }
 
-function openLangPopover(e: MouseEvent) {
-  langPopoverEvent.value = e;
-  langPopoverOpen.value = true;
+function openSettingsPopover(e: MouseEvent) {
+  settingsPopoverEvent.value = e;
+  settingsPopoverOpen.value = true;
 }
 
 function selectLeague(lg: LeagueDTO) {
   leagueStore.setCurrentLeague(lg);
   leaguePopoverOpen.value = false;
-}
-
-function selectLanguage(code: string) {
-  appStore.setLanguage(code);
-  langPopoverOpen.value = false;
 }
 
 // Google profile picture from the session; shown in the auth buttons so a
@@ -314,27 +303,11 @@ const navLinks = computed(() => [
 
 const isActive = (href: string) => route.path === href;
 
-const toggleTheme = () => {
-  appStore.toggleDarkMode();
-  document.body.classList.toggle("ion-palette-dark", appStore.isDarkMode);
-  localStorage.setItem("theme", appStore.isDarkMode ? "dark" : "light");
-};
-
 // Signing out asks for confirmation in a modal (same style as the login
 // one); the store is only touched when the modal is dismissed with the
 // "confirm" role.
-const handleAuth = () => {
-  if (appStore.isAuthenticated) {
-    isLogoutOpen.value = true;
-  } else {
-    // No route change: "/signin" was never a real route and would now hit
-    // the 404 catch-all; the modal simply opens over the current page.
-    isLoginOpen.value = true;
-  }
-};
-
 const onLogoutDismiss = (event: CustomEvent) => {
-  isLogoutOpen.value = false;
+  appStore.closeLogoutModal();
   if (event.detail.role === "confirm") {
     appStore.logout();
     router.push("/");
@@ -392,6 +365,15 @@ ion-toolbar {
   --padding-end: 16px;
 }
 
+/* Keep the bar full-width, just stop the logo and the actions sitting right on
+   the screen edge once there is room to breathe. */
+@media (min-width: 768px) {
+  ion-toolbar {
+    --padding-start: 32px;
+    --padding-end: 32px;
+  }
+}
+
 .transparent-top-layer {
   background: rgba(var(--ion-background-color-rgb), 0.8);
   backdrop-filter: blur(12px);
@@ -429,18 +411,50 @@ ion-footer {
 .profile-avatar {
   width: 1.75rem;
   height: 1.75rem;
+  color: var(--ion-color-medium);
 }
 
-.signout-button {
-  font-weight: 500;
-  text-transform: none;
+.profile-avatar ion-icon {
+  font-size: 1.75rem;
 }
 
-.signout-button .profile-avatar {
-  margin-inline-end: 0.5rem;
+/* The chevron is the whole affordance: it says "this opens" without a gear
+   claiming the menu is only settings. */
+.settings-trigger {
+  --padding-start: 4px;
+  --padding-end: 4px;
+}
+
+.trigger-chevron {
+  font-size: 0.75rem;
+  margin-inline-start: 0.25rem;
+  color: var(--ion-color-medium);
+}
+
+.settings-popover {
+  --width: 17rem;
 }
 
 ion-modal {
   --backdrop-opacity: 100%;
+}
+
+/* The sheet is a surface, not a dialog — it should not black out the page
+   behind it the way the login modal does. --height: auto makes it hug its
+   rows; align-items pins it to the bottom, where the trigger is. */
+ion-modal.settings-sheet {
+  --backdrop-opacity: 0.3;
+  --height: auto;
+  --width: 100%;
+  --border-radius: 16px 16px 0 0;
+  align-items: flex-end;
+}
+
+ion-modal.settings-sheet .sheet-inner {
+  /* Auto-height modals size to their content, so the scroll cap has to live
+     here — otherwise a long menu would grow past the viewport. */
+  max-height: 80vh;
+  overflow-y: auto;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 </style>

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -514,4 +514,16 @@ export const handlers = [
     const all = performancesByLeague[leagueId] ?? [];
     return HttpResponse.json(all.filter((p) => p.teamId === myTeam.id));
   }),
+
+  // Problem reports. Nothing is really filed on GitHub in mock mode — the mock
+  // just hands back a plausible issue so the success card can be exercised.
+  http.post("*/api/reports", () =>
+    HttpResponse.json(
+      {
+        issueNumber: 1234,
+        issueUrl: "https://github.com/FantasyWiki/FantasyWiki/issues/1234",
+      },
+      { status: 201 }
+    )
+  ),
 ];

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -9,6 +9,7 @@ import TeamPage from "@/views/TeamPage.vue";
 import TeamCreationPage from "@/views/TeamCreationPage.vue";
 import MarketPage from "@/views/MarketPage.vue";
 import LegalPage from "@/views/LegalPage.vue";
+import ReportProblemPage from "@/views/ReportProblemPage.vue";
 import NotFoundPage from "@/views/NotFoundPage.vue";
 import { useAppStore } from "@/stores/app";
 
@@ -72,6 +73,13 @@ const routes: Array<RouteRecordRaw> = [
     path: "/market",
     name: "Market",
     component: MarketPage,
+  },
+  {
+    // Auth-gated (no `public` meta): the reporter is resolved from the session,
+    // which is also what keeps the endpoint from being an open spam funnel.
+    path: "/report",
+    name: "Report",
+    component: ReportProblemPage,
   },
   // Catch-all 404 — must stay last
   {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -11,6 +11,10 @@ import { ContractDTO, type RawContract } from "../../../dto/contractDTO";
 import { ArticleDTO } from "../../../dto/articleDTO";
 import { PerformanceDTO } from "../../../dto/performanceDTO";
 import { LeaderboardEntryDTO } from "../../../dto/leaderboardDTO";
+import type {
+  CreateProblemReportRequest,
+  ProblemReportCreatedDTO,
+} from "../../../dto/problemReportDTO";
 import { Temporal } from "@js-temporal/polyfill";
 import {
   TIER_DAYS,
@@ -20,6 +24,23 @@ import {
 import { createWikimediaClient } from "@/services/wikimediaClient";
 
 const API_BASE_URL = "/api";
+
+/**
+ * Carries the HTTP status and the backend's error code alongside the message.
+ * Callers that only read `.message` are unaffected; the report form needs the
+ * status to tell "you just sent one" (429) apart from "GitHub is down" (502),
+ * which lead to very different offers to the user.
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
 
 async function apiRequest<T>(
   endpoint: string,
@@ -38,8 +59,10 @@ async function apiRequest<T>(
     const error = await response
       .json()
       .catch(() => ({ error: "Network error" }));
-    throw new Error(
-      error.error || `HTTP ${response.status}: ${response.statusText}`
+    throw new ApiError(
+      error.error || `HTTP ${response.status}: ${response.statusText}`,
+      response.status,
+      error.error
     );
   }
 
@@ -270,6 +293,17 @@ export const sessionApi = {
     apiRequest<{ success: boolean }>("/session", { method: "DELETE" }),
 };
 
+// ── Problem reports ───────────────────────────────────────────────────────────
+
+export const reportsApi = {
+  // The reporter is never sent: the backend resolves them from the session.
+  create: (request: CreateProblemReportRequest) =>
+    apiRequest<ProblemReportCreatedDTO>("/reports", {
+      method: "POST",
+      body: JSON.stringify(request),
+    }),
+};
+
 // ── Unified export ────────────────────────────────────────────────────────────
 
 export const api = {
@@ -281,6 +315,7 @@ export const api = {
   articles: articlesApi,
   dashboard: dashboardApi,
   session: sessionApi,
+  reports: reportsApi,
 };
 
 export default api;

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -20,16 +20,36 @@ const AVAILABLE_LANGUAGES: LanguageOption[] = [
   { code: "it", label: "🇮🇹", fullName: "Italiano" },
 ];
 
+// Theme is persisted under "theme" ("dark" | "light"). Absence of the key means
+// the user never chose, so we follow the OS preference and keep following it.
+const THEME_KEY = "theme";
+const DARK_CLASS = "ion-palette-dark";
+
+function prefersDarkQuery(): MediaQueryList {
+  return window.matchMedia("(prefers-color-scheme: dark)");
+}
+
+function resolveInitialDarkMode(): boolean {
+  const saved = localStorage.getItem(THEME_KEY);
+  return saved ? saved === "dark" : prefersDarkQuery().matches;
+}
+
 /**
  * Global application store for settings that persist across navigation
- * Manages: language, theme, and other app-wide preferences
+ * Manages: language, theme, auth-modal visibility and other app-wide preferences
  */
 export const useAppStore = defineStore("app", () => {
   // ========== STATE ==========
   // Same resolver the i18n instance booted with, so store and i18n agree.
   const languageCode = ref<string>(resolveInitialLocale());
 
-  const isDarkMode = ref<boolean>(localStorage.getItem("darkMode") === "true");
+  const isDarkMode = ref<boolean>(resolveInitialDarkMode());
+
+  // Auth modals live here rather than in NavBar so that anything on the page —
+  // the landing CTAs, the settings menu — can open them without prop drilling
+  // through the layout slot.
+  const isLoginModalOpen = ref<boolean>(false);
+  const isLogoutModalOpen = ref<boolean>(false);
 
   // State - no initial user data since we need to check with server
   const isAuthenticated = ref<boolean>(false);
@@ -107,16 +127,55 @@ export const useAppStore = defineStore("app", () => {
     setLanguage(AVAILABLE_LANGUAGES[nextIndex].code);
   }
 
-  function toggleDarkMode() {
-    isDarkMode.value = !isDarkMode.value;
-    localStorage.setItem("darkMode", isDarkMode.value.toString());
-    document.body.classList.toggle("dark", isDarkMode.value);
+  function applyDarkMode() {
+    document.body.classList.toggle(DARK_CLASS, isDarkMode.value);
   }
 
+  /**
+   * Set the theme and remember the choice. Once called, the OS preference is
+   * no longer followed — an explicit choice outranks it.
+   */
   function setDarkMode(value: boolean) {
     isDarkMode.value = value;
-    localStorage.setItem("darkMode", value.toString());
-    document.body.classList.toggle("dark", value);
+    localStorage.setItem(THEME_KEY, value ? "dark" : "light");
+    applyDarkMode();
+  }
+
+  function toggleDarkMode() {
+    setDarkMode(!isDarkMode.value);
+  }
+
+  /**
+   * Track the OS theme until the user picks one explicitly. Returns the
+   * listener's teardown so App.vue can drop it on unmount.
+   */
+  function followSystemTheme(): () => void {
+    const query = prefersDarkQuery();
+    const onChange = (event: MediaQueryListEvent) => {
+      if (localStorage.getItem(THEME_KEY)) {
+        return;
+      }
+      isDarkMode.value = event.matches;
+      applyDarkMode();
+    };
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }
+
+  function openLoginModal() {
+    isLoginModalOpen.value = true;
+  }
+
+  function closeLoginModal() {
+    isLoginModalOpen.value = false;
+  }
+
+  function openLogoutModal() {
+    isLogoutModalOpen.value = true;
+  }
+
+  function closeLogoutModal() {
+    isLogoutModalOpen.value = false;
   }
 
   function setUserFromData(userData: Session) {
@@ -132,9 +191,7 @@ export const useAppStore = defineStore("app", () => {
   }
 
   // Initialize on store creation
-  if (isDarkMode.value) {
-    document.body.classList.add("dark");
-  }
+  applyDarkMode();
   document.documentElement.lang = languageCode.value;
 
   // Return public API
@@ -142,6 +199,8 @@ export const useAppStore = defineStore("app", () => {
     // State
     languageCode,
     isDarkMode,
+    isLoginModalOpen,
+    isLogoutModalOpen,
     isAuthenticated,
     currentUser,
     // Getters
@@ -154,6 +213,11 @@ export const useAppStore = defineStore("app", () => {
     cycleLanguage,
     toggleDarkMode,
     setDarkMode,
+    followSystemTheme,
+    openLoginModal,
+    closeLoginModal,
+    openLogoutModal,
+    closeLogoutModal,
     setUserFromData,
     logout,
   };

--- a/frontend/src/tests/NavBar.spec.ts
+++ b/frontend/src/tests/NavBar.spec.ts
@@ -85,4 +85,38 @@ describe("NavBar.vue", () => {
     const leagueSelector = wrapper.find("#league-selector");
     expect(leagueSelector.exists()).toBe(true);
   });
+
+  // The settings menu trigger must keep its identity across auth states: only
+  // the picture inside it changes, so the menu never appears to move or vanish.
+  it("shows the settings menu trigger whether or not the user is authenticated", async () => {
+    await router.push("/");
+    await router.isReady();
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+
+    const appStore = useAppStore();
+    appStore.isAuthenticated = false;
+
+    const wrapper = mount(NavBar, {
+      global: {
+        plugins: [router, pinia, [VueQueryPlugin, { queryClient }]],
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.find("#settings-menu-trigger").exists()).toBe(true);
+
+    appStore.isAuthenticated = true;
+    appStore.currentUser = {
+      sub: "test-user",
+      name: "Test User",
+      email: "test@example.com",
+      picture: "https://example.com/avatar.png",
+    };
+    await flushPromises();
+
+    expect(wrapper.find("#settings-menu-trigger").exists()).toBe(true);
+  });
 });

--- a/frontend/src/tests/SettingsMenu.spec.ts
+++ b/frontend/src/tests/SettingsMenu.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, Pinia, setActivePinia } from "pinia";
+import SettingsMenu from "@/components/SettingsMenu.vue";
+import { useAppStore } from "@/stores/app";
+
+function mountMenu(pinia: Pinia) {
+  return mount(SettingsMenu, { global: { plugins: [pinia] } });
+}
+
+describe("SettingsMenu.vue", () => {
+  let pinia: Pinia;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    localStorage.clear();
+  });
+
+  it("opens the login modal from the auth row when signed out", async () => {
+    const appStore = useAppStore();
+    appStore.isAuthenticated = false;
+
+    const wrapper = mountMenu(pinia);
+    await wrapper.get(".auth-row").trigger("click");
+
+    expect(appStore.isLoginModalOpen).toBe(true);
+    expect(appStore.isLogoutModalOpen).toBe(false);
+    // The menu asks to be dismissed first — Ionic will not stack a modal
+    // reliably over a popover that is still open.
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+
+  it("opens the logout modal from the auth row when signed in", async () => {
+    const appStore = useAppStore();
+    appStore.isAuthenticated = true;
+
+    const wrapper = mountMenu(pinia);
+    await wrapper.get(".auth-row").trigger("click");
+
+    expect(appStore.isLogoutModalOpen).toBe(true);
+    expect(appStore.isLoginModalOpen).toBe(false);
+  });
+
+  it("shows the account row only when signed in", async () => {
+    const appStore = useAppStore();
+    appStore.isAuthenticated = false;
+    expect(mountMenu(pinia).find(".account-row").exists()).toBe(false);
+
+    appStore.isAuthenticated = true;
+    appStore.currentUser = {
+      sub: "test-user",
+      name: "Test User",
+      email: "test@example.com",
+      picture: "https://example.com/avatar.png",
+    };
+    expect(mountMenu(pinia).find(".account-row").exists()).toBe(true);
+  });
+
+  it("switches language from the sub-menu and returns to the root view", async () => {
+    const appStore = useAppStore();
+    const wrapper = mountMenu(pinia);
+
+    const rows = () => wrapper.findAll("ion-item");
+    // Root view: account row is absent (signed out), so language is first.
+    await rows()[0].trigger("click");
+
+    // Sub-menu: a back row followed by one row per available language.
+    expect(rows()).toHaveLength(1 + appStore.availableLanguages.length);
+
+    const italian = rows().find((row) => row.text().includes("Italiano"));
+    await italian!.trigger("click");
+
+    expect(appStore.languageCode).toBe("it");
+    expect(localStorage.getItem("language")).toBe("it");
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+});

--- a/frontend/src/tests/homePage/HeroSection.spec.ts
+++ b/frontend/src/tests/homePage/HeroSection.spec.ts
@@ -1,13 +1,12 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
+import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
 import router from "@/router/index";
-import CTASection from "@/components/homePage/CTASection.vue";
+import HeroSection from "@/components/homePage/HeroSection.vue";
 import { useAppStore } from "@/stores/app";
 
-// The store is resolved *after* mounting: installing a Pinia makes it the
-// active one, and the global test setup installs its own, so reading the store
-// before mount would seed a different instance than the component holds.
-describe("home-page/CTASection.vue", () => {
+// The store is resolved *after* mounting — see CTASection.spec.ts for why.
+describe("home-page/HeroSection.vue", () => {
   beforeEach(async () => {
     await router.push("/");
     await router.isReady();
@@ -16,12 +15,13 @@ describe("home-page/CTASection.vue", () => {
   afterEach(() => vi.restoreAllMocks());
 
   function mountSection() {
-    return mount(CTASection, { global: { plugins: [router] } });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+    return mount(HeroSection, {
+      global: { plugins: [router, [VueQueryPlugin, { queryClient }]] },
+    });
   }
-
-  it("should mount without any console errors or warnings", () => {
-    expect(mountSection().exists()).toBe(true);
-  });
 
   it("opens the login modal when the visitor is signed out", async () => {
     const push = vi.spyOn(router, "push");
@@ -29,7 +29,7 @@ describe("home-page/CTASection.vue", () => {
     const appStore = useAppStore();
     appStore.isAuthenticated = false;
 
-    await wrapper.get("ion-button").trigger("click");
+    await wrapper.get(".hero-cta").trigger("click");
 
     expect(appStore.isLoginModalOpen).toBe(true);
     expect(push).not.toHaveBeenCalled();
@@ -41,7 +41,7 @@ describe("home-page/CTASection.vue", () => {
     const appStore = useAppStore();
     appStore.isAuthenticated = true;
 
-    await wrapper.get("ion-button").trigger("click");
+    await wrapper.get(".hero-cta").trigger("click");
 
     expect(push).toHaveBeenCalledWith("/dashboard");
     expect(appStore.isLoginModalOpen).toBe(false);

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,9 +1,28 @@
-import { beforeAll, afterEach, afterAll } from "vitest";
+import { beforeAll, afterEach, afterAll, vi } from "vitest";
 import { config } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
 import { server } from "@/mocks/server";
 import i18n from "@/i18n";
+
+// ── jsdom gaps ────────────────────────────────────────────────────────────────
+// jsdom ships no matchMedia. The app store reads it on creation to fall back to
+// the OS theme when the user has never chosen one, so without this every test
+// that touches a store throws. Reports "light" so tests get a deterministic
+// theme regardless of the machine running them.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+});
 
 // ── MSW ───────────────────────────────────────────────────────────────────────
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));

--- a/frontend/src/tests/stores/appTheme.spec.ts
+++ b/frontend/src/tests/stores/appTheme.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useAppStore } from "@/stores/app";
+
+// Theme used to live in three places at once (App.vue, the store, and NavBar),
+// under two localStorage keys and two CSS classes, so the icon could disagree
+// with the page. These lock in the single owner: key "theme", class
+// "ion-palette-dark".
+describe("app store — theme", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.classList.remove("ion-palette-dark");
+    setActivePinia(createPinia());
+  });
+
+  it("applies the saved theme on creation", () => {
+    localStorage.setItem("theme", "dark");
+
+    const appStore = useAppStore();
+
+    expect(appStore.isDarkMode).toBe(true);
+    expect(document.body.classList.contains("ion-palette-dark")).toBe(true);
+  });
+
+  it("falls back to the OS preference when the user never chose", () => {
+    // setup.ts stubs matchMedia to report a light OS preference.
+    const appStore = useAppStore();
+
+    expect(appStore.isDarkMode).toBe(false);
+    expect(localStorage.getItem("theme")).toBeNull();
+  });
+
+  it("persists an explicit choice and toggles the palette class", () => {
+    const appStore = useAppStore();
+
+    appStore.toggleDarkMode();
+
+    expect(appStore.isDarkMode).toBe(true);
+    expect(localStorage.getItem("theme")).toBe("dark");
+    expect(document.body.classList.contains("ion-palette-dark")).toBe(true);
+
+    appStore.toggleDarkMode();
+
+    expect(appStore.isDarkMode).toBe(false);
+    expect(localStorage.getItem("theme")).toBe("light");
+    expect(document.body.classList.contains("ion-palette-dark")).toBe(false);
+  });
+});

--- a/frontend/src/tests/useProblemReport.spec.ts
+++ b/frontend/src/tests/useProblemReport.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { defineComponent } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import { http, HttpResponse } from "msw";
+import { server } from "@/mocks/server";
+import router from "@/router/index";
+import { useProblemReport } from "@/composables/useProblemReport";
+
+type Report = ReturnType<typeof useProblemReport>;
+
+/**
+ * The composable needs a component context (onUnmounted, i18n, router), so it
+ * is mounted inside a host rather than called bare. Testing it here instead of
+ * through the page keeps us off Ionic's web components, which jsdom does not
+ * render faithfully.
+ */
+function mountComposable(): Report {
+  let api!: Report;
+  const Host = defineComponent({
+    setup() {
+      api = useProblemReport();
+      return () => null;
+    },
+  });
+  mount(Host, { global: { plugins: [router] } });
+  return api;
+}
+
+function fillIn(report: Report) {
+  report.category.value = "broken";
+  report.title.value = "Market never loads";
+  report.body.value = "It spins forever after I buy a contract.";
+}
+
+describe("useProblemReport", () => {
+  beforeEach(async () => {
+    localStorage.clear();
+    await router.push("/");
+    await router.isReady();
+  });
+
+  it("will not submit until a category, a title and a body are present", () => {
+    const report = mountComposable();
+    expect(report.canSubmit.value).toBe(false);
+
+    report.category.value = "broken";
+    report.title.value = "Market never loads";
+    expect(report.canSubmit.value).toBe(false);
+
+    report.body.value = "It spins forever.";
+    expect(report.canSubmit.value).toBe(true);
+  });
+
+  it("returns the created issue so the reporter can attach a screenshot to it", async () => {
+    const report = mountComposable();
+    fillIn(report);
+
+    await report.submit();
+    await flushPromises();
+
+    expect(report.created.value).toEqual({
+      issueNumber: 1234,
+      issueUrl: "https://github.com/FantasyWiki/FantasyWiki/issues/1234",
+    });
+    expect(report.errorMessage.value).toBe("");
+    // The cooldown starts, so a double-click cannot file a second issue.
+    expect(report.cooldownRemaining.value).toBeGreaterThan(0);
+    expect(report.canSubmit.value).toBe(false);
+  });
+
+  // A backend outage must never cost the reporter their words.
+  it("offers a pre-filled GitHub link when the report cannot be filed", async () => {
+    server.use(
+      http.post("*/api/reports", () =>
+        HttpResponse.json(
+          { error: "REPORT_SUBMISSION_FAILED" },
+          { status: 502 }
+        )
+      )
+    );
+
+    const report = mountComposable();
+    fillIn(report);
+
+    await report.submit();
+    await flushPromises();
+
+    expect(report.created.value).toBeNull();
+    expect(report.errorMessage.value).not.toBe("");
+    expect(report.fallbackUrl.value).toContain(
+      "github.com/FantasyWiki/FantasyWiki/issues/new"
+    );
+    expect(report.fallbackUrl.value).toContain("Market+never+loads");
+    // What they typed is still there.
+    expect(report.title.value).toBe("Market never loads");
+  });
+
+  // Our own throttle must not hand out a bypass — that would defeat it.
+  it("shows a cooldown and no GitHub bypass when rate limited", async () => {
+    server.use(
+      http.post("*/api/reports", () =>
+        HttpResponse.json({ error: "REPORT_RATE_LIMITED" }, { status: 429 })
+      )
+    );
+
+    const report = mountComposable();
+    fillIn(report);
+
+    await report.submit();
+    await flushPromises();
+
+    expect(report.errorMessage.value).not.toBe("");
+    expect(report.fallbackUrl.value).toBe("");
+    expect(report.cooldownRemaining.value).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/views/ReportProblemPage.vue
+++ b/frontend/src/views/ReportProblemPage.vue
@@ -1,0 +1,253 @@
+<template>
+  <nav-bar>
+    <div class="report-page">
+      <h1>{{ $t("report.title") }}</h1>
+
+      <!-- Success replaces the form rather than firing a toast: the issue link
+           is the whole point. Screenshots cannot be attached through GitHub's
+           API, so we hand the reporter their issue and let GitHub's own
+           uploader do it. -->
+      <ion-card v-if="created" class="report-result">
+        <ion-card-content>
+          <ion-icon
+            :icon="checkmarkCircleOutline"
+            color="success"
+            class="result-icon"
+            aria-hidden="true"
+          />
+          <h2>{{ $t("report.success.title") }}</h2>
+          <p>
+            <i18n-t keypath="report.success.body" tag="span">
+              <template #issue>
+                <a :href="created.issueUrl" target="_blank" rel="noopener">
+                  #{{ created.issueNumber }}
+                </a>
+              </template>
+            </i18n-t>
+          </p>
+          <p class="result-hint">{{ $t("report.success.screenshotHint") }}</p>
+          <ion-button
+            fill="outline"
+            size="small"
+            :href="created.issueUrl"
+            target="_blank"
+            rel="noopener"
+          >
+            {{ $t("report.success.openIssue") }}
+            <ion-icon slot="end" :icon="openOutline" />
+          </ion-button>
+        </ion-card-content>
+      </ion-card>
+
+      <form v-else @submit.prevent="submit">
+        <p class="report-intro">{{ $t("report.intro") }}</p>
+
+        <ion-list class="report-form" lines="full">
+          <ion-item>
+            <ion-select
+              v-model="category"
+              :label="$t('report.fields.category')"
+              label-placement="stacked"
+              interface="popover"
+              :placeholder="$t('report.fields.categoryPlaceholder')"
+            >
+              <ion-select-option
+                v-for="option in categoryOptions"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </ion-select-option>
+            </ion-select>
+          </ion-item>
+
+          <ion-item>
+            <ion-input
+              v-model="title"
+              :label="$t('report.fields.titleLabel')"
+              label-placement="stacked"
+              :placeholder="$t('report.fields.titlePlaceholder')"
+              :maxlength="REPORT_TITLE_MAX_LENGTH"
+              :counter="true"
+            />
+          </ion-item>
+
+          <ion-item>
+            <ion-textarea
+              v-model="body"
+              :label="$t('report.fields.bodyLabel')"
+              label-placement="stacked"
+              :placeholder="$t('report.fields.bodyPlaceholder')"
+              :auto-grow="true"
+              :rows="6"
+            />
+          </ion-item>
+
+          <ion-item>
+            <ion-checkbox v-model="contactConsent" justify="start">
+              {{ $t("report.fields.contactConsent") }}
+            </ion-checkbox>
+          </ion-item>
+        </ion-list>
+
+        <!-- The consent box only ever covers this report. There is no
+             newsletter, and bundling marketing into a bug form is not consent
+             anyone gave knowingly. -->
+        <p class="report-note">{{ $t("report.privacyNote") }}</p>
+
+        <div v-if="errorMessage" class="report-error">
+          <ion-icon :icon="alertCircleOutline" aria-hidden="true" />
+          <div>
+            <p>{{ errorMessage }}</p>
+            <!-- If our backend could not reach GitHub, the reporter should not
+                 lose what they typed: hand them GitHub's own pre-filled form.
+                 Note such an issue lands unlabelled and under their own
+                 account, so it will not match the user-report filter. -->
+            <a
+              v-if="fallbackUrl"
+              :href="fallbackUrl"
+              target="_blank"
+              rel="noopener"
+            >
+              {{ $t("report.errors.fallbackLink") }}
+            </a>
+          </div>
+        </div>
+
+        <ion-button
+          type="submit"
+          expand="block"
+          :disabled="!canSubmit || isSubmitting"
+        >
+          <ion-spinner v-if="isSubmitting" name="crescent" />
+          <span v-else>{{ $t("report.submit") }}</span>
+        </ion-button>
+
+        <p v-if="cooldownRemaining > 0" class="report-note">
+          {{ $t("report.cooldown", { seconds: cooldownRemaining }) }}
+        </p>
+      </form>
+    </div>
+  </nav-bar>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import {
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonCheckbox,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonList,
+  IonSelect,
+  IonSelectOption,
+  IonSpinner,
+  IonTextarea,
+} from "@ionic/vue";
+import {
+  alertCircleOutline,
+  checkmarkCircleOutline,
+  openOutline,
+} from "ionicons/icons";
+import NavBar from "@/layout/NavBar.vue";
+import { useProblemReport } from "@/composables/useProblemReport";
+import {
+  REPORT_TITLE_MAX_LENGTH,
+  type ReportCategory,
+} from "../../../dto/problemReportDTO";
+
+const { t } = useI18n();
+
+const {
+  category,
+  title,
+  body,
+  contactConsent,
+  isSubmitting,
+  errorMessage,
+  fallbackUrl,
+  created,
+  cooldownRemaining,
+  canSubmit,
+  submit,
+} = useProblemReport();
+
+// The keys are written out as literals rather than interpolated from
+// REPORT_CATEGORIES: a computed key is invisible to @intlify/no-unused-keys,
+// which would then stop catching a category whose translation is genuinely
+// missing. Typing the array by ReportCategory keeps it exhaustive — adding a
+// category fails to compile until it is translated here.
+const categoryOptions = computed<{ value: ReportCategory; label: string }[]>(
+  () => [
+    { value: "broken", label: t("report.categories.broken") },
+    { value: "visual", label: t("report.categories.visual") },
+    { value: "idea", label: t("report.categories.idea") },
+    { value: "language", label: t("report.categories.language") },
+    { value: "rules", label: t("report.categories.rules") },
+    { value: "other", label: t("report.categories.other") },
+  ]
+);
+</script>
+
+<style scoped>
+.report-page {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 0 0.5rem;
+}
+
+.report-page h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.report-intro,
+.report-note {
+  color: var(--ion-color-medium);
+  font-size: 0.8rem;
+}
+
+.report-form {
+  margin: 1rem 0;
+  background: transparent;
+}
+
+.report-error {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--ion-color-danger);
+  border-radius: 8px;
+  background: rgba(var(--ion-color-danger-rgb), 0.1);
+  color: var(--ion-color-danger);
+  font-size: 0.875rem;
+}
+
+.report-error p {
+  margin: 0 0 0.25rem;
+}
+
+.report-error a {
+  color: var(--ion-color-danger);
+  font-weight: 600;
+}
+
+.report-result {
+  text-align: center;
+}
+
+.result-icon {
+  font-size: 2.5rem;
+}
+
+.result-hint {
+  color: var(--ion-color-medium);
+  font-size: 0.8rem;
+}
+</style>


### PR DESCRIPTION
Ships #439 and #437 to production.                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  ## Report a problem (#439)                                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  Signed-in players can file a problem from `/report`. The backend opens a GitHub                                                                                                                                                                                                                                                                                                                                                                               
  issue on this repository on their behalf, labelled by category, and the success                                                                                                                                                                                                                                                                                                                                                                               
  screen links it back.                                                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  **Issues are filed by a GitHub App, so they arrive as `FantasyWiki[bot]`.** A                                                                                                                                                                                                                                                                                                                                                                                 
  personal access token would author every player report under whichever maintainer                                                                                                                                                                                                                                                                                                                                                                             
  minted it, and would expire within a year — silently, since a dead token just                                                                                                                                                                                                                                                                                                                                                                                 
  turns submissions into 502s. The Worker signs an RS256 JWT with WebCrypto,                                                                                                                                                                                                                                                                                                                                                                                    
  exchanges it for a one-hour installation token, and caches that per isolate.                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  **The reporter's email is never published.** This repository is public, so an                                                                                                                                                                                                                                                                                                                                                                                 
  address in an issue body would be indexed and harvested permanently. The body                                                                                                                                                                                                                                                                                                                                                                                 
  carries the opaque `players.id` in a collapsed diagnostics block; resolving it is                                                                                                                                                                                                                                                                                                                                                                             
  `./gradlew who --player=<uuid>`, gated on the `contact-ok` label. The consent                                                                                                                                                                                                                                                                                                                                                                                 
  checkbox covers *this report only* — the "receive news" opt-in the original issue                                                                                                                                                                                                                                                                                                                                                                             
  asked for was dropped, as no newsletter exists and bundling marketing consent into                                                                                                                                                                                                                                                                                                                                                                            
  a bug form is not consent granularly given.                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  **Screenshots are not uploaded.** GitHub exposes no API for attaching an image to                                                                                                                                                                                                                                                                                                                                                                             
  an issue, so the success card links the created issue and invites the reporter to                                                                                                                                                                                                                                                                                                                                                                             
  drag it in there. R2-backed upload is a follow-up.                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  **Throttling is deliberately modest.** A Cloudflare rate-limit binding allows 3                                                                                                                                                                                                                                                                                                                                                                               
  submissions per 60s per player, plus a localStorage cooldown for double-clicks.                                                                                                                                                                                                                                                                                                                                                                               
  A daily cap isn't expressible without storage, and isn't warranted: this repo is                                                                                                                                                                                                                                                                                                                                                                              
  already publicly writable, so the form adds convenience, not a new abuse surface.                                                                                                                                                                                                                                                                                                                                                                             
  What the limit protects is the shared App credential.                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  **On failure, nothing is lost.** A 502 keeps the form populated and offers                                                                                                                                                                                                                                                                                                                                                                                    
  GitHub's pre-filled `issues/new` link. A 429 from our own limiter deliberately                                                                                                                                                                                                                                                                                                                                                                                
  does *not* offer that bypass.                                                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  ## Settings menu                                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  Theme and language were set-once preferences occupying the same visual weight as                                                                                                                                                                                                                                                                                                                                                                              
  the league selector, which is live gameplay context. They now collapse — along                                                                                                                                                                                                                                                                                                                                                                                
  with the user guide, the report link, and sign in/out — into one menu behind an                                                                                                                                                                                                                                                                                                                                                                               
  avatar-pill trigger: a popover on desktop, a bottom sheet on mobile. The trigger                                                                                                                                                                                                                                                                                                                                                                              
  exists in both auth states and only the picture inside it changes, so it never                                                                                                                                                                                                                                                                                                                                                                                
  swaps identity.                                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  On mobile this adds no chrome: the bottom nav's fourth button was already the                                                                                                                                                                                                                                                                                                                                                                                 
  avatar. It also lets the cramped mobile header drop to just the league selector.                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  ## Landing CTAs (#437)                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  `Get started` and `Create account` had no click handler at all — the navbar was                                                                                                                                                                                                                                                                                                                                                                               
  the app's only working sign-in path. Both now open the login modal when signed                                                                                                                                                                                                                                                                                                                                                                                
  out and route to `/dashboard` when signed in.                                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  Dark mode was also tracked in three places under two localStorage keys (`theme`,                                                                                                                                                                                                                                                                                                                                                                              
  `darkMode`) and two CSS classes, one of which (`dark`) no stylesheet targets — so                                                                                                                                                                                                                                                                                                                                                                             
  the toggle icon and the page could disagree after a reload. The app store now                                                                                                                                                                                                                                                                                                                                                                                 
  owns it: one key, one class, OS preference as fallback.                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  ## Production readiness                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  - Labels exist: `user-report`, `visual`, `preview`, `contact-ok`, `language`.                                                                                                                                                                                                                                                                                                                                                                                 
    (GitHub **drops unknown labels from a create-issue call and still returns 201**,                                                                                                                                                                                                                                                                                                                                                                            
    so a missing label fails silently, not loudly.)                                                                                                                                                                                                                                                                                                                                                                                                             
  - `GH_APP_ID` / `GH_APP_INSTALLATION_ID` are set for all three environments.                                                                                                                                                                                                                                                                                                                                                                                  
  - `GH_APP_PRIVATE_KEY` is an Actions secret, passed to production and preview.                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  Verified end to end on the QA environment: a submitted report produced a labelled                                                                                                                                                                                                                                                                                                                                                                             
  issue authored by `FantasyWiki[bot]`, and `./gradlew who --preview` resolved the                                                                                                                                                                                                                                                                                                                                                                              
  reporter.                                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  Production reports will land **unlabelled with `preview`** — that label is only                                                                                                                                                                                                                                                                                                                                                                               
  added outside production, which is what keeps QA noise filterable.                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  ## Docs                                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  New: `docs/architecture/problem-reports.md` — layering, label map,                                                                                                                                                                                                                                                                                                                                                                                            
  failure-status table, GitHub App setup, and reporter lookup.                                                                                                                                                                                                                                                                                                                                                                                                  
  Updated: `docs/development/local-dev-setup.md`.