### PR TITLE
refactor: extract the page reveal into a reusable PageReveal component

### DIFF
--- a/frontend/src/components/PageReveal.vue
+++ b/frontend/src/components/PageReveal.vue
@@ -1,0 +1,112 @@
+<template>
+  <div ref="root" class="page-reveal"><slot /></div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from "vue";
+
+/**
+ * Staggered page entrance. Hides its direct children, then releases them one
+ * after another in DOM order once the content is ready.
+ *
+ * The whole system is "hide the page, then reveal it", so its failure mode is
+ * an invisible page. Two guards keep that from happening:
+ *
+ *  - The hide is applied from JS (the `--armed` class), never from static CSS.
+ *    If setup throws, or a child is never collected, no class is added and the
+ *    page is merely un-animated — never blank.
+ *  - A `when` that never resolves still reveals after {@link SAFETY_MS}, so no
+ *    caller can hang its own content on a signal that never comes.
+ *
+ * The reveal rules live in `theme/variables.css`, not here: the children are
+ * slotted from the host page, so they carry the page's scoped-style attribute
+ * and a `<style scoped>` rule in this component would never match them.
+ */
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Turns true once the content is ready to be shown. Omit it entirely to
+     * reveal on mount — the common case, where the wrapper sits inside a
+     * `v-else` and so only mounts once the load has already resolved.
+     *
+     * The default is `true` rather than left undefined on purpose: Vue coerces
+     * an absent `Boolean` prop to `false`, which would leave every page that
+     * omits it hidden until the safety timer. Defaulting to `true` makes "omit"
+     * mean "reveal now", while an explicit `:when="false"` still gates.
+     */
+    when?: boolean;
+  }>(),
+  { when: true }
+);
+
+/** Reveal regardless once this elapses, so a stuck `when` cannot blank a page. */
+const SAFETY_MS = 2000;
+
+/**
+ * Seven elements get a distinct step (indices 0–6); every later child shares
+ * the sixth. That caps the total stagger at 6 × --reveal-stagger ≈ 540ms
+ * however many children a page has, and keeps every page's entrance identical
+ * for its first seven elements instead of scaling to fit the child count.
+ */
+const MAX_REVEAL_INDEX = 6;
+
+const root = ref<HTMLElement | null>(null);
+let revealed = false;
+let safetyTimer: number | undefined;
+let unwatch: (() => void) | undefined;
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+function reveal(): void {
+  const el = root.value;
+  if (revealed || !el) return;
+  revealed = true;
+  window.clearTimeout(safetyTimer);
+  unwatch?.();
+  el.classList.add("page-reveal--revealed");
+}
+
+onMounted(() => {
+  const el = root.value;
+  // Reduced motion skips the animation entirely: the children are simply
+  // present, never hidden and released.
+  if (!el || prefersReducedMotion()) return;
+
+  const children = Array.from(el.children) as HTMLElement[];
+  children.forEach((child, i) => {
+    child.style.setProperty(
+      "--reveal-index",
+      String(Math.min(i, MAX_REVEAL_INDEX))
+    );
+  });
+  el.classList.add("page-reveal--armed");
+
+  // Reveal anyway after the safety window, whatever `when` does.
+  safetyTimer = window.setTimeout(reveal, SAFETY_MS);
+
+  // React to `when` turning true later — the armed state has painted by then,
+  // so adding the revealed class transitions cleanly.
+  unwatch = watch(
+    () => props.when,
+    (ready) => {
+      if (ready) reveal();
+    }
+  );
+
+  // Mount default (`when` omitted, so true) or an already-true `when`: reveal
+  // now, but force the armed opacity:0 to commit first so the transition
+  // actually runs instead of the browser collapsing both changes into a frame.
+  if (props.when) {
+    void el.offsetHeight;
+    reveal();
+  }
+});
+
+onUnmounted(() => window.clearTimeout(safetyTimer));
+</script>

--- a/frontend/src/tests/PageReveal.spec.ts
+++ b/frontend/src/tests/PageReveal.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import PageReveal from "@/components/PageReveal.vue";
+
+// Six slotted children by default; a couple of tests override the count.
+function slotOf(n: number): string {
+  return Array.from({ length: n }, () => "<div class='child' />").join("");
+}
+
+function mountReveal(opts: { when?: boolean; children?: number } = {}) {
+  return mount(PageReveal, {
+    props: opts.when === undefined ? {} : { when: opts.when },
+    slots: { default: slotOf(opts.children ?? 4) },
+  });
+}
+
+/** Inline --reveal-index the component wrote on the nth direct child. */
+function indexOf(wrapper: ReturnType<typeof mountReveal>, n: number): string {
+  const child = wrapper.element.children[n] as HTMLElement;
+  return child.style.getPropertyValue("--reveal-index");
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("PageReveal.vue", () => {
+  it("arms (hides) its children on mount", () => {
+    const wrapper = mountReveal({ when: false });
+
+    // Armed is the JS-applied hidden state; the reveal is still pending.
+    expect(wrapper.classes()).toContain("page-reveal--armed");
+    expect(wrapper.classes()).not.toContain("page-reveal--revealed");
+  });
+
+  it("releases once `when` turns true", async () => {
+    const wrapper = mountReveal({ when: false });
+    expect(wrapper.classes()).not.toContain("page-reveal--revealed");
+
+    await wrapper.setProps({ when: true });
+    await nextTick();
+
+    expect(wrapper.classes()).toContain("page-reveal--revealed");
+  });
+
+  it("reveals on mount when `when` is omitted", () => {
+    const wrapper = mountReveal();
+
+    // No signal to wait for: the mount default fires straight away.
+    expect(wrapper.classes()).toContain("page-reveal--armed");
+    expect(wrapper.classes()).toContain("page-reveal--revealed");
+  });
+
+  it("assigns a DOM-order index to each child", () => {
+    const wrapper = mountReveal({ when: false, children: 4 });
+
+    expect(indexOf(wrapper, 0)).toBe("0");
+    expect(indexOf(wrapper, 1)).toBe("1");
+    expect(indexOf(wrapper, 2)).toBe("2");
+    expect(indexOf(wrapper, 3)).toBe("3");
+  });
+
+  it("clamps the index so late children share the last step", () => {
+    const wrapper = mountReveal({ when: false, children: 10 });
+
+    // Seven distinct steps (0–6); everything past the seventh child sits on 6.
+    expect(indexOf(wrapper, 6)).toBe("6");
+    expect(indexOf(wrapper, 7)).toBe("6");
+    expect(indexOf(wrapper, 9)).toBe("6");
+  });
+
+  it("does nothing under reduced motion", () => {
+    const original = window.matchMedia;
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    try {
+      const wrapper = mountReveal({ when: false });
+
+      // No hiding, so the worst case is a plainly visible page.
+      expect(wrapper.classes()).not.toContain("page-reveal--armed");
+      expect(wrapper.classes()).not.toContain("page-reveal--revealed");
+      expect(indexOf(wrapper, 0)).toBe("");
+    } finally {
+      window.matchMedia = original;
+    }
+  });
+
+  it("reveals anyway after the safety window when `when` never resolves", async () => {
+    vi.useFakeTimers();
+    const wrapper = mountReveal({ when: false });
+    expect(wrapper.classes()).not.toContain("page-reveal--revealed");
+
+    // A `when` that never turns true must not hold the page hidden forever.
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(wrapper.classes()).toContain("page-reveal--revealed");
+  });
+});

--- a/frontend/src/tests/homePage/HomePage.spec.ts
+++ b/frontend/src/tests/homePage/HomePage.spec.ts
@@ -55,13 +55,16 @@ describe("HomePage.vue", () => {
     const wrapper = mountPage();
 
     // Hidden, not absent: the sections are laid out all along, so the font
-    // swap they used to visibly re-run happens behind them.
-    const reveal = wrapper.get(".home-reveal");
-    expect(reveal.classes()).not.toContain("home-reveal--visible");
+    // swap they used to visibly re-run happens behind them. Home is the
+    // atypical PageReveal caller — it gates on the font signal, so the reveal
+    // stays armed until that flips rather than firing on mount.
+    const reveal = wrapper.get(".page-reveal");
+    expect(reveal.classes()).toContain("page-reveal--armed");
+    expect(reveal.classes()).not.toContain("page-reveal--revealed");
 
     fontsReady.isReady.value = true;
     await nextTick();
 
-    expect(reveal.classes()).toContain("home-reveal--visible");
+    expect(reveal.classes()).toContain("page-reveal--revealed");
   });
 });

--- a/frontend/src/theme/variables.css
+++ b/frontend/src/theme/variables.css
@@ -321,6 +321,39 @@ http://ionicframework.com/docs/theming/ */
   --font-family-headings: "Libre Baskerville", Georgia, serif;
 }
 
+/* ===================================
+       PAGE REVEAL
+       ================================== */
+
+/* Shared cadence for the staggered page entrance, so every page enters with
+   the same character. Tune here, not per page. The hide/reveal classes are
+   applied from JS by PageReveal.vue — a page that leaves them off stays plainly
+   visible rather than blank. */
+:root {
+  --reveal-duration: 0.5s;
+  --reveal-shift: 1.25rem;
+  --reveal-stagger: 90ms;
+}
+
+/* Armed = the JS-applied hidden state. It gates on this class (never on the
+   bare .page-reveal) so a failure to arm degrades to no animation, not a
+   permanently hidden page. */
+.page-reveal--armed > * {
+  opacity: 0;
+  transform: translateY(var(--reveal-shift));
+}
+
+/* Released: each child slides up into place, delayed by its DOM position. The
+   single calc() is what turns the inline --reveal-index into the stagger. */
+.page-reveal--armed.page-reveal--revealed > * {
+  opacity: 1;
+  transform: none;
+  transition:
+    opacity var(--reveal-duration) ease-out,
+    transform var(--reveal-duration) ease-out;
+  transition-delay: calc(var(--reveal-index, 0) * var(--reveal-stagger));
+}
+
 h1 {
   font-size: 2.25rem;
   line-height: 2.5rem;

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -2,14 +2,16 @@
   <nav-bar>
     <!-- Sections are revealed top to bottom once the fonts have settled, so the
          reflow that used to run down the page in the open is now hidden behind
-         a deliberate entrance. See useFontsReady. -->
-    <div class="home-reveal" :class="{ 'home-reveal--visible': isReady }">
+         a deliberate entrance. This is the atypical PageReveal caller: the
+         content is always present, so it gates on the font signal rather than
+         the mount default every other page uses. See useFontsReady. -->
+    <page-reveal :when="isReady">
       <hero-section class="ion-margin-vertical"></hero-section>
       <how-it-works></how-it-works>
       <app-feature></app-feature>
       <leaderboard-preview></leaderboard-preview>
       <CTA-section></CTA-section>
-    </div>
+    </page-reveal>
   </nav-bar>
 </template>
 
@@ -20,6 +22,7 @@ import HowItWorks from "@/components/homePage/HowItWorks.vue";
 import AppFeature from "@/components/homePage/AppFeature.vue";
 import LeaderboardPreview from "@/components/homePage/LeaderboardPreview.vue";
 import CTASection from "@/components/homePage/CTASection.vue";
+import PageReveal from "@/components/PageReveal.vue";
 import { useFontsReady } from "@/composables/useFontsReady";
 
 const { isReady } = useFontsReady();
@@ -27,48 +30,5 @@ const { isReady } = useFontsReady();
 <style scoped>
 ion-margin-vertical {
   --ion-margin: 24px;
-}
-
-/* Every section starts hidden and slides up into place. The stagger is what
-   gives the reveal its top-to-bottom direction. */
-.home-reveal > * {
-  opacity: 0;
-  transform: translateY(1.25rem);
-}
-
-.home-reveal--visible > * {
-  opacity: 1;
-  transform: none;
-  transition:
-    opacity 0.5s ease-out,
-    transform 0.5s ease-out;
-}
-
-.home-reveal--visible > *:nth-child(2) {
-  transition-delay: 90ms;
-}
-
-.home-reveal--visible > *:nth-child(3) {
-  transition-delay: 180ms;
-}
-
-.home-reveal--visible > *:nth-child(4) {
-  transition-delay: 270ms;
-}
-
-.home-reveal--visible > *:nth-child(5) {
-  transition-delay: 360ms;
-}
-
-/* Motion is the garnish, never the gate: with it suppressed the sections are
-   simply present, and the font swap is the only thing left to notice. */
-@media (prefers-reduced-motion: reduce) {
-  .home-reveal > *,
-  .home-reveal--visible > * {
-    opacity: 1;
-    transform: none;
-    transition: none;
-    transition-delay: 0s;
-  }
 }
 </style>

--- a/frontend/src/views/MarketPage.vue
+++ b/frontend/src/views/MarketPage.vue
@@ -38,7 +38,7 @@
       </ion-card>
 
       <!-- Main content -->
-      <template v-else>
+      <page-reveal v-else>
         <!-- Heading -->
         <div class="page-heading">
           <div class="heading-left">
@@ -368,7 +368,7 @@
             </ion-button>
           </div>
         </div>
-      </template>
+      </page-reveal>
     </div>
     <!-- /page-container -->
 
@@ -417,6 +417,7 @@ import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 
 import NavBar from "@/layout/NavBar.vue";
+import PageReveal from "@/components/PageReveal.vue";
 import ArticleDetail from "@/components/ArticleDetail.vue";
 import { useLeagueStore } from "@/stores/league";
 import {

--- a/frontend/src/views/TeamDashboard.vue
+++ b/frontend/src/views/TeamDashboard.vue
@@ -58,7 +58,7 @@
       On mobile the DOM order applies: hero, pitch, attention, leaderboard.
     -->
     <template v-else>
-      <div class="dashboard-layout">
+      <page-reveal class="dashboard-layout">
         <div class="area-hero">
           <!-- Hero contains the notification bell and all top-level actions -->
           <dashboard-hero
@@ -84,7 +84,7 @@
             :slice="LEADERBOARD_SLICE"
           />
         </div>
-      </div>
+      </page-reveal>
     </template>
   </nav-bar>
 </template>
@@ -110,6 +110,7 @@ import {
 } from "ionicons/icons";
 
 import NavBar from "@/layout/NavBar.vue";
+import PageReveal from "@/components/PageReveal.vue";
 import DashboardHero from "@/components/teamDashboard/DashboardHero.vue";
 import NeededAttention from "@/components/teamDashboard/NeededAttention.vue";
 import LeagueLeaderboard from "@/components/teamDashboard/LeagueLeaderboard.vue";

--- a/frontend/src/views/TeamPage.vue
+++ b/frontend/src/views/TeamPage.vue
@@ -35,7 +35,7 @@
     </ion-card>
 
     <!-- ── Main content ────────────────────────────────────────────────── -->
-    <template v-else>
+    <page-reveal v-else>
       <!-- Page heading -->
       <div class="page-heading">
         <div class="heading-left">
@@ -90,7 +90,7 @@
         @article-click="handleArticleClick"
         @swap="handleSwap"
       />
-    </template>
+    </page-reveal>
 
     <!-- ── Article detail modal ──────────────────────────────────────── -->
     <ArticleDetail
@@ -125,6 +125,7 @@ import {
 } from "ionicons/icons";
 
 import NavBar from "@/layout/NavBar.vue";
+import PageReveal from "@/components/PageReveal.vue";
 import FormationSelector from "@/components/formation/FormationSelector.vue";
 import TeamFormation from "@/components/formation/TeamFormation.vue";
 import BenchSection from "@/components/formation/BenchSection.vue";

--- a/frontend/templates/component.vue.hbs
+++ b/frontend/templates/component.vue.hbs
@@ -1,9 +1,14 @@
 <template>
-  <div>
-    <h1>{{ name }} component works!</h1>
-  </div>
+  <nav-bar>
+    <page-reveal>
+      <h1>{{ name }} component works!</h1>
+    </page-reveal>
+  </nav-bar>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import NavBar from "@/layout/NavBar.vue";
+import PageReveal from "@/components/PageReveal.vue";
+</script>
 
 <style scoped></style>


### PR DESCRIPTION
The staggered entrance from #60 livedasannth-childladderinHomePage's
scopedstyles,un-reusablebyeveryotherpage.Extractitinto
  <PageReveal>: it hides its direct children from JS, assigns each an inline
  --reveal-index,andreleasestheminaDOM-orderstagger,drivenbya`when`
  prop that defaults to reveal-on-mount.

Hiding is applied by JS and the reveal rules are global tokens in
  variables.css, so a failure degradesto "no animation" rather than a blank
  page, andthe slottedchildren (which carrythehostpage'sscope)are
  actuallymatched.Thestaggerisclampedatsevenelementstoboundthe
total entrance regardless of child count.

Roll it out to Home (font-gated), Dashboard, Market and Team (mount default,
  inside their v-else content branch), andupdate the Plop template to emitthe
nav-bar + page-reveal shell so newpages inheritit.