### PR TITLE
fix(scoring): inline backend URL and Wikimedia UA in nightly workflow

### DIFF
--- a/.github/workflows/scoring.yml
+++ b/.github/workflows/scoring.yml
@@ -59,9 +59,9 @@ jobs:
       fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.targets.outputs.matrix) }}
-    # Scopes the per-environment SCORING_BACKEND_URL var so each leg writes only
-    # its own D1; the matching ingest secret is picked by name below (qa reuses
-    # the preview secret, the same value the preview Worker is deployed with).
+    # Records the deployment target per leg; the backend URL and ingest secret
+    # are both selected by matrix.target in the step env below (qa reuses the
+    # preview values, the same the preview Worker is deployed with).
     environment: ${{ matrix.target }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -83,8 +83,9 @@ jobs:
             ./gradlew :scoring-collector:run
           fi
         env:
-          BACKEND_URL: ${{ vars.SCORING_BACKEND_URL }}
+          # Per-target backend Worker; both URLs are public (see deploy-strategy.md).
+          BACKEND_URL: ${{ matrix.target == 'production' && 'https://backend.luca0patrignani.workers.dev' || 'https://backend-preview.luca0patrignani.workers.dev' }}
           SCORING_INGEST_SECRET: ${{ matrix.target == 'production' && secrets.SCORING_INGEST_SECRET_PRODUCTION || secrets.SCORING_INGEST_SECRET_PREVIEW }}
           # Contact info Wikimedia requires (it 403s a request without a
-          # descriptive UA); public, so a var rather than a secret.
-          WIKIMEDIA_USER_AGENT: ${{ vars.WIKIMEDIA_USER_AGENT }}
+          # descriptive UA); public, so inlined rather than a var.
+          WIKIMEDIA_USER_AGENT: "FantasyWiki/1.0 (https://fantasywiki.pages.dev; luca0patrignani@gmail.com)"


### PR DESCRIPTION
## Problem

The nightly scoring collector aborts with *"Missing required environment variable: BACKEND_URL"*. The pipeline log shows both `BACKEND_URL` and `WIKIMEDIA_USER_AGENT` expanding to empty strings.

Root cause: `scoring.yml` read those two values from per-environment GitHub **variables** (`vars.SCORING_BACKEND_URL`, `vars.WIKIMEDIA_USER_AGENT`) that were never defined. The `production` environment has zero variables and no `qa` environment exists, so both expand empty. `Config.fromEnvAndArgs` then aborts on the missing `BACKEND_URL`. (`SCORING_INGEST_SECRET` works because it's a repo-level secret selected by name.)

## Fix

Both values are public (the backend URLs are in `deploy-strategy.md`; the UA is just contact info), so inline them in the workflow instead of routing through GitHub vars:

- `BACKEND_URL` — selected per matrix target (prod vs preview Worker) with the same conditional the ingest secret already uses.
- `WIKIMEDIA_USER_AGENT` — a literal contact string.

This leaves `SCORING_INGEST_SECRET_{PRODUCTION,PREVIEW}` as the only per-target secret and needs no GitHub settings changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)