### PR TITLE
feat(frontend): add onboarding with a guided tour of the app

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,12 +1,16 @@
 <template>
   <ion-app>
     <ion-router-outlet id="router-outlet"></ion-router-outlet>
+    <!-- The tour narrates real pages, so it lives above the outlet rather than
+         inside any one view: it has to survive the navigation it triggers. -->
+    <tour-dock />
   </ion-app>
 </template>
 
 <script setup lang="ts">
 import { onMounted, onUnmounted } from "vue";
 import { IonApp, IonRouterOutlet } from "@ionic/vue";
+import TourDock from "@/components/onboarding/TourDock.vue";
 import { useAppStore } from "@/stores/app";
 
 // The store applies the resolved theme when it is created; all we own here is

--- a/frontend/src/components/SettingsMenu.vue
+++ b/frontend/src/components/SettingsMenu.vue
@@ -58,22 +58,16 @@
         <ion-label>{{ $t("menu.reportProblem") }}</ion-label>
       </ion-item>
 
+      <!-- Signed out too: the guide is public, and someone deciding whether to
+           play is exactly who wants to read the rules first. -->
       <ion-item
         :button="true"
         :detail="false"
-        :href="USER_GUIDE_URL"
-        target="_blank"
-        rel="noopener"
-        @click="emit('close')"
+        class="user-guide-row"
+        @click="goToUserGuide"
       >
         <ion-icon :icon="bookOutline" slot="start" aria-hidden="true" />
         <ion-label>{{ $t("menu.userGuide") }}</ion-label>
-        <ion-icon
-          :icon="openOutline"
-          slot="end"
-          class="external-icon"
-          aria-hidden="true"
-        />
       </ion-item>
 
       <ion-item
@@ -145,14 +139,10 @@ import {
   logInOutline,
   logOutOutline,
   moonOutline,
-  openOutline,
   personCircleOutline,
   sunnyOutline,
 } from "ionicons/icons";
 import { useAppStore } from "@/stores/app";
-
-const USER_GUIDE_URL =
-  "https://github.com/FantasyWiki/FantasyWiki/tree/master/docs";
 
 const emit = defineEmits<{ close: [] }>();
 
@@ -162,6 +152,14 @@ const appStore = useAppStore();
 function goToReport() {
   emit("close");
   router.push("/report");
+}
+
+// Opens the written guide, not the tour. Asking for the guide should hand over
+// something you can read at your own pace; replaying the tour is a deliberate
+// second choice, offered by a button at the end of that page.
+function goToUserGuide() {
+  emit("close");
+  router.push("/guide");
 }
 
 // A nested list rather than an inline segment: adding a locale to
@@ -220,11 +218,6 @@ function onAuth() {
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.external-icon {
-  font-size: 0.875rem;
-  color: var(--ion-color-medium);
 }
 
 .auth-row {

--- a/frontend/src/components/TeamCreationForm.vue
+++ b/frontend/src/components/TeamCreationForm.vue
@@ -1,0 +1,193 @@
+<template>
+  <form class="team-form" @submit.prevent="handleSubmit">
+    <p class="form-league">
+      <span class="league-icon" aria-hidden="true">{{ league?.icon }}</span>
+      <span>
+        {{ t("views.teamCreation.joining") }}
+        <strong>{{ league?.title ?? "…" }}</strong>
+      </span>
+    </p>
+
+    <label class="form-label" for="team-name">
+      {{ t("views.teamCreation.nameLabel") }}
+    </label>
+
+    <ion-item
+      class="team-input-item"
+      lines="none"
+      :color="error ? 'danger' : ''"
+    >
+      <ion-input
+        id="team-name"
+        v-model="teamName"
+        :placeholder="t('views.teamCreation.placeholder')"
+        :maxlength="MAX_NAME"
+        autofocus
+        @ionInput="error = ''"
+      />
+    </ion-item>
+
+    <div class="input-footer">
+      <ion-text :color="error ? 'danger' : 'medium'" class="helper-text">
+        {{ error || t("views.teamCreation.helper") }}
+      </ion-text>
+      <ion-text color="medium" class="char-count">
+        {{ teamName.length }}/{{ MAX_NAME }}
+      </ion-text>
+    </div>
+
+    <ion-button
+      expand="block"
+      type="submit"
+      color="primary"
+      :disabled="isSubmitting || !teamName.trim()"
+      class="submit-button"
+    >
+      <ion-icon v-if="!isSubmitting" :icon="sparklesOutline" slot="start" />
+      {{
+        isSubmitting
+          ? t("views.teamCreation.creating")
+          : t("views.teamCreation.submit")
+      }}
+    </ion-button>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { useQuery } from "@tanstack/vue-query";
+import { IonItem, IonInput, IonButton, IonIcon, IonText } from "@ionic/vue";
+import { sparklesOutline } from "ionicons/icons";
+import { useI18n } from "vue-i18n";
+import api from "@/services/api";
+import { useToast } from "@/composables/useToast";
+import { queryKeys } from "@/composables/queryKeys";
+
+/**
+ * The team-name form only — no page chrome, no post-submit navigation. The
+ * page that hosts it decides what happens once the team exists (and, on the
+ * first run, that decision is what starts the guided tour).
+ */
+const emit = defineEmits<{ created: [name: string] }>();
+
+const MIN_NAME = 3;
+const MAX_NAME = 30;
+
+const { t } = useI18n();
+const { showSuccess } = useToast();
+
+// New players aren't part of any league yet, so the league store (which only
+// holds leagues the player already has a team in) can't be used here. The
+// Global League is the league every new player joins on team creation.
+const { data: league } = useQuery({
+  queryKey: queryKeys.globalLeague(),
+  queryFn: () => api.leagues.getGlobal(),
+});
+
+const teamName = ref("");
+const isSubmitting = ref(false);
+const error = ref("");
+
+const handleSubmit = async () => {
+  const trimmed = teamName.value.trim();
+
+  if (trimmed.length < MIN_NAME) {
+    error.value = t("views.teamCreation.tooShort", { min: MIN_NAME });
+    return;
+  }
+
+  if (trimmed.length > MAX_NAME) {
+    error.value = t("views.teamCreation.tooLong", { max: MAX_NAME });
+    return;
+  }
+
+  error.value = "";
+  isSubmitting.value = true;
+
+  try {
+    await api.leagues.createMyTeam(league.value?.id ?? "", trimmed);
+  } catch (err) {
+    isSubmitting.value = false;
+    error.value =
+      err instanceof Error ? err.message : t("views.teamCreation.failed");
+    return;
+  }
+
+  isSubmitting.value = false;
+
+  await showSuccess(
+    t("views.teamCreation.created", {
+      name: trimmed,
+      league: league.value?.title,
+    })
+  );
+
+  emit("created", trimmed);
+};
+</script>
+
+<style scoped>
+.team-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-league {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1.25rem;
+  font-size: 0.875rem;
+  color: var(--ion-color-medium);
+}
+
+.league-icon {
+  font-size: 1.25rem;
+}
+
+.form-label {
+  margin-bottom: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ion-text-color);
+}
+
+.team-input-item {
+  border: 1px solid var(--ion-border-color);
+  border-radius: 8px;
+  --padding-start: 12px;
+  --background: var(--ion-background-color);
+}
+
+.team-input-item:focus-within {
+  border-color: var(--ion-color-primary);
+  box-shadow: 0 0 0 3px rgba(var(--ion-color-primary-rgb), 0.16);
+}
+
+.team-input-item[color="danger"] {
+  border-color: var(--ion-color-danger);
+}
+
+.input-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-top: 0.4rem;
+  padding: 0 2px;
+}
+
+.helper-text,
+.char-count {
+  font-size: 0.75rem;
+}
+
+.char-count {
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.submit-button {
+  margin-top: 1.5rem;
+}
+</style>

--- a/frontend/src/components/formation/TeamFormation.vue
+++ b/frontend/src/components/formation/TeamFormation.vue
@@ -503,20 +503,20 @@ const chemistryLines = computed<RenderedChemistryLine[]>(() => {
 }
 
 .chem-line--excellent {
-  stroke: #2f8f5b;
+  stroke: var(--chem-excellent);
 }
 
 .chem-line--good {
-  stroke: #d6a71a;
+  stroke: var(--chem-good);
 }
 
 .chem-line--weak {
-  stroke: #d42a17;
+  stroke: var(--chem-weak);
 }
 
 .chem-line--empty {
   stroke-width: 2px;
-  stroke: rgba(var(--ion-color-medium-rgb), 0.75);
+  stroke: var(--chem-empty);
 }
 
 /* ── Swap mode banner ─────────────────────────────────────────────────────── */
@@ -675,19 +675,19 @@ const chemistryLines = computed<RenderedChemistryLine[]>(() => {
 }
 
 .chem-marker--excellent {
-  background: #2f8f5b;
+  background: var(--chem-excellent);
 }
 
 .chem-marker--good {
-  background: #d6a71a;
+  background: var(--chem-good);
 }
 
 .chem-marker--weak {
-  background: #d42a17;
+  background: var(--chem-weak);
 }
 
 .chem-marker--empty {
-  background: rgba(var(--ion-color-medium-rgb), 0.75);
+  background: var(--chem-empty);
 }
 
 /* ── Transitions ──────────────────────────────────────────────────────────── */

--- a/frontend/src/components/guide/ChemistryMap.vue
+++ b/frontend/src/components/guide/ChemistryMap.vue
@@ -1,0 +1,231 @@
+<template>
+  <figure class="chem">
+    <svg
+      class="chem-svg"
+      viewBox="0 0 320 132"
+      role="img"
+      :aria-label="t('guide.chemistry.alt')"
+    >
+      <!-- One arrowhead per level, since a marker does not inherit the stroke
+           of the line that references it. -->
+      <defs>
+        <marker
+          v-for="level in ['excellent', 'good']"
+          :id="`chem-arrow-${level}`"
+          :key="level"
+          viewBox="0 0 8 8"
+          refX="7"
+          refY="4"
+          markerWidth="5"
+          markerHeight="5"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L8,4 L0,8 z" :class="`chem-arrowhead--${level}`" />
+        </marker>
+      </defs>
+
+      <!-- Mutual link: both articles link to each other -->
+      <line
+        class="chem-link chem-link--excellent"
+        x1="72"
+        y1="88"
+        x2="148"
+        y2="40"
+        marker-start="url(#chem-arrow-excellent)"
+        marker-end="url(#chem-arrow-excellent)"
+      />
+      <!-- One-way link -->
+      <line
+        class="chem-link chem-link--good"
+        x1="172"
+        y1="40"
+        x2="248"
+        y2="88"
+        marker-end="url(#chem-arrow-good)"
+      />
+      <!-- Both placed, neither links to the other -->
+      <line
+        class="chem-link chem-link--weak"
+        x1="76"
+        y1="100"
+        x2="244"
+        y2="100"
+      />
+
+      <g class="chem-node">
+        <circle cx="60" cy="100" r="18" />
+        <text x="60" y="105">A</text>
+      </g>
+      <g class="chem-node">
+        <circle cx="160" cy="28" r="18" />
+        <text x="160" y="33">B</text>
+      </g>
+      <g class="chem-node">
+        <circle cx="260" cy="100" r="18" />
+        <text x="260" y="105">C</text>
+      </g>
+
+      <text class="chem-value chem-value--excellent" x="96" y="52">
+        {{ values.excellent }}
+      </text>
+      <text class="chem-value chem-value--good" x="216" y="52">
+        {{ values.good }}
+      </text>
+      <text class="chem-value chem-value--weak" x="160" y="122">
+        {{ values.weak }}
+      </text>
+    </svg>
+
+    <ul class="chem-legend">
+      <li>
+        <span class="swatch swatch--excellent" aria-hidden="true" />
+        {{ t("guide.chemistry.mutual") }}
+      </li>
+      <li>
+        <span class="swatch swatch--good" aria-hidden="true" />
+        {{ t("guide.chemistry.oneway") }}
+      </li>
+      <li>
+        <span class="swatch swatch--weak" aria-hidden="true" />
+        {{ t("guide.chemistry.none") }}
+      </li>
+    </ul>
+  </figure>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { synergyPoints } from "../../../../model/scoring";
+
+/**
+ * What a Chemistry Link pays, drawn as the topology it actually is: a value on
+ * the line between two connected spots, not a property of an article. The
+ * numbers come from the game's own synergy table.
+ */
+const { t, locale } = useI18n();
+
+const format = (points: number) =>
+  new Intl.NumberFormat(locale.value, {
+    signDisplay: points > 0 ? "always" : "never",
+    minimumFractionDigits: points > 0 ? 1 : 0,
+  }).format(points);
+
+const values = computed(() => ({
+  excellent: format(synergyPoints("excellent")),
+  good: format(synergyPoints("good")),
+  weak: format(synergyPoints("weak")),
+}));
+</script>
+
+<style scoped>
+.chem {
+  margin: 0;
+}
+
+.chem-svg {
+  display: block;
+  width: 100%;
+  max-width: 24rem;
+  height: auto;
+}
+
+/* Level is carried by colour and nothing else, exactly as the pitch draws it:
+   the same three values a player already reads on their formation. Weight is
+   uniform so the eye compares hue, not thickness. */
+.chem-link {
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  opacity: 0.85;
+  vector-effect: non-scaling-stroke;
+}
+
+.chem-link--excellent {
+  stroke: var(--chem-excellent);
+}
+
+.chem-link--good {
+  stroke: var(--chem-good);
+}
+
+.chem-link--weak {
+  stroke: var(--chem-weak);
+}
+
+.chem-arrowhead--excellent {
+  fill: var(--chem-excellent);
+}
+
+.chem-arrowhead--good {
+  fill: var(--chem-good);
+}
+
+.chem-node circle {
+  fill: var(--ion-background-color);
+  stroke: var(--ion-border-color);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.chem-node text {
+  fill: var(--ion-color-medium);
+  font-size: 13px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.chem-value {
+  font-size: 13px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.chem-value--excellent {
+  fill: var(--chem-excellent);
+}
+
+.chem-value--good {
+  fill: var(--chem-good);
+}
+
+.chem-value--weak {
+  fill: var(--chem-weak);
+}
+
+.chem-legend {
+  display: grid;
+  gap: 0.4rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--ion-color-medium);
+}
+
+.chem-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* The same rounded marker the pitch legend uses. */
+.swatch {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 4px;
+  border-radius: 999px;
+}
+
+.swatch--excellent {
+  background: var(--chem-excellent);
+}
+
+.swatch--good {
+  background: var(--chem-good);
+}
+
+.swatch--weak {
+  background: var(--chem-weak);
+}
+</style>

--- a/frontend/src/components/guide/PointsLadder.vue
+++ b/frontend/src/components/guide/PointsLadder.vue
@@ -1,0 +1,204 @@
+<template>
+  <figure class="ladder">
+    <svg
+      class="ladder-svg"
+      :viewBox="`0 0 ${W} ${H}`"
+      role="img"
+      :aria-label="t('guide.points.alt')"
+    >
+      <!-- Point gridlines -->
+      <g class="grid">
+        <template v-for="p in GRID_POINTS" :key="`g${p}`">
+          <line :x1="PAD.l" :x2="W - PAD.r" :y1="y(p)" :y2="y(p)" />
+        </template>
+      </g>
+
+      <!-- The curve itself, sampled from the real scoring rule -->
+      <polyline class="curve" :points="curve" />
+
+      <!-- Rungs a player can check against the table below -->
+      <g class="rungs">
+        <template v-for="rung in RUNGS" :key="rung.views">
+          <line
+            :x1="x(rung.views)"
+            :x2="x(rung.views)"
+            :y1="y(0)"
+            :y2="y(points(rung.views))"
+          />
+          <circle :cx="x(rung.views)" :cy="y(points(rung.views))" r="3.5" />
+        </template>
+      </g>
+    </svg>
+
+    <!-- Axis labels live in HTML, not SVG text: they stay selectable, scale
+         with the reader's font size and never distort with the viewBox. -->
+    <ol class="ladder-scale">
+      <li
+        v-for="rung in RUNGS"
+        :key="`l${rung.views}`"
+        :style="{ left: `${(x(rung.views) / W) * 100}%` }"
+      >
+        <span class="scale-views">{{ format(rung.views) }}</span>
+        <span class="scale-points">
+          {{
+            t(
+              "guide.points.worth",
+              { points: pointsLabel(rung.views) },
+              Math.round(points(rung.views))
+            )
+          }}
+        </span>
+      </li>
+    </ol>
+
+    <figcaption class="ladder-caption">{{ t("guide.points.rule") }}</figcaption>
+  </figure>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { basePoints } from "../../../../model/scoring";
+
+/**
+ * The scoring curve, drawn by calling the game's own `basePoints` rather than
+ * traced by hand, so the picture cannot drift from what the backend scores.
+ *
+ * Readers run on a **plain linear axis**, deliberately: a log axis would
+ * straighten the doubling stretch and bend the flat-rate tail upwards, showing
+ * the reader the exact opposite of the shape the rule describes. On this axis
+ * the picture says what the caption says — steep early returns that flatten
+ * out, then a straight climb once the tail takes over at 150,000.
+ */
+const { t, locale } = useI18n();
+
+const W = 320;
+const H = 150;
+const PAD = { l: 8, r: 8, t: 10, b: 8 };
+
+/** Where the curve crosses zero; also the left edge of the drawing. */
+const MIN_VIEWS = 2_000;
+const MAX_VIEWS = 250_000;
+const MAX_POINTS = 9;
+
+/** Point levels the gridlines sit on. */
+const GRID_POINTS = [0, 3, 6, 9] as const;
+
+/**
+ * The anchor of the doubling stretch and the point where the tail takes over.
+ * Both sit far enough from the edges for their labels to stay inside the frame.
+ */
+const RUNGS = [{ views: 32_000 }, { views: 150_000 }] as const;
+
+const points = basePoints;
+
+function x(views: number): number {
+  const ratio = (views - MIN_VIEWS) / (MAX_VIEWS - MIN_VIEWS);
+  return PAD.l + ratio * (W - PAD.l - PAD.r);
+}
+
+function y(pts: number): number {
+  const ratio = pts / MAX_POINTS;
+  return H - PAD.b - ratio * (H - PAD.t - PAD.b);
+}
+
+const curve = computed(() => {
+  // Sampled geometrically but drawn linearly: that puts the most samples where
+  // the curve actually bends, and the straight tail needs barely any.
+  const samples = 120;
+  return Array.from({ length: samples + 1 }, (_, i) => {
+    const views = MIN_VIEWS * Math.pow(MAX_VIEWS / MIN_VIEWS, i / samples);
+    return `${x(views).toFixed(1)},${y(points(views)).toFixed(1)}`;
+  }).join(" ");
+});
+
+const format = (views: number) =>
+  new Intl.NumberFormat(locale.value, {
+    notation: "compact",
+    maximumFractionDigits: 0,
+  }).format(views);
+
+const pointsLabel = (views: number) =>
+  new Intl.NumberFormat(locale.value, {
+    maximumFractionDigits: 1,
+  }).format(Math.round(points(views) * 10) / 10);
+</script>
+
+<style scoped>
+.ladder {
+  margin: 0;
+}
+
+.ladder-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.grid line {
+  stroke: var(--ion-border-color);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.curve {
+  fill: none;
+  stroke: var(--ion-color-primary);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.rungs line {
+  stroke: var(--ion-color-primary);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+  opacity: 0.55;
+  vector-effect: non-scaling-stroke;
+}
+
+.rungs circle {
+  fill: var(--ion-color-primary);
+}
+
+/* Each label sits under the rung it belongs to, positioned with the same
+   scale function the curve uses, so the two can never drift apart. */
+.ladder-scale {
+  position: relative;
+  height: 2.5rem;
+  margin: 0.35rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ladder-scale li {
+  position: absolute;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+  min-width: 4.25rem;
+  text-align: center;
+  transform: translateX(-50%);
+}
+
+.scale-views {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--ion-text-color);
+}
+
+.scale-points {
+  font-size: 0.75rem;
+  color: var(--ion-color-medium);
+}
+
+.ladder-caption {
+  margin-top: 0.9rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--ion-color-medium);
+}
+</style>

--- a/frontend/src/components/guide/SpikeVsSteady.vue
+++ b/frontend/src/components/guide/SpikeVsSteady.vue
@@ -1,0 +1,199 @@
+<template>
+  <div class="contrast">
+    <article v-for="c in cases" :key="c.id" class="case">
+      <h3 class="case-title">{{ c.title }}</h3>
+
+      <svg
+        class="case-chart"
+        :viewBox="`0 0 ${W} ${H}`"
+        role="img"
+        :aria-label="c.alt"
+      >
+        <polyline class="case-line" :points="c.line" />
+        <line class="case-base" :x1="0" :x2="W" :y1="H - 1" :y2="H - 1" />
+      </svg>
+      <p class="case-axis">{{ t("guide.contrast.axis") }}</p>
+
+      <dl class="case-readout">
+        <div>
+          <dt>{{ t("guide.contrast.pointsToday") }}</dt>
+          <dd class="readout-points">{{ c.points }}</dd>
+        </div>
+        <div>
+          <dt>{{ t("guide.contrast.pricedOn") }}</dt>
+          <dd>{{ t("guide.contrast.readersPerDay", { views: c.priceOn }) }}</dd>
+        </div>
+      </dl>
+
+      <p class="case-note">{{ c.note }}</p>
+    </article>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { basePoints } from "../../../../model/scoring";
+
+/**
+ * The one thing a player has to internalise: points are paid on *today's*
+ * readers, prices are set by the *last 30 days*. Two articles, same month, very
+ * different bills.
+ *
+ * Both series are drawn on the same vertical scale, and every number under them
+ * is computed from the series by the game's own scoring curve, so the
+ * comparison is not a flattering illustration.
+ */
+const { t, locale } = useI18n();
+
+const W = 240;
+const H = 64;
+
+/** A quiet article that broke out today. Views in thousands, 30 days. */
+const SPIKE_DAYS = [
+  3, 2.8, 3.2, 3, 2.6, 3.4, 3.1, 2.9, 3, 3.3, 2.7, 3, 3.2, 2.8, 3.1, 3, 2.9,
+  3.4, 3, 2.6, 3.2, 3, 3.1, 2.8, 3, 3.3, 2.9, 3.1, 3, 200,
+].map((k) => k * 1_000);
+
+/** A page that is read heavily every single day. */
+const STEADY_DAYS = [
+  58, 61, 59, 63, 60, 57, 62, 60, 59, 64, 61, 58, 60, 62, 59, 61, 60, 63, 58,
+  60, 62, 59, 61, 60, 58, 63, 60, 59, 62, 60,
+].map((k) => k * 1_000);
+
+const PEAK = Math.max(...SPIKE_DAYS, ...STEADY_DAYS);
+
+function line(series: number[]): string {
+  const step = W / (series.length - 1);
+  return series
+    .map((views, i) => {
+      const y = H - 2 - (views / PEAK) * (H - 6);
+      return `${(i * step).toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+const average = (series: number[]) =>
+  series.reduce((sum, v) => sum + v, 0) / series.length;
+
+const compact = (views: number) =>
+  new Intl.NumberFormat(locale.value, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(views);
+
+const pointsLabel = (views: number) =>
+  new Intl.NumberFormat(locale.value, { maximumFractionDigits: 1 }).format(
+    Math.round(basePoints(views) * 10) / 10
+  );
+
+const cases = computed(() => [
+  {
+    id: "spike",
+    title: t("guide.contrast.spike.title"),
+    alt: t("guide.contrast.spike.alt"),
+    line: line(SPIKE_DAYS),
+    points: pointsLabel(SPIKE_DAYS[SPIKE_DAYS.length - 1]),
+    priceOn: compact(average(SPIKE_DAYS)),
+    note: t("guide.contrast.spike.note"),
+  },
+  {
+    id: "steady",
+    title: t("guide.contrast.steady.title"),
+    alt: t("guide.contrast.steady.alt"),
+    line: line(STEADY_DAYS),
+    points: pointsLabel(STEADY_DAYS[STEADY_DAYS.length - 1]),
+    priceOn: compact(average(STEADY_DAYS)),
+    note: t("guide.contrast.steady.note"),
+  },
+]);
+</script>
+
+<style scoped>
+.contrast {
+  display: grid;
+  gap: 1.75rem;
+}
+
+@media (min-width: 640px) {
+  .contrast {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2.5rem;
+  }
+}
+
+.case-title {
+  margin: 0 0 0.6rem;
+  font-family: var(--ion-font-family);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--ion-text-color);
+}
+
+.case-chart {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.case-line {
+  fill: none;
+  stroke: var(--ion-color-primary);
+  stroke-width: 1.5;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.case-base {
+  stroke: var(--ion-border-color);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.case-axis {
+  margin: 0.3rem 0 0.9rem;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ion-color-medium);
+}
+
+.case-readout {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.case-readout > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--ion-border-color);
+}
+
+.case-readout dt {
+  font-size: 0.8125rem;
+  color: var(--ion-color-medium);
+}
+
+.case-readout dd {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--ion-text-color);
+}
+
+.readout-points {
+  color: var(--ion-color-primary);
+}
+
+.case-note {
+  margin: 0.75rem 0 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--ion-color-medium);
+}
+</style>

--- a/frontend/src/components/onboarding/DayLoop.vue
+++ b/frontend/src/components/onboarding/DayLoop.vue
@@ -1,0 +1,144 @@
+<template>
+  <figure class="day-loop">
+    <figcaption class="loop-caption">
+      {{ t("onboarding.loop.caption") }}
+    </figcaption>
+
+    <ol class="loop-track">
+      <li class="loop-beat">
+        <span class="beat-glyph" aria-hidden="true">
+          <ion-icon :icon="documentTextOutline" />
+        </span>
+        <span class="beat-value">{{ t("onboarding.loop.holdValue") }}</span>
+        <span class="beat-label">{{ t("onboarding.loop.hold") }}</span>
+      </li>
+
+      <li class="loop-beat">
+        <span class="beat-glyph" aria-hidden="true">
+          <ion-icon :icon="eyeOutline" />
+        </span>
+        <span class="beat-value">{{ readers }}</span>
+        <span class="beat-label">{{ t("onboarding.loop.read") }}</span>
+      </li>
+
+      <li class="loop-beat loop-beat--score">
+        <span class="beat-glyph" aria-hidden="true">
+          <ion-icon :icon="starOutline" />
+        </span>
+        <span class="beat-value">
+          {{ t("onboarding.loop.scoreValue", { points: scored }) }}
+        </span>
+        <span class="beat-label">{{ t("onboarding.loop.score") }}</span>
+      </li>
+    </ol>
+  </figure>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { IonIcon } from "@ionic/vue";
+import { documentTextOutline, eyeOutline, starOutline } from "ionicons/icons";
+import { basePoints } from "../../../../model/scoring";
+
+/**
+ * The core loop in one line of pictures: an article you hold, the people who
+ * read it today, the points that lands you.
+ *
+ * The example is scored by the game's own curve rather than written into the
+ * copy, so it agrees with the ladder on the guide page by construction.
+ */
+const EXAMPLE_READERS = 32_000;
+
+const { t, locale } = useI18n();
+
+const readers = computed(() =>
+  new Intl.NumberFormat(locale.value).format(EXAMPLE_READERS)
+);
+
+const scored = computed(() =>
+  new Intl.NumberFormat(locale.value, { maximumFractionDigits: 1 }).format(
+    Math.round(basePoints(EXAMPLE_READERS) * 10) / 10
+  )
+);
+</script>
+
+<style scoped>
+.day-loop {
+  margin: 0;
+}
+
+.loop-caption {
+  margin-bottom: 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ion-color-medium);
+}
+
+/* The rule runs behind the beats and is what makes this read as one flow
+   rather than three tiles. */
+.loop-track {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.loop-track::before {
+  content: "";
+  position: absolute;
+  top: 1.125rem;
+  left: 16%;
+  right: 16%;
+  border-top: 1px dashed var(--ion-border-color);
+}
+
+.loop-beat {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.3rem;
+}
+
+.beat-glyph {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: var(--ion-background-color);
+  border: 1px solid var(--ion-border-color);
+  color: var(--ion-color-medium);
+  font-size: 1.125rem;
+}
+
+.loop-beat--score .beat-glyph {
+  border-color: var(--ion-color-primary);
+  color: var(--ion-color-primary);
+}
+
+.beat-value {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--ion-text-color);
+  font-variant-numeric: tabular-nums;
+}
+
+.loop-beat--score .beat-value {
+  color: var(--ion-color-primary);
+}
+
+.beat-label {
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--ion-color-medium);
+}
+</style>

--- a/frontend/src/components/onboarding/TourDock.vue
+++ b/frontend/src/components/onboarding/TourDock.vue
@@ -1,0 +1,441 @@
+<template>
+  <transition name="dock">
+    <aside
+      v-if="onboarding.isActive"
+      class="tour-dock"
+      role="region"
+      :aria-label="t('onboarding.tour.label')"
+    >
+      <div class="dock-rail" aria-hidden="true">
+        <span class="dock-rail__fill" :style="{ width: railWidth }" />
+      </div>
+
+      <!-- Announced politely: the step changes under a screen reader that is
+           reading the page behind it, not a dialog it was moved into. -->
+      <div class="dock-body" aria-live="polite">
+        <p class="dock-count">
+          {{
+            t("onboarding.tour.progress", {
+              current: onboarding.stepIndex + 1,
+              total: onboarding.totalSteps,
+            })
+          }}
+        </p>
+        <h2 class="dock-title">{{ copy.title }}</h2>
+        <p class="dock-text">{{ copy.body }}</p>
+        <!-- Leaving for the written guide ends the tour: a dock still
+             narrating the dashboard on top of a page the player deliberately
+             navigated away to is just clutter. -->
+        <router-link
+          v-if="onboarding.isLastStep"
+          to="/guide"
+          class="dock-link"
+          @click="onboarding.end()"
+        >
+          {{ t("onboarding.tour.guideLink") }}
+        </router-link>
+      </div>
+
+      <div class="dock-actions">
+        <ion-button
+          v-if="!onboarding.isLastStep"
+          fill="clear"
+          size="small"
+          class="dock-skip"
+          @click="onboarding.end()"
+        >
+          {{ t("onboarding.tour.skip") }}
+        </ion-button>
+        <span class="dock-spacer" />
+        <ion-button
+          v-if="!onboarding.isFirstStep"
+          fill="clear"
+          size="small"
+          @click="onboarding.back()"
+        >
+          {{ t("onboarding.tour.back") }}
+        </ion-button>
+        <ion-button
+          color="primary"
+          fill="solid"
+          size="small"
+          class="dock-next"
+          @click="onboarding.next()"
+        >
+          {{ onboarding.isLastStep ? t("onboarding.tour.done") : nextLabel }}
+        </ion-button>
+      </div>
+    </aside>
+  </transition>
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { IonButton } from "@ionic/vue";
+import { useOnboardingStore, type TourStepId } from "@/stores/onboarding";
+
+/**
+ * Narrates the tour from a dock pinned above the navigation, while the player
+ * looks at the real page behind it.
+ *
+ * Two rules keep it from becoming the slideshow it replaced:
+ *  - it never covers the app and never blocks input, so the player can ignore
+ *    it, scroll, switch language or click the very button it is describing;
+ *  - it owns no content of its own beyond one line per step. The screen behind
+ *    it is the explanation.
+ *
+ * The ring it draws on the described element is a *best effort* side effect: a
+ * step whose target is still loading (or absent, on a page that failed to
+ * fetch) narrates anyway rather than stalling the tour.
+ */
+const RING_CLASS = "tour-ring";
+/**
+ * Retry budget for a target that has not rendered yet (~5s total). The
+ * dashboard ledger and the market listing only exist once their fetch
+ * resolves, and the market's comes from Wikimedia, which on a cold first load
+ * is the slowest thing here (~8s of patience).
+ */
+const RING_RETRY_MS = 200;
+const RING_MAX_TRIES = 40;
+/**
+ * Ionic animates a page in over roughly 300ms, and scrolling a page that is
+ * still sliding either gets lost or lands on the wrong offset. Wait for it to
+ * settle, then move.
+ */
+const SCROLL_SETTLE_MS = 360;
+/** Length of the scroll itself: long enough to be followed by eye. */
+const SCROLL_MS = 320;
+
+const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
+const onboarding = useOnboardingStore();
+
+// Copy is resolved through a computed rather than baked into the step list, so
+// switching language mid-tour (the settings menu is reachable throughout)
+// re-renders the dock instead of freezing it in the locale it started in.
+const copyByStep = computed<
+  Record<TourStepId, { title: string; body: string }>
+>(() => ({
+  stats: {
+    title: t("onboarding.tour.stats.title"),
+    body: t("onboarding.tour.stats.body"),
+  },
+  league: {
+    title: t("onboarding.tour.league.title"),
+    body: t("onboarding.tour.league.body"),
+  },
+  market: {
+    title: t("onboarding.tour.market.title"),
+    body: t("onboarding.tour.market.body"),
+  },
+  manageTeam: {
+    title: t("onboarding.tour.manageTeam.title"),
+    body: t("onboarding.tour.manageTeam.body"),
+  },
+  formation: {
+    title: t("onboarding.tour.formation.title"),
+    body: t("onboarding.tour.formation.body"),
+  },
+  wrap: {
+    title: t("onboarding.tour.wrap.title"),
+    body: t("onboarding.tour.wrap.body"),
+  },
+}));
+
+const copy = computed(() => {
+  const step = onboarding.currentStep;
+  return step ? copyByStep.value[step.id] : { title: "", body: "" };
+});
+
+// "Next" reads as "take me there" when the step is on another page, so the
+// button says what the click will actually do.
+const nextLabel = computed(() => {
+  const step = onboarding.currentStep;
+  return step && step.route !== route.path
+    ? t("onboarding.tour.take")
+    : t("onboarding.tour.next");
+});
+
+const railWidth = computed(
+  () => `${((onboarding.stepIndex + 1) / onboarding.totalSteps) * 100}%`
+);
+
+// ── Ring ────────────────────────────────────────────────────────────────────
+
+let ringEls: HTMLElement[] = [];
+let retryTimer: ReturnType<typeof setTimeout> | undefined;
+let scrollTimer: ReturnType<typeof setTimeout> | undefined;
+let hasScrolled = false;
+
+function clearRings() {
+  clearTimeout(retryTimer);
+  clearTimeout(scrollTimer);
+  retryTimer = undefined;
+  scrollTimer = undefined;
+  ringEls.forEach((el) => el.classList.remove(RING_CLASS));
+  ringEls = [];
+  hasScrolled = false;
+}
+
+/**
+ * Puts the ringed element on screen. A highlight below the fold is not a
+ * highlight: the Manage team button sits under the dashboard hero on a phone,
+ * so the step that points at it has to bring it up.
+ *
+ * An Ionic page scrolls inside its own `ion-content`, not the window, so
+ * `scrollIntoView` alone is unreliable here. Ask the content element to do it
+ * when there is one, and keep the plain DOM call as the fallback for anything
+ * rendered outside a page (and for jsdom, which has neither).
+ */
+async function bringIntoView(el: HTMLElement): Promise<void> {
+  const content = el.closest("ion-content") as HTMLIonContentElement | null;
+
+  if (typeof content?.getScrollElement === "function") {
+    const scroller = await content.getScrollElement();
+    const offset =
+      el.getBoundingClientRect().top -
+      scroller.getBoundingClientRect().top +
+      scroller.scrollTop;
+    // Centre it, so the dock pinned to the bottom never sits on top of it.
+    const centred = offset - (scroller.clientHeight - el.clientHeight) / 2;
+    await content.scrollToPoint(0, Math.max(0, centred), SCROLL_MS);
+    return;
+  }
+
+  el.scrollIntoView?.({ block: "center", behavior: "smooth" });
+}
+
+function resolveTarget(
+  selector: string,
+  scope: ParentNode = document
+): HTMLElement | null {
+  const matches = Array.from(
+    scope.querySelectorAll<HTMLElement>(selector)
+  ).filter((el) => el.isConnected && !el.closest(".ion-page-hidden"));
+  if (!matches.length) return null;
+  // One selector can match several elements: Ionic keeps visited pages mounted
+  // in the router outlet, and a couple of anchors (the market listing, the
+  // navigation links) exist once for mobile and once for desktop. Prefer one
+  // that is actually laid out, then the last in document order, which is the
+  // most recently entered page.
+  return (
+    matches.find((el) => el.offsetParent !== null) ??
+    matches[matches.length - 1]
+  );
+}
+
+/** The Ionic page an element belongs to, so siblings can be found within it. */
+function pageOf(el: HTMLElement): ParentNode {
+  return el.closest(".ion-page") ?? document;
+}
+
+/**
+ * Rings the targets of a step, on the page the step is about.
+ *
+ * The first selector is the subject and drives everything: nothing is ringed
+ * until it resolves, and the remaining selectors (the navigation button that
+ * reaches this page) are then looked up **inside the subject's own Ionic
+ * page**. That scoping is load-bearing. Ionic keeps the page you came from
+ * mounted, so a document-wide lookup for the navigation button finds the
+ * *previous* page's copy, rings it, and the ring vanishes with that page a
+ * moment later, leaving the entered page with nothing lit up.
+ */
+function applyRings(
+  selectors: readonly string[],
+  triesLeft = RING_MAX_TRIES
+): void {
+  const [subject, ...companions] = selectors;
+
+  const subjectEl = resolveTarget(subject);
+  if (!subjectEl) {
+    // The page is still arriving or still fetching. Keep looking for a bounded
+    // while, then give up quietly: the dock has already said its line.
+    if (triesLeft > 0) {
+      retryTimer = setTimeout(
+        () => applyRings(selectors, triesLeft - 1),
+        RING_RETRY_MS
+      );
+    }
+    return;
+  }
+
+  ring(subjectEl);
+  if (!hasScrolled) {
+    hasScrolled = true;
+    scrollTimer = setTimeout(
+      () => void bringIntoView(subjectEl),
+      SCROLL_SETTLE_MS
+    );
+  }
+
+  const page = pageOf(subjectEl);
+  for (const selector of companions) {
+    const el = resolveTarget(selector, page);
+    if (el) ring(el);
+  }
+}
+
+function ring(el: HTMLElement): void {
+  if (el.classList.contains(RING_CLASS)) return;
+  el.classList.add(RING_CLASS);
+  ringEls.push(el);
+}
+
+// ── Step driving ────────────────────────────────────────────────────────────
+
+// Driven by the step *and* the route, because a step is only ringable once the
+// app is actually on its page. Navigating and ringing in the same tick lit up
+// the outgoing page; now the navigation happens, this watcher fires again on
+// arrival, and only then does anything get ringed. It also means a player who
+// wanders off mid-step gets the ring back when they return.
+watch(
+  [() => onboarding.currentStep, () => route.path],
+  ([step, path]) => {
+    clearRings();
+    if (!step) return;
+    if (step.route !== path) {
+      void router.push(step.route);
+      return;
+    }
+    if (step.targets?.length) applyRings(step.targets);
+  },
+  { immediate: true }
+);
+
+// Replay entry point. `?tour=1` on the dashboard is what the settings menu and
+// the public guide link to: it is a normal auth-gated route, so an anonymous
+// visitor following it from the guide gets the login modal rather than a
+// broken tour. The flag is stripped once consumed so a later reload is clean.
+watch(
+  () => route.query.tour,
+  (flag) => {
+    if (flag !== "1") return;
+    onboarding.start();
+    const query = { ...route.query };
+    delete query.tour;
+    void router.replace({ path: route.path, query });
+  },
+  { immediate: true }
+);
+
+onUnmounted(clearRings);
+</script>
+
+<style scoped>
+.tour-dock {
+  position: fixed;
+  z-index: 999;
+  left: 50%;
+  transform: translateX(-50%);
+  /* Clears the mobile navigation footer, which is where the thumb is. */
+  bottom: calc(4.5rem + env(safe-area-inset-bottom));
+  width: min(31rem, calc(100vw - 1.5rem));
+  overflow: hidden;
+  border: 1px solid var(--ion-border-color);
+  border-radius: 12px;
+  background: var(--ion-background-color);
+  /* The themed shadow token, so the dock does not glow white in dark mode. */
+  box-shadow: 0 6px 28px var(--ion-box-shadow-color);
+}
+
+@media (min-width: 768px) {
+  .tour-dock {
+    bottom: 1.5rem;
+  }
+}
+
+.dock-rail {
+  height: 2px;
+  background: var(--ion-background-color-step-100);
+}
+
+.dock-rail__fill {
+  display: block;
+  height: 100%;
+  background: var(--ion-color-primary);
+  transition: width 220ms ease-out;
+}
+
+.dock-body {
+  padding: 0.875rem 1rem 0.25rem;
+}
+
+.dock-count {
+  margin: 0 0 0.35rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ion-color-medium);
+}
+
+.dock-title {
+  margin: 0 0 0.25rem;
+  font-family: var(--ion-font-family);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--ion-text-color);
+}
+
+.dock-text {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--ion-color-medium);
+}
+
+.dock-link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--ion-color-primary);
+  text-decoration: none;
+}
+
+.dock-link:hover {
+  text-decoration: underline;
+}
+
+.dock-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.65rem 0.6rem;
+}
+
+.dock-spacer {
+  flex: 1;
+}
+
+.dock-next {
+  --padding-start: 14px;
+  --padding-end: 14px;
+}
+
+/* Enter and leave: 200ms, transform and opacity only. */
+.dock-enter-active,
+.dock-leave-active {
+  transition:
+    opacity 200ms ease-out,
+    transform 200ms ease-out;
+}
+
+.dock-enter-from,
+.dock-leave-to {
+  opacity: 0;
+  transform: translate(-50%, 0.75rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dock-enter-active,
+  .dock-leave-active,
+  .dock-rail__fill {
+    transition: none;
+  }
+}
+</style>

--- a/frontend/src/components/teamDashboard/DashboardHero.vue
+++ b/frontend/src/components/teamDashboard/DashboardHero.vue
@@ -60,7 +60,8 @@
       </div>
 
       <!-- ── Stat ledger: label left, value right ───── -->
-      <div class="stat-list" v-if="data">
+      <!-- data-tour: the onboarding tour's first step rings this ledger. -->
+      <div class="stat-list" data-tour="stats" v-if="data">
         <div v-for="stat in allStats" :key="stat.label" class="stat-row">
           <div class="stat-row__meta">
             <div

--- a/frontend/src/components/teamDashboard/TeamManagement.vue
+++ b/frontend/src/components/teamDashboard/TeamManagement.vue
@@ -16,7 +16,10 @@
           </div>
         </div>
 
+        <!-- data-tour: the onboarding tour points here before it opens the
+             pitch, so the player learns the door as well as the room. -->
         <ion-button
+          data-tour="manage-team"
           fill="outline"
           size="small"
           color="primary"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -114,7 +114,7 @@
       },
       "portfolio": {
         "title": "Build Your Portfolio",
-        "description": "Buy articles with your 1,000 starting credits. Choose contract durations from 3 to 90 days."
+        "description": "Buy articles with your 1,000 starting credits. Choose contracts of 3, 7 or 14 days."
       },
       "points": {
         "title": "Earn Points Daily",
@@ -357,7 +357,16 @@
   },
   "views": {
     "teamCreation": {
-      "created": "Team Created! 🎉 \"{name}\" is ready to compete in {league}."
+      "created": "Team Created! 🎉 \"{name}\" is ready to compete in {league}.",
+      "joining": "You are joining",
+      "nameLabel": "Team name",
+      "placeholder": "e.g. The Wiki Wizards",
+      "helper": "Must be unique within the league",
+      "submit": "Create team and start playing",
+      "creating": "Creating…",
+      "tooShort": "Team names need at least {min} characters.",
+      "tooLong": "Team names are at most {max} characters.",
+      "failed": "Could not create the team. Try again."
     },
     "teamDashboard": {
       "loading": "Loading dashboard…",
@@ -411,5 +420,121 @@
     "renewError": "Couldn't renew this contract",
     "cancelRenewalSuccess": "Renewal cancelled",
     "cancelRenewalError": "Couldn't cancel this renewal"
+  },
+  "onboarding": {
+    "start": {
+      "eyebrow": "New player",
+      "title": "Welcome to FantasyWiki",
+      "lede": "Fantasy sport played with Wikipedia. You sign contracts on real articles, and they score for you on the days people actually read them.",
+      "creditsValue": "{credits} credits",
+      "credits": "to spend in your first league",
+      "slotsValue": "11 articles",
+      "slots": "on the pitch at once",
+      "winValue": "Highest total",
+      "win": "at the end of the league wins",
+      "formTitle": "Name your team",
+      "formHint": "Next stop is your dashboard, with the tour running beside it."
+    },
+    "loop": {
+      "caption": "How a day scores",
+      "holdValue": "1 article",
+      "hold": "under contract",
+      "read": "people read it that day",
+      "scoreValue": "{points} points",
+      "score": "added to your total"
+    },
+    "tour": {
+      "label": "Guided tour",
+      "progress": "Step {current} of {total}",
+      "skip": "Skip",
+      "back": "Back",
+      "next": "Next",
+      "take": "Show me",
+      "done": "Done",
+      "guideLink": "Read the full guide",
+      "stats": {
+        "title": "Points and credits",
+        "body": "Yesterday's points, what is left of your credits, and how you stand. This ledger is your team in one glance."
+      },
+      "league": {
+        "title": "Your league",
+        "body": "You start in the Global League. Each league keeps its own budget, market and standings, and you switch between them here."
+      },
+      "market": {
+        "title": "The market",
+        "body": "Every article shows what people are reading and what a contract costs. Sign one and it scores for you from the next daily update."
+      },
+      "formation": {
+        "title": "The pitch",
+        "body": "Place your articles on the pitch. Two that link to each other on Wikipedia pay a bonus when their spots are connected."
+      },
+      "wrap": {
+        "title": "That is the tour",
+        "body": "Sign your first contracts whenever you are ready. You can replay this from the menu any time."
+      },
+      "manageTeam": {
+        "title": "Getting to your pitch",
+        "body": "Your formation lives one click away, behind this button. There is no menu entry for it, so this is the way in."
+      }
+    }
+  },
+  "guide": {
+    "title": "How FantasyWiki works",
+    "lede": "What decides your score, what decides your prices, and what you can do about either.",
+    "day": {
+      "title": "A day in the league",
+      "body": "Every morning your articles are scored on how many people read them the day before. Those daily scores stack up for the whole league, and the highest total wins it."
+    },
+    "contrast": {
+      "title": "Points follow today, prices follow the month",
+      "body": "You score on yesterday's readers. A contract costs what the last 30 days of readers say it is worth. The same article can be loud on one side and quiet on the other.",
+      "axis": "Last 30 days",
+      "pointsToday": "Points today",
+      "pricedOn": "Priced on",
+      "readersPerDay": "{views} readers a day",
+      "spike": {
+        "title": "Quiet page, big day",
+        "alt": "Thirty flat days ending in one huge spike",
+        "note": "Cheap to sign, because its price still reads a quiet month. It pays once, then goes quiet again."
+      },
+      "steady": {
+        "title": "Read every day",
+        "alt": "Thirty days of consistently high readership",
+        "note": "Priced for what it is, and it pays again tomorrow."
+      },
+      "takeaway": "Catching a rise early is the cheap way to score. Holding a favourite is the dependable one. Most teams want some of each."
+    },
+    "points": {
+      "title": "What a reader is worth",
+      "alt": "Readers in a day plotted against the points they earn",
+      "rule": "Every doubling of readers adds a point, starting at one point for 4,000 readers a day. Past 150,000 readers, each extra 50,000 adds another point.",
+      "worth": "{points} point | {points} points",
+      "floor": "Under 2,000 readers a day an article scores nothing. Those articles also cost nothing to sign, which is how a team with no credits gets back on its feet."
+    },
+    "chemistry": {
+      "title": "Chemistry between your picks",
+      "alt": "Three connected spots showing what each kind of Wikipedia link pays",
+      "mutual": "They link to each other on Wikipedia",
+      "oneway": "One of them links to the other",
+      "none": "Neither links to the other",
+      "body": "Chemistry is only counted between spots your formation connects, so where you place an article matters as much as which one you signed.",
+      "cap": "A whole formation banks at most {cap} chemistry points, so even a perfectly linked team has a ceiling on the bonus."
+    },
+    "contracts": {
+      "title": "Signing, selling, renewing",
+      "shortDays": "days, short",
+      "mediumDays": "days, medium",
+      "longDays": "days, long",
+      "holdTitle": "Hold it to the end",
+      "hold": "You get your credits back, plus or minus however the price moved while you held it.",
+      "sellTitle": "Sell it early",
+      "sell": "You are paid for the days you did not use, at today's price. The days you did use are spent.",
+      "renewTitle": "Renew or let it go",
+      "renew": "On the last day you choose. Doing nothing lets it go. Renewing the same article again costs 10% more each time you do it in a row.",
+      "budget": "You start each league with {credits} credits and room for 11 articles.",
+      "free": "Articles nobody is reading are free to sign, so running out of credits is never the end of your league."
+    },
+    "replay": "Replay the tour",
+    "signIn": "Sign in to play"
   }
 }

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -114,7 +114,7 @@
       },
       "portfolio": {
         "title": "Costruisci il tuo portfolio",
-        "description": "Acquista articoli con i tuoi 1.000 crediti iniziali. Scegli durate dei contratti da 3 a 90 giorni."
+        "description": "Acquista articoli con i tuoi 1.000 crediti iniziali. Scegli contratti da 3, 7 o 14 giorni."
       },
       "points": {
         "title": "Guadagna punti ogni giorno",
@@ -357,7 +357,16 @@
   },
   "views": {
     "teamCreation": {
-      "created": "Squadra creata! 🎉 \"{name}\" è pronta a competere in {league}."
+      "created": "Squadra creata! 🎉 \"{name}\" è pronta a competere in {league}.",
+      "joining": "Stai entrando in",
+      "nameLabel": "Nome della squadra",
+      "placeholder": "es. I Maghi della Wiki",
+      "helper": "Deve essere unico nella lega",
+      "submit": "Crea la squadra e inizia",
+      "creating": "Creazione…",
+      "tooShort": "Il nome della squadra deve avere almeno {min} caratteri.",
+      "tooLong": "Il nome della squadra può avere al massimo {max} caratteri.",
+      "failed": "Creazione della squadra non riuscita. Riprova."
     },
     "teamDashboard": {
       "loading": "Caricamento dashboard…",
@@ -411,5 +420,121 @@
     "renewError": "Impossibile rinnovare questo contratto",
     "cancelRenewalSuccess": "Rinnovo annullato",
     "cancelRenewalError": "Impossibile annullare il rinnovo"
+  },
+  "onboarding": {
+    "start": {
+      "eyebrow": "Nuovo giocatore",
+      "title": "Benvenuto su FantasyWiki",
+      "lede": "Un fantasy giocato con Wikipedia. Firmi contratti su articoli veri, e quegli articoli segnano per te nei giorni in cui la gente li legge davvero.",
+      "creditsValue": "{credits} crediti",
+      "credits": "da spendere nella tua prima lega",
+      "slotsValue": "11 articoli",
+      "slots": "in campo insieme",
+      "winValue": "Punteggio più alto",
+      "win": "a fine lega vince",
+      "formTitle": "Dai un nome alla squadra",
+      "formHint": "Subito dopo arrivi alla tua dashboard, con il tour al fianco."
+    },
+    "loop": {
+      "caption": "Come si segna in un giorno",
+      "holdValue": "1 articolo",
+      "hold": "sotto contratto",
+      "read": "persone lo leggono quel giorno",
+      "scoreValue": "{points} punti",
+      "score": "aggiunti al tuo totale"
+    },
+    "tour": {
+      "label": "Tour guidato",
+      "progress": "Passo {current} di {total}",
+      "skip": "Salta",
+      "back": "Indietro",
+      "next": "Avanti",
+      "take": "Mostrami",
+      "done": "Fine",
+      "guideLink": "Leggi la guida completa",
+      "stats": {
+        "title": "Punti e crediti",
+        "body": "I punti di ieri, i crediti che ti restano e la tua posizione. Questo prospetto è la tua squadra in un colpo d'occhio."
+      },
+      "league": {
+        "title": "La tua lega",
+        "body": "Parti dalla Lega Globale. Ogni lega ha budget, mercato e classifica propri, e da qui passi dall'una all'altra."
+      },
+      "market": {
+        "title": "Il mercato",
+        "body": "Ogni articolo mostra quanto viene letto e quanto costa un contratto. Firmalo e segna per te dal prossimo aggiornamento giornaliero."
+      },
+      "formation": {
+        "title": "Il campo",
+        "body": "Disponi i tuoi articoli in campo. Due articoli che si citano a vicenda su Wikipedia danno un bonus quando le loro caselle sono collegate."
+      },
+      "wrap": {
+        "title": "Il tour finisce qui",
+        "body": "Firma i primi contratti quando ti senti pronto. Puoi rivedere questo tour dal menu quando vuoi."
+      },
+      "manageTeam": {
+        "title": "Come arrivare al campo",
+        "body": "La tua formazione è a un clic da qui, dietro questo pulsante. Non ha una voce di menu, quindi questa è la strada."
+      }
+    }
+  },
+  "guide": {
+    "title": "Come funziona FantasyWiki",
+    "lede": "Cosa decide il tuo punteggio, cosa decide i prezzi e cosa puoi farci.",
+    "day": {
+      "title": "Una giornata di lega",
+      "body": "Ogni mattina i tuoi articoli ricevono punti in base a quante persone li hanno letti il giorno prima. I punti giornalieri si sommano per tutta la lega, e il totale più alto la vince."
+    },
+    "contrast": {
+      "title": "I punti seguono oggi, i prezzi seguono il mese",
+      "body": "Segni con i lettori di ieri. Un contratto costa quanto dicono gli ultimi 30 giorni di letture. Lo stesso articolo può essere rumoroso da una parte e silenzioso dall'altra.",
+      "axis": "Ultimi 30 giorni",
+      "pointsToday": "Punti oggi",
+      "pricedOn": "Prezzo basato su",
+      "readersPerDay": "{views} lettori al giorno",
+      "spike": {
+        "title": "Pagina tranquilla, giornata enorme",
+        "alt": "Trenta giorni piatti che finiscono con un picco enorme",
+        "note": "Costa poco, perché il prezzo legge ancora un mese tranquillo. Paga una volta, poi torna in silenzio."
+      },
+      "steady": {
+        "title": "Letta tutti i giorni",
+        "alt": "Trenta giorni di letture costantemente alte",
+        "note": "Costa quanto vale, e paga di nuovo domani."
+      },
+      "takeaway": "Intercettare una salita in anticipo è il modo economico di segnare. Tenere una pagina molto letta è quello affidabile. Le squadre migliori usano entrambi."
+    },
+    "points": {
+      "title": "Quanto vale un lettore",
+      "alt": "Lettori in un giorno confrontati con i punti che generano",
+      "rule": "Ogni raddoppio dei lettori aggiunge un punto, a partire da un punto per 4.000 lettori al giorno. Oltre i 150.000 lettori, ogni 50.000 in più aggiungono un altro punto.",
+      "worth": "{points} punto | {points} punti",
+      "floor": "Sotto i 2.000 lettori al giorno un articolo non segna nulla. Quegli articoli però si firmano gratis, ed è così che una squadra senza crediti si rialza."
+    },
+    "chemistry": {
+      "title": "Chimica tra le tue scelte",
+      "alt": "Tre caselle collegate che mostrano quanto paga ogni tipo di collegamento su Wikipedia",
+      "mutual": "Si citano a vicenda su Wikipedia",
+      "oneway": "Uno dei due cita l'altro",
+      "none": "Nessuno dei due cita l'altro",
+      "body": "La chimica conta solo tra le caselle collegate dal tuo modulo: dove metti un articolo pesa quanto la scelta dell'articolo.",
+      "cap": "Una formazione intera accumula al massimo {cap} punti di chimica, quindi anche una squadra collegata alla perfezione ha un tetto al bonus."
+    },
+    "contracts": {
+      "title": "Firmare, vendere, rinnovare",
+      "shortDays": "giorni, breve",
+      "mediumDays": "giorni, medio",
+      "longDays": "giorni, lungo",
+      "holdTitle": "Tienilo fino alla fine",
+      "hold": "Riprendi i tuoi crediti, più o meno quanto si è mosso il prezzo mentre lo tenevi.",
+      "sellTitle": "Vendilo prima",
+      "sell": "Ti vengono pagati i giorni che non hai usato, al prezzo di oggi. I giorni usati restano spesi.",
+      "renewTitle": "Rinnova o lascialo andare",
+      "renew": "L'ultimo giorno scegli tu. Se non fai nulla, il contratto si chiude. Rinnovare lo stesso articolo di fila costa il 10% in più ogni volta.",
+      "budget": "Inizi ogni lega con {credits} crediti e spazio per 11 articoli.",
+      "free": "Gli articoli che non legge nessuno si firmano gratis, quindi restare senza crediti non è mai la fine della tua lega."
+    },
+    "replay": "Rivedi il tour",
+    "signIn": "Accedi per giocare"
   }
 }

--- a/frontend/src/layout/InfoFooter.vue
+++ b/frontend/src/layout/InfoFooter.vue
@@ -7,9 +7,7 @@
         {{ $t("footer.technicalDocs") }}
       </a>
       <span aria-hidden="true">·</span>
-      <a :href="`${REPO_URL}/tree/master/docs`" target="_blank" rel="noopener">
-        {{ $t("footer.userGuide") }}
-      </a>
+      <router-link to="/guide">{{ $t("footer.userGuide") }}</router-link>
       <span aria-hidden="true">·</span>
       <a :href="REPO_URL" target="_blank" rel="noopener">
         <ion-icon :icon="logoGithub" aria-hidden="true" />

--- a/frontend/src/layout/NavBar.vue
+++ b/frontend/src/layout/NavBar.vue
@@ -15,6 +15,7 @@
             v-for="link in navLinks"
             :key="link.name"
             :router-link="link.href"
+            :data-tour="link.tour"
             router-direction="forward"
             fill="clear"
             class="nav-link"
@@ -27,8 +28,11 @@
 
         <!-- Right Actions -->
         <div slot="end" class="actions-container">
+          <!-- data-tour marks the elements the onboarding tour rings. They are
+               selectors on real controls, not tour-only markup. -->
           <ion-button
             id="league-selector"
+            data-tour="league"
             fill="solid"
             size="small"
             shape="round"
@@ -179,10 +183,15 @@
     >
       <ion-toolbar class="transparent-bot-layer">
         <div class="mobile-nav">
+          <!-- Same data-tour as the desktop bar: only one of the two is ever
+               laid out, and the tour rings whichever that is. Ringing the
+               mobile icons is the point — they are the least self-explanatory
+               control in the app. -->
           <ion-button
             fill="clear"
             v-for="link in navLinks"
             :key="link.name"
+            :data-tour="link.tour"
             @click="router.push(link.href)"
           >
             <ion-icon :icon="link.icon" />
@@ -295,10 +304,28 @@ const profilePicture = computed(() =>
   appStore.isAuthenticated ? appStore.currentUser?.picture : undefined
 );
 
+// `tour` is the selector hook the onboarding tour rings on this link; it is
+// carried here rather than hardcoded per template so the desktop bar and the
+// mobile footer can never disagree about which button a step means.
 const navLinks = computed(() => [
-  { name: t("nav.dashboard"), href: "/dashboard", icon: gridOutline },
-  { name: t("nav.leagues"), href: "/leagues", icon: trophyOutline },
-  { name: t("nav.market"), href: "/market", icon: storefrontOutline },
+  {
+    name: t("nav.dashboard"),
+    href: "/dashboard",
+    icon: gridOutline,
+    tour: "nav-dashboard",
+  },
+  {
+    name: t("nav.leagues"),
+    href: "/leagues",
+    icon: trophyOutline,
+    tour: "nav-leagues",
+  },
+  {
+    name: t("nav.market"),
+    href: "/market",
+    icon: storefrontOutline,
+    tour: "nav-market",
+  },
 ]);
 
 const isActive = (href: string) => route.path === href;

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -9,6 +9,7 @@ import TeamPage from "@/views/TeamPage.vue";
 import TeamCreationPage from "@/views/TeamCreationPage.vue";
 import MarketPage from "@/views/MarketPage.vue";
 import LegalPage from "@/views/LegalPage.vue";
+import GuidePage from "@/views/GuidePage.vue";
 import ReportProblemPage from "@/views/ReportProblemPage.vue";
 import NotFoundPage from "@/views/NotFoundPage.vue";
 import { useAppStore } from "@/stores/app";
@@ -68,6 +69,19 @@ const routes: Array<RouteRecordRaw> = [
     path: "/team-creation",
     name: "TeamCreation",
     component: TeamCreationPage,
+  },
+  {
+    // Onboarding is no longer a place: it is the guided tour running on top of
+    // the real pages (see stores/onboarding.ts). The old path is kept as a
+    // redirect so bookmarks and older links land on the tour rather than a 404.
+    path: "/onboarding",
+    redirect: { path: "/dashboard", query: { tour: "1" } },
+  },
+  {
+    path: "/guide",
+    name: "Guide",
+    component: GuidePage,
+    meta: { public: true },
   },
   {
     path: "/market",

--- a/frontend/src/stores/onboarding.ts
+++ b/frontend/src/stores/onboarding.ts
@@ -1,0 +1,126 @@
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+
+/**
+ * The guided first-run tour.
+ *
+ * The tour is not a place you go: it is a state the app is in. Every step
+ * happens on a *real* route, with the real NavBar, the real data and the real
+ * buttons on screen; the only thing this store adds is which step is current.
+ * That is why there is no `/onboarding` view and no slide content here — the
+ * pages themselves are the content, and `TourDock.vue` narrates them.
+ *
+ * Nothing is persisted. The trigger for a first run is creating a team (the
+ * one thing a new player necessarily does, and can only do once), and the
+ * trigger for a replay is `?tour=1`, so there is no "has seen onboarding" flag
+ * to keep in sync with the backend.
+ */
+export type TourStepId =
+  | "stats"
+  | "league"
+  | "market"
+  | "manageTeam"
+  | "formation"
+  | "wrap";
+
+export interface TourStep {
+  id: TourStepId;
+  /** Route the step is narrated on. Entering the step navigates there. */
+  route: string;
+  /**
+   * Elements the step is about, as selectors, most important first. Resolved
+   * best-effort at runtime: a step whose targets never appear still narrates,
+   * just without a ring.
+   *
+   * Most steps name two — the thing on the page *and* the navigation button
+   * that reaches it. The mobile navigation is a row of bare icons, so the tour
+   * has to say which icon it is talking about, not just what the page holds.
+   */
+  targets?: readonly string[];
+}
+
+/**
+ * Order follows the navigation bar (dashboard, leagues, market, team) so the
+ * tour teaches the menu the player is about to use, in the order they read it.
+ *
+ * Two deliberate detours:
+ *  - `league` has no route of its own. `/leagues` is still a stub, and the
+ *    league switcher in the NavBar is the real thing a player needs to find, so
+ *    the tour points at it in place rather than walking them into a placeholder.
+ *  - `manageTeam` sends the player back to the dashboard to show the button
+ *    that opens the pitch *before* the pitch itself. The pitch has no
+ *    navigation entry of its own, so without this step a player would learn a
+ *    screen they cannot find again.
+ */
+export const TOUR_STEPS: readonly TourStep[] = [
+  {
+    id: "stats",
+    route: "/dashboard",
+    targets: ["[data-tour='stats']", "[data-tour='nav-dashboard']"],
+  },
+  { id: "league", route: "/dashboard", targets: ["[data-tour='league']"] },
+  {
+    id: "market",
+    route: "/market",
+    targets: ["[data-tour='market']", "[data-tour='nav-market']"],
+  },
+  {
+    id: "manageTeam",
+    route: "/dashboard",
+    targets: ["[data-tour='manage-team']"],
+  },
+  { id: "formation", route: "/team", targets: ["[data-tour='formation']"] },
+  { id: "wrap", route: "/dashboard" },
+] as const;
+
+export const useOnboardingStore = defineStore("onboarding", () => {
+  const isActive = ref(false);
+  const stepIndex = ref(0);
+
+  const currentStep = computed<TourStep | undefined>(() =>
+    isActive.value ? TOUR_STEPS[stepIndex.value] : undefined
+  );
+
+  const totalSteps = computed(() => TOUR_STEPS.length);
+  const isFirstStep = computed(() => stepIndex.value === 0);
+  const isLastStep = computed(() => stepIndex.value === TOUR_STEPS.length - 1);
+
+  /** Begin (or restart) the tour at its first step. */
+  function start() {
+    stepIndex.value = 0;
+    isActive.value = true;
+  }
+
+  /** Advance; the last step's "next" is the finish. */
+  function next() {
+    if (!isActive.value) return;
+    if (isLastStep.value) {
+      end();
+      return;
+    }
+    stepIndex.value += 1;
+  }
+
+  function back() {
+    if (!isActive.value || isFirstStep.value) return;
+    stepIndex.value -= 1;
+  }
+
+  function end() {
+    isActive.value = false;
+    stepIndex.value = 0;
+  }
+
+  return {
+    isActive,
+    stepIndex,
+    currentStep,
+    totalSteps,
+    isFirstStep,
+    isLastStep,
+    start,
+    next,
+    back,
+    end,
+  };
+});

--- a/frontend/src/tests/AuthCallbackPage.spec.ts
+++ b/frontend/src/tests/AuthCallbackPage.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { http, HttpResponse } from "msw";
+import { server } from "@/mocks/server";
+import router from "@/router/index";
+import AuthCallbackPage from "@/views/auth/AuthCallbackPage.vue";
+
+function mockSession() {
+  server.use(
+    http.get("*/api/session", () =>
+      HttpResponse.json({
+        sub: "player-1",
+        email: "player@example.com",
+        name: "Player One",
+        picture: "",
+      })
+    )
+  );
+}
+
+describe("AuthCallbackPage.vue", () => {
+  it("sends a brand-new player to team creation, which is where the game starts", async () => {
+    mockSession();
+    await router.push({ path: "/auth/callback", query: { new: "1" } });
+    await router.isReady();
+
+    mount(AuthCallbackPage, { global: { plugins: [router] } });
+    await flushPromises();
+
+    expect(router.currentRoute.value.path).toBe("/team-creation");
+  });
+
+  it("sends a returning player straight home", async () => {
+    mockSession();
+    await router.push({ path: "/auth/callback" });
+    await router.isReady();
+
+    mount(AuthCallbackPage, { global: { plugins: [router] } });
+    await flushPromises();
+
+    expect(router.currentRoute.value.path).toBe("/home");
+  });
+});

--- a/frontend/src/tests/GuidePage.spec.ts
+++ b/frontend/src/tests/GuidePage.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+import router from "@/router/index";
+import GuidePage from "@/views/GuidePage.vue";
+import { useAppStore } from "@/stores/app";
+import { basePoints } from "../../../model/scoring";
+import { TIER_DAYS } from "../../../model/pricing";
+
+let pinia: Pinia;
+
+async function mountGuide() {
+  await router.push("/guide");
+  await router.isReady();
+  const wrapper = mount(GuidePage, { global: { plugins: [pinia, router] } });
+  await flushPromises();
+  return wrapper;
+}
+
+describe("GuidePage.vue", () => {
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  it("mounts without a session, since the route is public", async () => {
+    const wrapper = await mountGuide();
+
+    expect(wrapper.text()).toContain("How FantasyWiki works");
+  });
+
+  it("gets the direction of scoring right: points from today, price from the month", async () => {
+    const wrapper = await mountGuide();
+    const text = wrapper.text();
+
+    expect(text).toContain("Points follow today, prices follow the month");
+    expect(text).toContain("You score on yesterday's readers");
+    expect(text).toContain("Priced on");
+  });
+
+  it("draws its numbers from the game model rather than from copy", async () => {
+    const wrapper = await mountGuide();
+    const text = wrapper.text();
+
+    // The contract tiers a player can actually buy.
+    for (const days of Object.values(TIER_DAYS)) {
+      expect(text).toContain(String(days));
+    }
+    // 32,000 readers is worth 4 points on the real curve, and the day-loop
+    // figure says so.
+    expect(Math.round(basePoints(32_000))).toBe(4);
+    expect(text).toContain("4 points");
+  });
+
+  it("teaches the rules without leaking why they were designed that way", async () => {
+    const wrapper = await mountGuide();
+    const text = wrapper.text().toLowerCase();
+
+    for (const tell of [
+      "deliberate",
+      "we chose",
+      "the reason",
+      "designed",
+      "formula",
+      "exponent",
+    ]) {
+      expect(text).not.toContain(tell);
+    }
+  });
+
+  it("offers the tour to a signed-in player and a sign-in to everyone else", async () => {
+    const anonymous = await mountGuide();
+    expect(anonymous.text()).toContain("Sign in to play");
+
+    useAppStore().setUserFromData({
+      sub: "player-1",
+      email: "player@example.com",
+      name: "Player One",
+      picture: "",
+    });
+    const player = await mountGuide();
+
+    // Ionic renders the routerLink prop onto the custom element as a plain
+    // lowercase attribute.
+    expect(player.get(".guide-foot ion-button").attributes("routerlink")).toBe(
+      "/dashboard?tour=1"
+    );
+  });
+});

--- a/frontend/src/tests/InfoFooter.spec.ts
+++ b/frontend/src/tests/InfoFooter.spec.ts
@@ -18,6 +18,7 @@ describe("InfoFooter.vue", () => {
       "https://github.com/FantasyWiki/FantasyWiki/issues"
     );
     expect(wrapper.find("a[href='/legal']").exists()).toBe(true);
+    expect(wrapper.find("a[href='/guide']").exists()).toBe(true);
   });
 
   it("credits both authors", async () => {

--- a/frontend/src/tests/OnboardingTour.spec.ts
+++ b/frontend/src/tests/OnboardingTour.spec.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mount,
+  flushPromises,
+  enableAutoUnmount,
+  VueWrapper,
+} from "@vue/test-utils";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+import router from "@/router/index";
+import i18n from "@/i18n";
+import TourDock from "@/components/onboarding/TourDock.vue";
+import { useAppStore } from "@/stores/app";
+import { useOnboardingStore, TOUR_STEPS } from "@/stores/onboarding";
+
+/**
+ * The tour is a state the real app is in, so these tests drive the store and
+ * the dock and assert on the *routes* and the *real elements* the tour claims
+ * to be pointing at — never on slide content, because there is none.
+ */
+function signIn() {
+  useAppStore().setUserFromData({
+    sub: "player-1",
+    email: "player@example.com",
+    name: "Player One",
+    picture: "",
+  });
+}
+
+function findButton(wrapper: VueWrapper, text: string) {
+  return wrapper.findAll("ion-button").find((b) => b.text().includes(text));
+}
+
+/** Stands in for a real page element the tour rings. */
+function plantTarget(name: string): HTMLElement {
+  const el = document.createElement("div");
+  el.setAttribute("data-tour", name);
+  document.body.appendChild(el);
+  return el;
+}
+
+/**
+ * Stands in for an Ionic page in the router outlet, with the tour anchors it
+ * carries. Ionic keeps the page you came from mounted, so several pages can
+ * hold an element matching the same selector at once.
+ */
+function plantPage(...names: string[]): Record<string, HTMLElement> {
+  const page = document.createElement("div");
+  page.className = "ion-page";
+  document.body.appendChild(page);
+  return Object.fromEntries(
+    names.map((name) => {
+      const el = document.createElement("div");
+      el.setAttribute("data-tour", name);
+      page.appendChild(el);
+      return [name, el];
+    })
+  );
+}
+
+// The dock and the test have to share one store instance, so the spec's own
+// pinia is passed at mount rather than relying on the global test default.
+let pinia: Pinia;
+
+async function mountDock() {
+  const wrapper = mount(TourDock, { global: { plugins: [pinia, router] } });
+  await flushPromises();
+  return wrapper;
+}
+
+// Every dock listens to the one shared router, so a wrapper left mounted keeps
+// reacting to the next test's navigation. Unmount them as they finish.
+enableAutoUnmount(afterEach);
+
+describe("the guided tour", () => {
+  beforeEach(async () => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    signIn();
+    i18n.global.locale.value = "en";
+    await router.push("/dashboard");
+    await router.isReady();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    i18n.global.locale.value = "en";
+  });
+
+  it("stays out of the way until it is started", async () => {
+    const wrapper = await mountDock();
+
+    expect(wrapper.find(".tour-dock").exists()).toBe(false);
+  });
+
+  it("narrates the dashboard first, with no way back from step one", async () => {
+    const onboarding = useOnboardingStore();
+    const wrapper = await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+
+    expect(wrapper.find(".tour-dock").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Points and credits");
+    expect(wrapper.text()).toContain(`Step 1 of ${TOUR_STEPS.length}`);
+    expect(findButton(wrapper, "Back")).toBeFalsy();
+    // Still on the real dashboard: the tour never replaces the page.
+    expect(router.currentRoute.value.path).toBe("/dashboard");
+  });
+
+  it("rings the real element a step is about", async () => {
+    const stats = plantTarget("stats");
+    const onboarding = useOnboardingStore();
+    await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+
+    expect(stats.classList.contains("tour-ring")).toBe(true);
+  });
+
+  it("moves the ring off the previous element when the step changes", async () => {
+    const stats = plantTarget("stats");
+    const league = plantTarget("league");
+    const onboarding = useOnboardingStore();
+    await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+    onboarding.next();
+    await flushPromises();
+
+    expect(stats.classList.contains("tour-ring")).toBe(false);
+    expect(league.classList.contains("tour-ring")).toBe(true);
+  });
+
+  it("walks the player onto the real market and team pages", async () => {
+    const onboarding = useOnboardingStore();
+    const wrapper = await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+
+    onboarding.next(); // league selector, still on the dashboard
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/dashboard");
+
+    onboarding.next(); // market
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/market");
+    expect(wrapper.text()).toContain("The market");
+
+    // Back to the dashboard to point at the button that opens the pitch,
+    // before showing the pitch itself: it has no navigation entry of its own.
+    onboarding.next();
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/dashboard");
+    expect(wrapper.text()).toContain("Getting to your pitch");
+
+    onboarding.next(); // pitch
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/team");
+
+    onboarding.next(); // wrap up, back where it started
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/dashboard");
+    expect(wrapper.find("a[href='/guide']").exists()).toBe(true);
+  });
+
+  it("rings the navigation button for the page a step is about", async () => {
+    // The mobile navigation is a row of bare icons, so naming the icon is the
+    // point of the step, not a decoration on it.
+    const stats = plantTarget("stats");
+    const navDashboard = plantTarget("nav-dashboard");
+    const onboarding = useOnboardingStore();
+    await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+
+    expect(stats.classList.contains("tour-ring")).toBe(true);
+    expect(navDashboard.classList.contains("tour-ring")).toBe(true);
+  });
+
+  it("rings the navigation button on the page it arrived at, not the one it left", async () => {
+    // The bug this pins down: the ring used to be applied in the same tick as
+    // the navigation, so the market step lit up the *dashboard's* copy of the
+    // market button, which then vanished with the outgoing page and left the
+    // market page with nothing highlighted.
+    const leaving = plantPage("nav-market");
+    const entering = plantPage("market", "nav-market");
+    const onboarding = useOnboardingStore();
+    await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+    onboarding.next(); // league
+    await flushPromises();
+    onboarding.next(); // market, on /market
+    await flushPromises();
+
+    expect(router.currentRoute.value.path).toBe("/market");
+    expect(entering.market.classList.contains("tour-ring")).toBe(true);
+    expect(entering["nav-market"].classList.contains("tour-ring")).toBe(true);
+    expect(leaving["nav-market"].classList.contains("tour-ring")).toBe(false);
+  });
+
+  it("ends itself when the player leaves for the written guide", async () => {
+    const onboarding = useOnboardingStore();
+    const wrapper = await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+    for (let i = 0; i < TOUR_STEPS.length - 1; i++) {
+      onboarding.next();
+      await flushPromises();
+    }
+
+    await wrapper.get("a[href='/guide']").trigger("click");
+    await flushPromises();
+
+    expect(onboarding.isActive).toBe(false);
+  });
+
+  it("finishes on the dashboard and takes the dock with it", async () => {
+    const onboarding = useOnboardingStore();
+    const wrapper = await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+    for (let i = 0; i < TOUR_STEPS.length - 1; i++) {
+      onboarding.next();
+      await flushPromises();
+    }
+
+    await findButton(wrapper, "Done")!.trigger("click");
+    await flushPromises();
+
+    expect(onboarding.isActive).toBe(false);
+    expect(wrapper.find(".tour-dock").exists()).toBe(false);
+    expect(router.currentRoute.value.path).toBe("/dashboard");
+  });
+
+  it("can be skipped from any step before the last", async () => {
+    const onboarding = useOnboardingStore();
+    const wrapper = await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+    await findButton(wrapper, "Skip")!.trigger("click");
+    await flushPromises();
+
+    expect(onboarding.isActive).toBe(false);
+  });
+
+  it("follows a language switch made while it is running", async () => {
+    const onboarding = useOnboardingStore();
+    const wrapper = await mountDock();
+
+    onboarding.start();
+    await flushPromises();
+    expect(wrapper.text()).toContain("Points and credits");
+
+    // The settings menu (and its language rows) stays reachable throughout the
+    // tour, so the copy has to re-resolve rather than freeze at the locale the
+    // tour started in.
+    i18n.global.locale.value = "it";
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Punti e crediti");
+    expect(wrapper.text()).toContain(`Passo 1 di ${TOUR_STEPS.length}`);
+  });
+
+  it("replays from ?tour=1 and clears the flag behind it", async () => {
+    const onboarding = useOnboardingStore();
+    await router.push("/dashboard?tour=1");
+    await mountDock();
+
+    expect(onboarding.isActive).toBe(true);
+    expect(router.currentRoute.value.query.tour).toBeUndefined();
+  });
+
+  it("never routes a replaying player back into team creation", async () => {
+    // A returning player already has a team, and creating a second one is not
+    // a thing: no step may point at the creation route.
+    expect(TOUR_STEPS.some((step) => step.route === "/team-creation")).toBe(
+      false
+    );
+  });
+
+  it("keeps the old /onboarding link working by redirecting it to the tour", async () => {
+    const onboarding = useOnboardingStore();
+    await mountDock();
+
+    await router.push("/onboarding");
+    await flushPromises();
+
+    expect(router.currentRoute.value.path).toBe("/dashboard");
+    expect(onboarding.isActive).toBe(true);
+  });
+});

--- a/frontend/src/tests/SettingsMenu.spec.ts
+++ b/frontend/src/tests/SettingsMenu.spec.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { createPinia, Pinia, setActivePinia } from "pinia";
+import router from "@/router/index";
 import SettingsMenu from "@/components/SettingsMenu.vue";
 import { useAppStore } from "@/stores/app";
 
 function mountMenu(pinia: Pinia) {
-  return mount(SettingsMenu, { global: { plugins: [pinia] } });
+  return mount(SettingsMenu, { global: { plugins: [pinia, router] } });
 }
 
 describe("SettingsMenu.vue", () => {
@@ -55,6 +56,32 @@ describe("SettingsMenu.vue", () => {
       picture: "https://example.com/avatar.png",
     };
     expect(mountMenu(pinia).find(".account-row").exists()).toBe(true);
+  });
+
+  it("opens the written guide from the user-guide row, signed in or not", async () => {
+    await router.push("/home");
+    await router.isReady();
+
+    const appStore = useAppStore();
+    // The guide is public, so someone still deciding whether to play can read
+    // the rules from the same row a player uses.
+    appStore.isAuthenticated = false;
+    expect(mountMenu(pinia).find(".user-guide-row").exists()).toBe(true);
+
+    appStore.setUserFromData({
+      sub: "player-1",
+      email: "player@example.com",
+      name: "Player One",
+      picture: "",
+    });
+    const wrapper = mountMenu(pinia);
+    // The row hands over a page to read; replaying the guided tour is a
+    // deliberate second choice, offered at the end of that page.
+    const pushSpy = vi.spyOn(router, "push");
+    await wrapper.get(".user-guide-row").trigger("click");
+
+    expect(pushSpy).toHaveBeenCalledWith("/guide");
+    expect(wrapper.emitted("close")).toHaveLength(1);
   });
 
   it("switches language from the sub-menu and returns to the root view", async () => {

--- a/frontend/src/tests/TeamCreationPage.spec.ts
+++ b/frontend/src/tests/TeamCreationPage.spec.ts
@@ -1,37 +1,87 @@
-import { describe, it, expect } from "vitest";
-import { mount, flushPromises } from "@vue/test-utils";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount, flushPromises, VueWrapper } from "@vue/test-utils";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
 import { http, HttpResponse } from "msw";
 import { server } from "@/mocks/server";
 import router from "@/router/index";
 import TeamCreationPage from "@/views/TeamCreationPage.vue";
+import { useAppStore } from "@/stores/app";
+import { useLeagueStore } from "@/stores/league";
+import { useOnboardingStore } from "@/stores/onboarding";
+
+// The real toast needs Ionic's overlay lifecycle to settle, which jsdom's
+// microtask queue alone will not do; stubbed so the success path resolves.
+vi.mock("@/composables/useToast", () => ({
+  useToast: () => ({ showSuccess: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+// One pinia shared by the page and the assertions: the global test default
+// would hand the component a different store instance than the spec reads.
+let pinia: Pinia;
+
+async function mountPage() {
+  await router.push("/team-creation");
+  await router.isReady();
+  const wrapper = mount(TeamCreationPage, {
+    global: { plugins: [pinia, router] },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+async function submitName(wrapper: VueWrapper, name: string) {
+  const input = wrapper.find("ion-input");
+  (input.element as unknown as { value: string }).value = name;
+  await input.trigger("ionInput");
+  await wrapper.find("form").trigger("submit");
+  await flushPromises();
+}
 
 describe("TeamCreationPage.vue", () => {
-  it("should mount without any console errors or warnings", async () => {
-    await router.push("/");
-    await router.isReady();
-    const wrapper = mount(TeamCreationPage, {
-      global: {
-        plugins: [router],
-      },
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    localStorage.clear();
+    useAppStore().setUserFromData({
+      sub: "player-1",
+      email: "player@example.com",
+      name: "Player One",
+      picture: "",
     });
+  });
 
-    expect(wrapper.exists()).toBe(true);
+  it("explains the game beside the form instead of before it", async () => {
+    const wrapper = await mountPage();
+    const text = wrapper.text();
+
+    expect(text).toContain("Welcome to FantasyWiki");
+    // The objective and the day loop are on the same screen as the field the
+    // player has to fill in, not on slides in front of it.
+    expect(text).toContain("How a day scores");
+    expect(text).toContain("at the end of the league wins");
+    expect(wrapper.find("ion-input").exists()).toBe(true);
   });
 
   it("loads the Global League from /api/leagues/global and shows it", async () => {
-    await router.push("/");
-    await router.isReady();
-
-    const wrapper = mount(TeamCreationPage, {
-      global: {
-        plugins: [router],
-      },
-    });
-
-    await flushPromises();
+    const wrapper = await mountPage();
 
     expect(wrapper.text()).toContain("Global League");
     expect(wrapper.text()).toContain("🌍");
+  });
+
+  it("hands over to the populated dashboard with the tour running", async () => {
+    const leagueStore = useLeagueStore();
+    const onboarding = useOnboardingStore();
+    const wrapper = await mountPage();
+
+    await submitName(wrapper, "The Wiki Wizards");
+
+    // The league store was empty a moment ago (the player had no team), so
+    // without this refresh the dashboard would greet them with its "no league"
+    // card instead of their team.
+    expect(leagueStore.currentLeague).toBeDefined();
+    expect(onboarding.isActive).toBe(true);
+    expect(router.currentRoute.value.path).toBe("/dashboard");
   });
 
   it("shows an error message and re-enables the form when team creation fails", async () => {
@@ -44,25 +94,20 @@ describe("TeamCreationPage.vue", () => {
       )
     );
 
-    await router.push("/");
-    await router.isReady();
-
-    const wrapper = mount(TeamCreationPage, {
-      global: {
-        plugins: [router],
-      },
-    });
-
-    await flushPromises();
-
-    const input = wrapper.find("ion-input");
-    (input.element as unknown as { value: string }).value = "The Wiki Wizards";
-    await input.trigger("ionInput");
-    await wrapper.find("form").trigger("submit");
-    await flushPromises();
+    const wrapper = await mountPage();
+    await submitName(wrapper, "The Wiki Wizards");
 
     expect(wrapper.text()).toContain(
       "This team name is already taken in this league."
     );
+    expect(useOnboardingStore().isActive).toBe(false);
+  });
+
+  it("rejects a name that is too short before calling the API", async () => {
+    const wrapper = await mountPage();
+    await submitName(wrapper, "ab");
+
+    expect(wrapper.text()).toContain("at least 3 characters");
+    expect(router.currentRoute.value.path).toBe("/team-creation");
   });
 });

--- a/frontend/src/theme/variables.css
+++ b/frontend/src/theme/variables.css
@@ -242,6 +242,15 @@ http://ionicframework.com/docs/theming/ */
          CUSTOM FANTASYWIKI VARIABLES
          ================================== */
 
+  /* Chemistry levels. The formation pitch and the guide's chemistry figure
+     read from the same three values on purpose: a player learns the colours on
+     the pitch, so the guide has to teach them in that language and not invent
+     its own. */
+  --chem-excellent: #2f8f5b;
+  --chem-good: #d6a71a;
+  --chem-weak: #d42a17;
+  --chem-empty: rgba(var(--ion-color-medium-rgb), 0.75);
+
   --ion-color-wiki-gold: #f5c842;
   --ion-color-wiki-gold-rgb: 245, 200, 66;
   --ion-color-wiki-gold-contrast: #000000;
@@ -352,6 +361,48 @@ http://ionicframework.com/docs/theming/ */
     opacity var(--reveal-duration) ease-out,
     transform var(--reveal-duration) ease-out;
   transition-delay: calc(var(--reveal-index, 0) * var(--reveal-stagger));
+}
+
+/* ===================================
+       ONBOARDING TOUR RING
+       ================================== */
+
+/* The tour draws attention to a real element on a real page, so the rule has
+   to live globally: TourDock.vue puts this class on a node it does not own,
+   and a scoped style would never match it. Outline rather than border, so
+   nothing in the highlighted component reflows while the ring is on.
+
+   It glows, and slowly breathes, because the things it has to pick out include
+   a single bare icon in the mobile navigation bar — a hairline ring there reads
+   as a rendering artefact rather than as "this one". */
+.tour-ring {
+  outline: 2px solid var(--ion-color-primary);
+  outline-offset: 4px;
+  border-radius: 12px;
+  animation: tour-ring-glow 1.8s ease-in-out infinite alternate;
+  box-shadow:
+    0 0 0 5px rgba(var(--ion-color-primary-rgb), 0.22),
+    0 0 18px 4px rgba(var(--ion-color-primary-rgb), 0.45);
+}
+
+@keyframes tour-ring-glow {
+  from {
+    box-shadow:
+      0 0 0 5px rgba(var(--ion-color-primary-rgb), 0.18),
+      0 0 14px 2px rgba(var(--ion-color-primary-rgb), 0.32);
+  }
+  to {
+    box-shadow:
+      0 0 0 7px rgba(var(--ion-color-primary-rgb), 0.28),
+      0 0 26px 8px rgba(var(--ion-color-primary-rgb), 0.6);
+  }
+}
+
+/* Reduced motion keeps the glow, drops the breathing. */
+@media (prefers-reduced-motion: reduce) {
+  .tour-ring {
+    animation: none;
+  }
 }
 
 h1 {

--- a/frontend/src/views/GuidePage.vue
+++ b/frontend/src/views/GuidePage.vue
@@ -1,0 +1,247 @@
+<template>
+  <nav-bar>
+    <page-reveal class="guide">
+      <header class="guide-head">
+        <h1 class="guide-title">{{ t("guide.title") }}</h1>
+        <p class="guide-lede">{{ t("guide.lede") }}</p>
+      </header>
+
+      <section class="guide-section">
+        <h2 class="section-title">{{ t("guide.day.title") }}</h2>
+        <day-loop class="section-figure" />
+        <p class="section-text">{{ t("guide.day.body") }}</p>
+      </section>
+
+      <section class="guide-section">
+        <h2 class="section-title">{{ t("guide.contrast.title") }}</h2>
+        <p class="section-text section-text--lead">
+          {{ t("guide.contrast.body") }}
+        </p>
+        <spike-vs-steady class="section-figure" />
+        <p class="section-text">{{ t("guide.contrast.takeaway") }}</p>
+      </section>
+
+      <section class="guide-section">
+        <h2 class="section-title">{{ t("guide.points.title") }}</h2>
+        <points-ladder class="section-figure" />
+        <p class="section-text">{{ t("guide.points.floor") }}</p>
+      </section>
+
+      <section class="guide-section">
+        <h2 class="section-title">{{ t("guide.chemistry.title") }}</h2>
+        <chemistry-map class="section-figure" />
+        <p class="section-text">{{ t("guide.chemistry.body") }}</p>
+        <p class="section-text">
+          {{ t("guide.chemistry.cap", { cap: synergyCap }) }}
+        </p>
+      </section>
+
+      <section class="guide-section">
+        <h2 class="section-title">{{ t("guide.contracts.title") }}</h2>
+
+        <ul class="tier-row">
+          <li v-for="tier in tiers" :key="tier.label">
+            <span class="tier-days">{{ tier.days }}</span>
+            <span class="tier-label">{{ tier.label }}</span>
+          </li>
+        </ul>
+
+        <dl class="rule-list">
+          <div>
+            <dt>{{ t("guide.contracts.holdTitle") }}</dt>
+            <dd>{{ t("guide.contracts.hold") }}</dd>
+          </div>
+          <div>
+            <dt>{{ t("guide.contracts.sellTitle") }}</dt>
+            <dd>{{ t("guide.contracts.sell") }}</dd>
+          </div>
+          <div>
+            <dt>{{ t("guide.contracts.renewTitle") }}</dt>
+            <dd>{{ t("guide.contracts.renew") }}</dd>
+          </div>
+        </dl>
+
+        <p class="section-text">
+          {{ t("guide.contracts.budget", { credits: startingCredits }) }}
+        </p>
+        <p class="section-text">{{ t("guide.contracts.free") }}</p>
+      </section>
+
+      <footer class="guide-foot">
+        <ion-button
+          v-if="appStore.isAuthenticated"
+          router-link="/dashboard?tour=1"
+          color="primary"
+          fill="solid"
+          size="small"
+        >
+          {{ t("guide.replay") }}
+        </ion-button>
+        <ion-button
+          v-else
+          color="primary"
+          fill="solid"
+          size="small"
+          @click="appStore.openLoginModal()"
+        >
+          {{ t("guide.signIn") }}
+        </ion-button>
+      </footer>
+    </page-reveal>
+  </nav-bar>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { IonButton } from "@ionic/vue";
+import NavBar from "@/layout/NavBar.vue";
+import PageReveal from "@/components/PageReveal.vue";
+import DayLoop from "@/components/onboarding/DayLoop.vue";
+import PointsLadder from "@/components/guide/PointsLadder.vue";
+import SpikeVsSteady from "@/components/guide/SpikeVsSteady.vue";
+import ChemistryMap from "@/components/guide/ChemistryMap.vue";
+import { useAppStore } from "@/stores/app";
+import { TIER_DAYS } from "../../../model/pricing";
+import { TEAM_SYNERGY_CAP } from "../../../model/scoring";
+import { STARTING_CREDITS } from "../../../model/team";
+
+/**
+ * The rules, for a player: what happens to you, in the order you meet it.
+ * Every number on this page is read from the shared game model rather than
+ * written into the copy, so the guide cannot quietly go out of date, and every
+ * figure is a picture of a rule the player can act on.
+ *
+ * Public on purpose (no session needed), which is why the closing call to
+ * action has a signed-out branch.
+ */
+const { t, locale } = useI18n();
+const appStore = useAppStore();
+
+const tiers = computed(() => [
+  { days: TIER_DAYS.SHORT, label: t("guide.contracts.shortDays") },
+  { days: TIER_DAYS.MEDIUM, label: t("guide.contracts.mediumDays") },
+  { days: TIER_DAYS.LONG, label: t("guide.contracts.longDays") },
+]);
+
+const startingCredits = computed(() =>
+  new Intl.NumberFormat(locale.value).format(STARTING_CREDITS)
+);
+
+const synergyCap = computed(() =>
+  new Intl.NumberFormat(locale.value).format(TEAM_SYNERGY_CAP)
+);
+</script>
+
+<style scoped>
+.guide {
+  max-width: 44rem;
+  margin: 0 auto;
+  padding: 1rem 0 1.5rem;
+}
+
+.guide-head {
+  padding-bottom: 2rem;
+}
+
+.guide-title {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+  line-height: 1.15;
+}
+
+@media (min-width: 768px) {
+  .guide-title {
+    font-size: 2.5rem;
+  }
+}
+
+.guide-lede {
+  margin: 0;
+  max-width: 32rem;
+  font-size: 1.0625rem;
+  line-height: 1.55;
+  color: var(--ion-color-medium);
+}
+
+/* Sections are separated by rule and rhythm rather than boxed into cards, so
+   the page reads as one document and the figures stay the loudest thing on it. */
+.guide-section {
+  padding: 2.25rem 0;
+  border-top: 1px solid var(--ion-border-color);
+}
+
+.section-title {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  line-height: 1.3;
+}
+
+.section-figure {
+  margin: 1.25rem 0;
+}
+
+.section-text {
+  margin: 0.75rem 0 0;
+  max-width: 38rem;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--ion-color-medium);
+}
+
+.section-text--lead {
+  margin-top: 0;
+}
+
+.tier-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 2.5rem;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  list-style: none;
+}
+
+.tier-row li {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+
+.tier-days {
+  font-size: 1.5rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--ion-color-primary);
+}
+
+.tier-label {
+  font-size: 0.875rem;
+  color: var(--ion-color-medium);
+}
+
+.rule-list {
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.rule-list dt {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--ion-text-color);
+}
+
+.rule-list dd {
+  margin: 0.2rem 0 0;
+  max-width: 38rem;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--ion-color-medium);
+}
+
+.guide-foot {
+  padding-top: 2rem;
+  border-top: 1px solid var(--ion-border-color);
+}
+</style>

--- a/frontend/src/views/MarketPage.vue
+++ b/frontend/src/views/MarketPage.vue
@@ -116,7 +116,13 @@
         </div>
 
         <!-- Desktop table -->
-        <div v-if="!isSearching" class="table-wrapper ion-hide-md-down">
+        <!-- data-tour: the onboarding tour rings the price column's table so
+             the player sees a real listing while it is explained. -->
+        <div
+          v-if="!isSearching"
+          data-tour="market"
+          class="table-wrapper ion-hide-md-down"
+        >
           <table class="market-table">
             <thead>
               <tr>
@@ -224,7 +230,9 @@
         </div>
 
         <!-- Mobile cards -->
-        <div v-if="!isSearching" class="ion-hide-md-up">
+        <!-- Carries data-tour too: only one of the two listings is ever
+             visible, and the tour rings whichever that is. -->
+        <div v-if="!isSearching" data-tour="market" class="ion-hide-md-up">
           <!-- Mobile sort chips -->
           <div class="mobile-sort-row">
             <span class="sort-label">{{ t("market.sortLabel") }}</span>

--- a/frontend/src/views/TeamCreationPage.vue
+++ b/frontend/src/views/TeamCreationPage.vue
@@ -1,233 +1,169 @@
 <template>
   <nav-bar>
-    <div class="team-creation-container">
-      <ion-card class="team-card">
-        <ion-card-header class="ion-text-center">
-          <div class="league-icon-container">
-            <span class="league-icon">{{ league?.icon }}</span>
-          </div>
-          <ion-card-title>Create Your Team</ion-card-title>
-          <p class="subtitle">
-            You're joining <strong>{{ league?.title }}</strong
-            >. Choose a unique name for your team.
-          </p>
-        </ion-card-header>
+    <page-reveal class="start-layout">
+      <section class="start-intro">
+        <p class="intro-eyebrow">{{ t("onboarding.start.eyebrow") }}</p>
+        <h1 class="intro-title">{{ t("onboarding.start.title") }}</h1>
+        <p class="intro-lede">{{ t("onboarding.start.lede") }}</p>
 
-        <ion-card-content>
-          <form @submit.prevent="handleSubmit">
-            <ion-label class="team-name-label">
-              <ion-icon :icon="shieldOutline" color="primary"></ion-icon>
-              Team Name
-            </ion-label>
+        <day-loop class="intro-loop" />
 
-            <ion-item
-              class="team-input-item"
-              lines="none"
-              :color="error ? 'danger' : ''"
-            >
-              <ion-input
-                placeholder="e.g. The Wiki Wizards"
-                v-model="teamName"
-                :maxlength="30"
-                @ionInput="error = ''"
-                autofocus
-              ></ion-input>
-            </ion-item>
+        <ul class="intro-facts">
+          <li>
+            <strong>
+              {{ t("onboarding.start.creditsValue", { credits }) }}
+            </strong>
+            {{ t("onboarding.start.credits") }}
+          </li>
+          <li>
+            <strong>{{ t("onboarding.start.slotsValue") }}</strong>
+            {{ t("onboarding.start.slots") }}
+          </li>
+          <li>
+            <strong>{{ t("onboarding.start.winValue") }}</strong>
+            {{ t("onboarding.start.win") }}
+          </li>
+        </ul>
+      </section>
 
-            <div class="input-footer">
-              <ion-text
-                :color="error ? 'danger' : 'medium'"
-                class="helper-text"
-              >
-                {{ error || "Must be unique within the league" }}
-              </ion-text>
-              <ion-text color="medium" class="char-count">
-                {{ teamName.length }}/30
-              </ion-text>
-            </div>
-
-            <ion-button
-              expand="block"
-              type="submit"
-              :disabled="isSubmitting || !teamName.trim()"
-              class="submit-button"
-            >
-              <ion-icon
-                :icon="sparklesOutline"
-                slot="start"
-                v-if="!isSubmitting"
-              ></ion-icon>
-              {{ isSubmitting ? "Creating..." : "Create Team & Start Playing" }}
-            </ion-button>
-          </form>
-        </ion-card-content>
-      </ion-card>
-    </div>
+      <section class="start-form">
+        <h2 class="form-title">{{ t("onboarding.start.formTitle") }}</h2>
+        <p class="form-hint">{{ t("onboarding.start.formHint") }}</p>
+        <team-creation-form @created="startPlaying" />
+      </section>
+    </page-reveal>
   </nav-bar>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed } from "vue";
 import { useRouter } from "vue-router";
-import { useQuery } from "@tanstack/vue-query";
-import {
-  IonCard,
-  IonCardHeader,
-  IonCardTitle,
-  IonCardContent,
-  IonItem,
-  IonInput,
-  IonButton,
-  IonIcon,
-  IonLabel,
-  IonText,
-} from "@ionic/vue";
-import { shieldOutline, sparklesOutline } from "ionicons/icons";
 import { useI18n } from "vue-i18n";
 import NavBar from "@/layout/NavBar.vue";
-import api from "@/services/api";
-import { useToast } from "@/composables/useToast";
-import { queryKeys } from "@/composables/queryKeys";
+import PageReveal from "@/components/PageReveal.vue";
+import DayLoop from "@/components/onboarding/DayLoop.vue";
+import TeamCreationForm from "@/components/TeamCreationForm.vue";
+import { useLeagueStore } from "@/stores/league";
+import { useOnboardingStore } from "@/stores/onboarding";
+import { STARTING_CREDITS } from "../../../model/team";
 
+/**
+ * First screen of a new player's game: what FantasyWiki is, next to the one
+ * form they have to fill in. The app chrome stays (so the language switcher in
+ * the NavBar is reachable here like everywhere else), and submitting the form
+ * hands straight over to the real dashboard with the guided tour running on
+ * top of it — no interstitial slideshow between signing up and playing.
+ */
+const { t, locale } = useI18n();
 const router = useRouter();
-const { t } = useI18n();
-const { showSuccess } = useToast();
+const leagueStore = useLeagueStore();
+const onboarding = useOnboardingStore();
 
-// New players aren't part of any league yet, so the league store (which only
-// holds leagues the player already has a team in) can't be used here. The
-// Global League is the league every new player joins on team creation.
-const { data: league } = useQuery({
-  queryKey: queryKeys.globalLeague(),
-  queryFn: () => api.leagues.getGlobal(),
-});
+const credits = computed(() =>
+  new Intl.NumberFormat(locale.value).format(STARTING_CREDITS)
+);
 
-const teamName = ref("");
-const isSubmitting = ref(false);
-const error = ref("");
-
-const handleSubmit = async () => {
-  const trimmed = teamName.value.trim();
-
-  if (!trimmed) {
-    error.value = "Team name is required.";
-    return;
-  }
-
-  if (trimmed.length < 3) {
-    error.value = "Team name must be at least 3 characters.";
-    return;
-  }
-
-  if (trimmed.length > 30) {
-    error.value = "Team name must be 30 characters or less.";
-    return;
-  }
-
-  error.value = "";
-  isSubmitting.value = true;
-
-  try {
-    await api.leagues.createMyTeam(league.value?.id ?? "", trimmed);
-  } catch (err) {
-    isSubmitting.value = false;
-    error.value = err instanceof Error ? err.message : "Failed to create team.";
-    return;
-  }
-
-  isSubmitting.value = false;
-
-  await showSuccess(
-    t("views.teamCreation.created", {
-      name: trimmed,
-      league: league.value?.title,
-    })
-  );
-
-  router.push("/dashboard");
-};
+async function startPlaying() {
+  // The player had no league a second ago, so the store NavBar populated on
+  // mount is empty and the dashboard would render its "no league" card.
+  // Refetching here is what makes the next screen the *populated* dashboard.
+  await leagueStore.initialize();
+  // Land on the dashboard first, then start narrating it: starting the tour
+  // while still on this page would make the dock issue the same navigation a
+  // moment before this one does.
+  await router.push("/dashboard");
+  onboarding.start();
+}
 </script>
 
 <style scoped>
-.team-creation-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100%;
+.start-layout {
+  display: grid;
+  gap: 2rem;
+  max-width: 62rem;
+  margin: 0 auto;
+  padding: 1rem 0 2rem;
 }
 
-.team-card {
-  width: 100%;
-  max-width: 450px;
-  box-shadow: none;
-  border: 1px solid var(--ion-border-color);
-  border-radius: 0.5rem;
+/* Side by side once there is room; the intro keeps reading order above the
+   form when stacked. */
+@media (min-width: 992px) {
+  .start-layout {
+    grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+    gap: 3.5rem;
+    align-items: start;
+    padding-top: 2.5rem;
+  }
 }
 
-.league-icon-container {
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0 auto 16px;
-  background: rgba(var(--ion-color-primary-rgb), 0.1);
+.intro-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ion-color-primary);
 }
 
-.league-icon {
-  font-size: 32px;
+.intro-title {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+  line-height: 1.15;
 }
 
-ion-card-title {
-  font-size: 1.5rem;
-  line-height: 2rem;
+@media (min-width: 768px) {
+  .intro-title {
+    font-size: 2.5rem;
+  }
 }
 
-.subtitle {
+.intro-lede {
+  margin: 0 0 2rem;
+  max-width: 34rem;
+  font-size: 1.0625rem;
+  line-height: 1.55;
   color: var(--ion-color-medium);
-  font-size: 14px;
-  margin-top: 8px;
 }
 
-.team-name-label {
+.intro-loop {
+  max-width: 30rem;
+  margin-bottom: 2rem;
+}
+
+.intro-facts {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  font-weight: 500;
-  margin-bottom: 8px;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.75rem;
+  margin: 0;
+  padding: 1rem 0 0;
+  border-top: 1px solid var(--ion-border-color);
+  list-style: none;
+  font-size: 0.875rem;
+  color: var(--ion-color-medium);
 }
 
-.team-input-item {
+.intro-facts strong {
+  font-weight: 700;
+  color: var(--ion-text-color);
+}
+
+.start-form {
+  padding: 1.5rem;
   border: 1px solid var(--ion-border-color);
-  border-radius: 8px;
-  --padding-start: 16px;
-  margin-bottom: 8px;
+  border-radius: 12px;
+  background: var(--ion-background-color-step-50);
 }
 
-.team-input-item:focus-within {
-  border-color: var(--ion-color-primary);
-  box-shadow: 0 0 0 2px rgba(var(--ion-color-primary-rgb), 0.2);
+.form-title {
+  margin: 0 0 0.35rem;
+  font-size: 1.25rem;
+  line-height: 1.3;
 }
 
-.team-input-item[color="danger"] {
-  border-color: var(--ion-color-danger);
-}
-
-.input-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 24px;
-  padding: 0 4px;
-}
-
-.helper-text,
-.char-count {
-  font-size: 12px;
-}
-
-.submit-button {
-  margin-top: 24px;
+.form-hint {
+  margin: 0 0 1.5rem;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--ion-color-medium);
 }
 </style>

--- a/frontend/src/views/TeamPage.vue
+++ b/frontend/src/views/TeamPage.vue
@@ -72,7 +72,9 @@
       />
 
       <!-- Pitch -->
+      <!-- data-tour: rung of the onboarding tour (chemistry step). -->
       <TeamFormation
+        data-tour="formation"
         :formation="draftFormation"
         :swap-mode="swapMode"
         :swap-source="swapSource"

--- a/frontend/src/views/auth/AuthCallbackPage.vue
+++ b/frontend/src/views/auth/AuthCallbackPage.vue
@@ -48,6 +48,10 @@ onMounted(async () => {
   try {
     const response = await sessionApi.get();
     appStore.setUserFromData(response);
+    // A brand-new player has no team yet, so their first screen is the one
+    // that creates it. That page carries the welcome and the objective beside
+    // the form, and hands over to the real dashboard (with the guided tour
+    // running on it) the moment the team exists — no interstitial tour route.
     const isNewPlayer = route.query.new === "1";
     router.replace(isNewPlayer ? "/team-creation" : "/home");
   } catch {


### PR DESCRIPTION
Team creation is now the game's first screen inside the normal app
  chrome, handing off straight into the real, populated dashboard, where
  a non-blocking tour dock narrates the live UI (dashboard, league
  switcher, market, team management, pitch) instead of a separate
  carousel. The written /guide reference is public, figure-first, and
  reads every number from the shared game model instead of hardcoding
  it, so it can't drift out of sync with the scoring/pricing rules.