### PR TITLE
fix(frontend): settle the load, explain redirects, honour the back button 

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,11 +15,12 @@
     <meta name="msapplication-tap-highlight" content="no" />
 
     <link rel="shortcut icon" type="image/png" href="/favicon.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Source+Sans+3:wght@300;400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Both brand families are self-hosted and imported from main.ts, so they
+         ship on our own origin with the rest of the bundle. Loading them from
+         the Google Fonts CDN instead cost two extra cross-origin connections
+         (googleapis for the CSS, then gstatic for the files) before any glyph
+         could paint, which is what made the landing page re-lay out top to
+         bottom once the fonts finally landed. -->
 
     <!-- add to homescreen for ios -->
     <meta name="mobile-web-app-capable" content="yes" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1853,9 +1853,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1870,9 +1870,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -1887,9 +1887,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -1904,9 +1904,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -1921,9 +1921,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1938,9 +1938,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -1955,9 +1955,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -1972,9 +1972,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -1989,9 +1989,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -2006,9 +2006,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -2023,9 +2023,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -2040,9 +2040,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -2057,9 +2057,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -2074,9 +2074,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2091,9 +2091,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2108,9 +2108,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -2125,9 +2125,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -2159,9 +2159,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -2210,9 +2210,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -2244,9 +2244,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -2261,9 +2261,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -2278,9 +2278,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -2417,9 +2417,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4731,16 +4731,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5378,9 +5378,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5496,9 +5496,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5509,32 +5509,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -6250,9 +6250,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6966,9 +6966,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -7453,9 +7453,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7943,9 +7943,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7962,7 +7962,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/haptics": "8.0.2",
         "@capacitor/keyboard": "8.0.5",
         "@capacitor/status-bar": "8.0.2",
+        "@fontsource-variable/source-sans-3": "^5.3.0",
         "@fontsource/libre-baskerville": "^5.2.10",
         "@ionic/vue": "^8.0.0",
         "@ionic/vue-router": "^8.0.0",
@@ -2561,6 +2562,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/source-sans-3": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-sans-3/-/source-sans-3-5.3.0.tgz",
+      "integrity": "sha512-dpi0GZk7EQe2tYpg6Q0Fx0OmUgnuGu+0rHPgtXqtKhglYmJuP7jZ12Mu1uN+NfRaJRY1Emn8AQJEWzmoZ4wa9g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource/libre-baskerville": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@capacitor/haptics": "8.0.2",
     "@capacitor/keyboard": "8.0.5",
     "@capacitor/status-bar": "8.0.2",
+    "@fontsource-variable/source-sans-3": "^5.3.0",
     "@fontsource/libre-baskerville": "^5.2.10",
     "@ionic/vue": "^8.0.0",
     "@ionic/vue-router": "^8.0.0",

--- a/frontend/src/components/ArticleDetail.vue
+++ b/frontend/src/components/ArticleDetail.vue
@@ -126,6 +126,7 @@ import { closeOutline } from "ionicons/icons";
 import { ArticleDTO } from "../../../dto/articleDTO";
 import { ContractDTO } from "../../../dto/contractDTO";
 import { useArticleOwnership } from "@/composables/useArticleOwnership";
+import { useBackButtonDismiss } from "@/composables/useBackButtonDismiss";
 import ArticleDescriptionBlock from "@/components/articleDetail/ArticleDescriptionBlock.vue";
 import ArticleStatsBlock from "@/components/articleDetail/ArticleStatsBlock.vue";
 import ContractDetailsBlock from "@/components/articleDetail/ContractDetailsBlock.vue";
@@ -164,6 +165,10 @@ const props = defineProps<Props>();
 const emit = defineEmits<{
   close: [];
 }>();
+
+// Owned here rather than by each host: all four drive `is-open` from local
+// state, so the back button behaves the same everywhere for free.
+useBackButtonDismiss(toRef(props, "isOpen"), () => emit("close"));
 
 const selectedTier = ref<ContractTier>("MEDIUM");
 

--- a/frontend/src/composables/useBackButtonDismiss.ts
+++ b/frontend/src/composables/useBackButtonDismiss.ts
@@ -1,0 +1,69 @@
+import { onUnmounted, watch, type Ref } from "vue";
+
+/**
+ * Makes an overlay answer the phone's back button by closing, instead of
+ * letting the page underneath it navigate away.
+ *
+ * An Ionic modal driven by `is-open` is invisible to history, so on the web —
+ * where the phone's back button is the browser's — a back press unwound the
+ * route stack while the modal stayed on screen over whatever page landed
+ * there. The fix is to give the open overlay a history entry of its own for
+ * that press to consume.
+ *
+ * The entry repeats the current URL and the router's own state object, so
+ * vue-router sees nothing on the way in (`pushState` fires no `popstate`) and
+ * resolves to the location it is already on when the entry is popped — a
+ * redundant navigation it drops. Only the listener below reacts.
+ *
+ * @param isOpen whether the overlay is currently presented
+ * @param dismiss closes the overlay; called when back is pressed
+ */
+export function useBackButtonDismiss(
+  isOpen: Ref<boolean>,
+  dismiss: () => void
+) {
+  // Whether the entry below is ours to consume. Guards the two ways this can
+  // go wrong: closing without having pushed (which would eat a real history
+  // entry) and popping twice for a single press.
+  let pushedEntry = false;
+
+  function onPopState() {
+    // Back was pressed. The browser has already dropped our entry, so there is
+    // nothing left to consume — just close.
+    pushedEntry = false;
+    window.removeEventListener("popstate", onPopState);
+    dismiss();
+  }
+
+  watch(
+    isOpen,
+    (open) => {
+      if (open) {
+        if (pushedEntry) return;
+        window.history.pushState(window.history.state, "");
+        pushedEntry = true;
+        window.addEventListener("popstate", onPopState);
+        return;
+      }
+
+      if (!pushedEntry) return;
+      // Closed from the UI — the X, a swipe down, or an action that finished.
+      // Drop the listener before stepping back so the resulting `popstate`
+      // finds no handler, then consume the entry we added: leaving it would
+      // make the next back press do nothing at all.
+      pushedEntry = false;
+      window.removeEventListener("popstate", onPopState);
+      window.history.back();
+    },
+    // Hosts typically render the overlay and open it in the same tick, so the
+    // first `true` arrives before any watcher would have run.
+    { immediate: true }
+  );
+
+  onUnmounted(() => {
+    // Unmounting while open means the page navigated out from under the
+    // overlay. History has already moved on; stepping back would undo that
+    // navigation, so the orphaned entry is left alone.
+    window.removeEventListener("popstate", onPopState);
+  });
+}

--- a/frontend/src/composables/useFontsReady.ts
+++ b/frontend/src/composables/useFontsReady.ts
@@ -1,0 +1,45 @@
+import { onMounted, onUnmounted, ref, type Ref } from "vue";
+
+/**
+ * How long a caller will wait for the fonts before giving up on them. A font
+ * that is slow — or never arrives — must not leave the page blank, so the flag
+ * flips regardless once this elapses.
+ */
+const MAX_WAIT_MS = 500;
+
+/**
+ * Flips once the web fonts have finished loading, so a caller can hold content
+ * back until the layout has stopped moving.
+ *
+ * Text first paints in the fallback family and then re-lays out the moment the
+ * real fonts land (`font-display: swap`), which on a text-heavy page reads as
+ * the whole thing reloading top to bottom. Self-hosting the fonts shortened
+ * that window but cannot close it; gating the entrance animation on this flag
+ * does, because the swap happens while the section is still invisible.
+ *
+ * `document.fonts` is absent under jsdom, where there is nothing to wait for.
+ */
+export function useFontsReady(): { isReady: Ref<boolean> } {
+  const isReady = ref(false);
+  let timer: number | undefined;
+
+  onMounted(() => {
+    if (typeof document === "undefined" || !document.fonts) {
+      isReady.value = true;
+      return;
+    }
+
+    timer = window.setTimeout(() => {
+      isReady.value = true;
+    }, MAX_WAIT_MS);
+
+    void document.fonts.ready.then(() => {
+      window.clearTimeout(timer);
+      isReady.value = true;
+    });
+  });
+
+  onUnmounted(() => window.clearTimeout(timer));
+
+  return { isReady };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -337,6 +337,7 @@
     "login": {
       "subtitle": "Sign in to manage your leagues and track your team.",
       "authFailed": "Authentication failed. Please try again.",
+      "authRequired": "That page is for signed-in players. Sign in to continue.",
       "signInGoogle": "Sign in with Google",
       "termsPrefix": "By signing in you agree to our {terms} and {privacy}.",
       "terms": "Terms of Service",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -337,6 +337,7 @@
     "login": {
       "subtitle": "Accedi per gestire le tue leghe e seguire la tua squadra.",
       "authFailed": "Autenticazione fallita. Riprova.",
+      "authRequired": "Quella pagina è riservata ai giocatori registrati. Accedi per continuare.",
       "signInGoogle": "Accedi con Google",
       "termsPrefix": "Accedendo accetti i nostri {terms} e la {privacy}.",
       "terms": "Termini di servizio",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -25,7 +25,14 @@ import "./theme/variables.css";
 import "./theme/background-and-text.css";
 import "./theme/dark-mode.css";
 
-import "@fontsource/libre-baskerville";
+// Self-hosted brand fonts, same origin as the bundle (see index.html). Source
+// Sans 3 ships as a single variable file covering the whole 200–900 range, so
+// the four static weights the UI uses cost one request; Libre Baskerville is
+// headings-only, so only the two weights headings actually render are pulled in.
+// Every subset is unicode-range gated, so an en/it visitor downloads latin only.
+import "@fontsource-variable/source-sans-3/wght.css";
+import "@fontsource/libre-baskerville/400.css";
+import "@fontsource/libre-baskerville/700.css";
 
 // ── Query client ─────────────────────────────────────────────────────────────
 const queryClient = new QueryClient({

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -96,7 +96,14 @@ const router = createRouter({
 });
 
 router.beforeEach((to) => {
-  if (!to.meta.public && !useAppStore().isAuthenticated) {
+  const appStore = useAppStore();
+  if (!to.meta.public && !appStore.isAuthenticated) {
+    // Bouncing to the landing page without a word was indistinguishable from a
+    // broken link. The login modal both explains the redirect and offers the
+    // way out of it; it is opened before the redirect rather than after
+    // because the blocked route never mounts, so the only NavBar that ends up
+    // rendering is the landing page's, already reading this flag.
+    appStore.openLoginModal("auth-required");
     return "/home";
   }
 });

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -11,6 +11,13 @@ interface LanguageOption {
   fullName: string;
 }
 
+/**
+ * Why the login modal is on screen. `auth-required` means the visitor tried to
+ * reach a page the router guard turned them away from, so the modal explains
+ * the bounce instead of leaving it looking like a broken link.
+ */
+export type LoginReason = "auth-required";
+
 // Available languages configuration. Codes are lowercase to match the i18n
 // locales, the persisted `language` key, and the <html lang> attribute. Adding
 // a locale here (plus its catalog in src/i18n/locales and SUPPORTED_LOCALES)
@@ -46,10 +53,15 @@ export const useAppStore = defineStore("app", () => {
   const isDarkMode = ref<boolean>(resolveInitialDarkMode());
 
   // Auth modals live here rather than in NavBar so that anything on the page —
-  // the landing CTAs, the settings menu — can open them without prop drilling
-  // through the layout slot.
+  // the landing CTAs, the settings menu, the router's auth guard — can open
+  // them without prop drilling through the layout slot.
   const isLoginModalOpen = ref<boolean>(false);
   const isLogoutModalOpen = ref<boolean>(false);
+
+  // Why the login modal was opened, when it wasn't the visitor's own idea.
+  // A token rather than a message: the i18n lint rules only see statically
+  // written keys, so the catalog lookup has to happen in the template.
+  const loginReason = ref<LoginReason | null>(null);
 
   // State - no initial user data since we need to check with server
   const isAuthenticated = ref<boolean>(false);
@@ -162,12 +174,14 @@ export const useAppStore = defineStore("app", () => {
     return () => query.removeEventListener("change", onChange);
   }
 
-  function openLoginModal() {
+  function openLoginModal(reason: LoginReason | null = null) {
+    loginReason.value = reason;
     isLoginModalOpen.value = true;
   }
 
   function closeLoginModal() {
     isLoginModalOpen.value = false;
+    loginReason.value = null;
   }
 
   function openLogoutModal() {
@@ -201,6 +215,7 @@ export const useAppStore = defineStore("app", () => {
     isDarkMode,
     isLoginModalOpen,
     isLogoutModalOpen,
+    loginReason,
     isAuthenticated,
     currentUser,
     // Getters

--- a/frontend/src/tests/backButtonDismissRouting.spec.ts
+++ b/frontend/src/tests/backButtonDismissRouting.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { defineComponent, h, nextTick, ref } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createRouter, createWebHistory } from "vue-router";
+import { useBackButtonDismiss } from "@/composables/useBackButtonDismiss";
+
+/**
+ * The composable's own spec asserts what it asks the browser to do. This one
+ * asserts what the browser and vue-router then actually do about it, against a
+ * real history stack: the whole point of the fix is that a back press stops at
+ * the overlay instead of unwinding the route behind it.
+ */
+const Blank = defineComponent({ render: () => h("div") });
+
+function makeRouter() {
+  return createRouter({
+    history: createWebHistory("/"),
+    routes: [
+      { path: "/dashboard", component: Blank },
+      { path: "/market", component: Blank },
+    ],
+  });
+}
+
+/** Resolves after the browser has delivered its (asynchronous) popstate. */
+function popped() {
+  return new Promise<void>((resolve) =>
+    window.addEventListener("popstate", () => resolve(), { once: true })
+  );
+}
+
+describe("useBackButtonDismiss against a real history stack", () => {
+  it("spends the back press on the overlay, not on the route", async () => {
+    const router = makeRouter();
+    await router.push("/dashboard");
+    await router.push("/market");
+
+    const isOpen = ref(false);
+    const dismiss = vi.fn(() => {
+      isOpen.value = false;
+    });
+
+    mount(
+      defineComponent({
+        setup() {
+          useBackButtonDismiss(isOpen, dismiss);
+          return () => h("div");
+        },
+      }),
+      { global: { plugins: [router] } }
+    );
+
+    isOpen.value = true;
+    await nextTick();
+
+    const settled = popped();
+    window.history.back();
+    await settled;
+    await nextTick();
+
+    expect(dismiss).toHaveBeenCalledTimes(1);
+    // The reported bug: this used to land back on /dashboard with the modal
+    // still on screen.
+    expect(router.currentRoute.value.path).toBe("/market");
+  });
+
+  it("hands the next back press to the route once the overlay is closed", async () => {
+    const router = makeRouter();
+    await router.push("/dashboard");
+    await router.push("/market");
+
+    const isOpen = ref(false);
+    mount(
+      defineComponent({
+        setup() {
+          useBackButtonDismiss(isOpen, () => {
+            isOpen.value = false;
+          });
+          return () => h("div");
+        },
+      }),
+      { global: { plugins: [router] } }
+    );
+
+    // Opened, then closed from the UI — the entry it pushed must be gone, or
+    // the press below would be swallowed by an overlay nobody can see.
+    isOpen.value = true;
+    await nextTick();
+    const consumed = popped();
+    isOpen.value = false;
+    await nextTick();
+    await consumed;
+    // vue-router resolves a popstate asynchronously; the next press has to
+    // land on a settled stack, exactly as a second thumb tap would.
+    await flushPromises();
+
+    const settled = popped();
+    window.history.back();
+    await settled;
+    await flushPromises();
+
+    expect(router.currentRoute.value.path).toBe("/dashboard");
+  });
+});

--- a/frontend/src/tests/homePage/HomePage.spec.ts
+++ b/frontend/src/tests/homePage/HomePage.spec.ts
@@ -1,8 +1,23 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
+import { nextTick, type Ref } from "vue";
 import router from "@/router/index";
 import { createPinia, Pinia } from "pinia";
 import HomePage from "@/views/HomePage.vue";
+
+// The reveal is driven by a flag this spec owns, so the assertions are about
+// what the page does with it rather than about jsdom's font loading. The ref is
+// created inside the factory because hoisted mocks run before `vue` is
+// imported.
+const fontsReady = vi.hoisted(() => ({
+  isReady: null as unknown as Ref<boolean>,
+}));
+
+vi.mock("@/composables/useFontsReady", async () => {
+  const { ref } = await import("vue");
+  fontsReady.isReady = ref(false);
+  return { useFontsReady: () => ({ isReady: fontsReady.isReady }) };
+});
 
 describe("HomePage.vue", () => {
   let pinia: Pinia;
@@ -10,11 +25,11 @@ describe("HomePage.vue", () => {
   beforeEach(() => {
     // Create a fresh Pinia instance for each test
     pinia = createPinia();
+    fontsReady.isReady.value = false;
   });
-  it("should mount without any console errors or warnings", async () => {
-    router.push("/");
-    await router.isReady();
-    const wrapper = mount(HomePage, {
+
+  function mountPage() {
+    return mount(HomePage, {
       global: {
         plugins: [router, pinia],
         stubs: {
@@ -24,7 +39,29 @@ describe("HomePage.vue", () => {
         },
       },
     });
+  }
+
+  it("should mount without any console errors or warnings", async () => {
+    router.push("/");
+    await router.isReady();
+    const wrapper = mountPage();
 
     expect(wrapper.exists()).toBe(true);
+  });
+
+  it("holds the sections back until the fonts have settled", async () => {
+    router.push("/");
+    await router.isReady();
+    const wrapper = mountPage();
+
+    // Hidden, not absent: the sections are laid out all along, so the font
+    // swap they used to visibly re-run happens behind them.
+    const reveal = wrapper.get(".home-reveal");
+    expect(reveal.classes()).not.toContain("home-reveal--visible");
+
+    fontsReady.isReady.value = true;
+    await nextTick();
+
+    expect(reveal.classes()).toContain("home-reveal--visible");
   });
 });

--- a/frontend/src/tests/routerAuthGuard.spec.ts
+++ b/frontend/src/tests/routerAuthGuard.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import router from "@/router/index";
+import { useAppStore } from "@/stores/app";
+
+describe("router auth guard", () => {
+  beforeEach(async () => {
+    // The guard resolves the store itself, outside any component, so the
+    // active Pinia has to be the one this test reads back.
+    setActivePinia(createPinia());
+    await router.replace("/home");
+    await router.isReady();
+  });
+
+  it("explains the bounce instead of redirecting in silence", async () => {
+    const appStore = useAppStore();
+    expect(appStore.isAuthenticated).toBe(false);
+
+    await router.push("/market");
+
+    expect(router.currentRoute.value.path).toBe("/home");
+    expect(appStore.isLoginModalOpen).toBe(true);
+    expect(appStore.loginReason).toBe("auth-required");
+  });
+
+  it("lets a signed-in player through untouched", async () => {
+    const appStore = useAppStore();
+    appStore.setUserFromData({
+      sub: "player-1",
+      email: "player@example.com",
+      name: "Player One",
+      picture: "",
+    });
+
+    await router.push("/market");
+
+    expect(router.currentRoute.value.path).toBe("/market");
+    expect(appStore.isLoginModalOpen).toBe(false);
+    expect(appStore.loginReason).toBeNull();
+  });
+
+  it("leaves public pages alone", async () => {
+    await router.push("/legal");
+
+    expect(router.currentRoute.value.path).toBe("/legal");
+    expect(useAppStore().isLoginModalOpen).toBe(false);
+  });
+});

--- a/frontend/src/tests/useBackButtonDismiss.spec.ts
+++ b/frontend/src/tests/useBackButtonDismiss.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { defineComponent, h, nextTick, ref, type Ref } from "vue";
+import { mount } from "@vue/test-utils";
+import { useBackButtonDismiss } from "@/composables/useBackButtonDismiss";
+
+// history.back() in jsdom unwinds a session history this test has no interest
+// in, and pops asynchronously. Spying keeps the assertions about *what the
+// composable asked the browser to do*, and lets the back press be delivered
+// explicitly with a dispatched popstate.
+let pushState: ReturnType<typeof vi.spyOn>;
+let back: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  pushState = vi.spyOn(window.history, "pushState");
+  back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+/**
+ * Stands in for a host: `dismiss` flips `isOpen` back to false, exactly as
+ * every ArticleDetail host does when it handles the `close` emit.
+ */
+function mountHost(isOpen: Ref<boolean>) {
+  const dismiss = vi.fn(() => {
+    isOpen.value = false;
+  });
+
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        useBackButtonDismiss(isOpen, dismiss);
+        return () => h("div");
+      },
+    })
+  );
+
+  return { wrapper, dismiss };
+}
+
+function pressBack() {
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+describe("useBackButtonDismiss", () => {
+  it("claims a history entry when the overlay opens", async () => {
+    const isOpen = ref(false);
+    mountHost(isOpen);
+    expect(pushState).not.toHaveBeenCalled();
+
+    isOpen.value = true;
+    await nextTick();
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+  });
+
+  it("claims one when it mounts already open", async () => {
+    // Hosts render the overlay and open it in the same tick, so the watcher
+    // has to fire immediately or the entry is never pushed at all.
+    mountHost(ref(true));
+    await nextTick();
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the overlay on a back press without stepping back again", async () => {
+    const isOpen = ref(true);
+    const { dismiss } = mountHost(isOpen);
+    await nextTick();
+
+    pressBack();
+    await nextTick();
+
+    expect(dismiss).toHaveBeenCalledTimes(1);
+    // The browser already dropped the entry — stepping back here would eat the
+    // navigation the entry was protecting.
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  it("consumes its entry when the overlay is closed from the UI", async () => {
+    const isOpen = ref(true);
+    const { dismiss } = mountHost(isOpen);
+    await nextTick();
+
+    isOpen.value = false;
+    await nextTick();
+
+    expect(back).toHaveBeenCalledTimes(1);
+    // Leaving the listener attached would turn the *next* back press into a
+    // second close of an overlay that is no longer on screen.
+    pressBack();
+    await nextTick();
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+
+  it("leaves history alone for an overlay that never opened", async () => {
+    const isOpen = ref(true);
+    mountHost(isOpen);
+    await nextTick();
+    pushState.mockClear();
+
+    isOpen.value = false;
+    await nextTick();
+    back.mockClear();
+
+    isOpen.value = false;
+    await nextTick();
+
+    expect(back).not.toHaveBeenCalled();
+    expect(pushState).not.toHaveBeenCalled();
+  });
+
+  it("does not step back when unmounted while open", async () => {
+    const isOpen = ref(true);
+    const { wrapper, dismiss } = mountHost(isOpen);
+    await nextTick();
+
+    // The page navigated out from under the overlay; history has moved on.
+    wrapper.unmount();
+    pressBack();
+
+    expect(back).not.toHaveBeenCalled();
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/useFontsReady.spec.ts
+++ b/frontend/src/tests/useFontsReady.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { defineComponent, h, nextTick, type Ref } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import { useFontsReady } from "@/composables/useFontsReady";
+
+/**
+ * Installs a FontFaceSet whose `ready` this test resolves by hand, so the wait
+ * can be held open. jsdom has no font loading of its own.
+ */
+function stubFontFaceSet(): { settle: () => void } {
+  let settle: () => void = () => {};
+  const ready = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+
+  Object.defineProperty(document, "fonts", {
+    configurable: true,
+    value: { ready },
+  });
+
+  return { settle };
+}
+
+function removeFontFaceSet() {
+  Object.defineProperty(document, "fonts", {
+    configurable: true,
+    value: undefined,
+  });
+}
+
+function mountHost(): Ref<boolean> {
+  let flag!: Ref<boolean>;
+  mount(
+    defineComponent({
+      setup() {
+        flag = useFontsReady().isReady;
+        return () => h("div");
+      },
+    })
+  );
+  return flag;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  removeFontFaceSet();
+});
+
+describe("useFontsReady", () => {
+  it("waits for the fonts, then flips", async () => {
+    const { settle } = stubFontFaceSet();
+    const isReady = mountHost();
+    await nextTick();
+
+    expect(isReady.value).toBe(false);
+
+    settle();
+    await flushPromises();
+
+    expect(isReady.value).toBe(true);
+  });
+
+  it("gives up on fonts that never arrive", async () => {
+    vi.useFakeTimers();
+    stubFontFaceSet();
+    const isReady = mountHost();
+    await nextTick();
+
+    expect(isReady.value).toBe(false);
+
+    // A slow font must not leave the page holding back its content forever.
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(isReady.value).toBe(true);
+  });
+
+  it("does not wait at all where font loading is unobservable", async () => {
+    removeFontFaceSet();
+    const isReady = mountHost();
+    await nextTick();
+
+    expect(isReady.value).toBe(true);
+  });
+});

--- a/frontend/src/theme/variables.css
+++ b/frontend/src/theme/variables.css
@@ -265,9 +265,11 @@ http://ionicframework.com/docs/theming/ */
     hsl(145 70% 22%) 100%
   );
 
+  /* The variable cut is a distinct family name, so the static "Source Sans 3"
+     stays behind it for anyone who has it installed locally. */
   --ion-font-family:
-    "Source Sans 3", -apple-system, BlinkMacSystemFont, "Helvetica Neue",
-    "Roboto", sans-serif;
+    "Source Sans 3 Variable", "Source Sans 3", -apple-system,
+    BlinkMacSystemFont, "Helvetica Neue", "Roboto", sans-serif;
 }
 
 .ion-color-wiki-gold {

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -1,10 +1,15 @@
 <template>
   <nav-bar>
-    <hero-section class="ion-margin-vertical"></hero-section>
-    <how-it-works></how-it-works>
-    <app-feature></app-feature>
-    <leaderboard-preview></leaderboard-preview>
-    <CTA-section></CTA-section>
+    <!-- Sections are revealed top to bottom once the fonts have settled, so the
+         reflow that used to run down the page in the open is now hidden behind
+         a deliberate entrance. See useFontsReady. -->
+    <div class="home-reveal" :class="{ 'home-reveal--visible': isReady }">
+      <hero-section class="ion-margin-vertical"></hero-section>
+      <how-it-works></how-it-works>
+      <app-feature></app-feature>
+      <leaderboard-preview></leaderboard-preview>
+      <CTA-section></CTA-section>
+    </div>
   </nav-bar>
 </template>
 
@@ -15,9 +20,55 @@ import HowItWorks from "@/components/homePage/HowItWorks.vue";
 import AppFeature from "@/components/homePage/AppFeature.vue";
 import LeaderboardPreview from "@/components/homePage/LeaderboardPreview.vue";
 import CTASection from "@/components/homePage/CTASection.vue";
+import { useFontsReady } from "@/composables/useFontsReady";
+
+const { isReady } = useFontsReady();
 </script>
 <style scoped>
 ion-margin-vertical {
   --ion-margin: 24px;
+}
+
+/* Every section starts hidden and slides up into place. The stagger is what
+   gives the reveal its top-to-bottom direction. */
+.home-reveal > * {
+  opacity: 0;
+  transform: translateY(1.25rem);
+}
+
+.home-reveal--visible > * {
+  opacity: 1;
+  transform: none;
+  transition:
+    opacity 0.5s ease-out,
+    transform 0.5s ease-out;
+}
+
+.home-reveal--visible > *:nth-child(2) {
+  transition-delay: 90ms;
+}
+
+.home-reveal--visible > *:nth-child(3) {
+  transition-delay: 180ms;
+}
+
+.home-reveal--visible > *:nth-child(4) {
+  transition-delay: 270ms;
+}
+
+.home-reveal--visible > *:nth-child(5) {
+  transition-delay: 360ms;
+}
+
+/* Motion is the garnish, never the gate: with it suppressed the sections are
+   simply present, and the font swap is the only thing left to notice. */
+@media (prefers-reduced-motion: reduce) {
+  .home-reveal > *,
+  .home-reveal--visible > * {
+    opacity: 1;
+    transform: none;
+    transition: none;
+    transition-delay: 0s;
+  }
 }
 </style>

--- a/frontend/src/views/auth/LoginPage.vue
+++ b/frontend/src/views/auth/LoginPage.vue
@@ -15,6 +15,17 @@
       {{ errorMessage }}
     </div>
 
+    <!-- Shown when the router bounced the visitor off a page instead of when
+         they opened this themselves, so the redirect reads as an explanation
+         rather than a dead link. -->
+    <div
+      v-else-if="appStore.loginReason === 'auth-required'"
+      class="notice-banner"
+    >
+      <ion-icon :icon="lockClosedOutline" />
+      {{ $t("auth.login.authRequired") }}
+    </div>
+
     <ion-button expand="block" class="google-btn" @click="signInWithGoogle">
       <ion-icon :icon="logoGoogle" slot="start" />
       <ion-text>{{ $t("auth.login.signInGoogle") }}</ion-text>
@@ -43,12 +54,19 @@
 import { IonButton, IonText, IonIcon, modalController } from "@ionic/vue";
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { alertCircleOutline, closeOutline, logoGoogle } from "ionicons/icons";
+import {
+  alertCircleOutline,
+  closeOutline,
+  lockClosedOutline,
+  logoGoogle,
+} from "ionicons/icons";
 import { computed } from "vue";
 import AppLogo from "@/components/AppLogo.vue";
+import { useAppStore } from "@/stores/app";
 
 const route = useRoute();
 const { t } = useI18n();
+const appStore = useAppStore();
 
 const errorMessage = computed(() =>
   route.query.error === "auth_failed" ? t("auth.login.authFailed") : null
@@ -103,6 +121,21 @@ function signInWithGoogle() {
   border: 1px solid var(--ion-color-danger);
   border-radius: 8px;
   color: var(--ion-color-danger);
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Same shape as the error banner, in the neutral brand tone — this explains a
+   detour, it does not report a failure. */
+.notice-banner {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: rgba(var(--ion-color-primary-rgb), 0.1);
+  border: 1px solid var(--ion-color-primary);
+  border-radius: 8px;
+  color: var(--ion-color-primary);
   font-size: 0.875rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Three landing-and-navigation defects that all showed up as the app doing
something the player did not ask for.

The home page appeared to reload itself top to bottom on every visit. Both
brand families were fetched from the Google Fonts CDN — two cross-origin hops
before any glyph could paint — while Libre Baskerville was also imported from
the bundle. Text painted in the fallback and re-laid out the moment the real
fonts landed. Self-host both families (Source Sans 3 as its variable cut, one
file for the four weights the UI uses) and hold the home sections until
document.fonts settles, then release them with a stagger, so the cascade that
used to happen by accident now happens on purpose and covers the swap.

A visitor sent back to the landing page from a protected route got no
indication why, which is indistinguishable from a broken link. The router
guard now opens the login modal with a reason, so the bounce is explained and
the way out of it is one tap away.

An Ionic modal driven by is-open is invisible to history, so the phone's back
button unwound the route stack while the article detail stayed on screen over
whatever page landed there. Give the open modal a history entry of its own for
that press to consume — the entry repeats the current URL and the router's own
state, so vue-router sees nothing on the way in and drops the redundant
navigation on the way out. Owned by ArticleDetail rather than its four hosts,
so they all behave the same.

Closes #60
Closes #419
Closes #436