### PR TITLE
feat: show popup when a player does not have a team in a league (#511)

### DIFF
--- a/backend/src/services/league.ts
+++ b/backend/src/services/league.ts
@@ -1,11 +1,14 @@
-import { League } from "../../../model";
+import { GLOBAL_LEAGUE_ID, League } from "../../../model";
 import { LeagueDTO } from "../../../dto/leagueDTO";
 import { Domain } from "../../../model/enums";
 import { LeagueRepository } from "../repositories/leagueRepository";
 import { LeagueRepositoryD1 } from "../repositories/d1/leagueRepositoryD1";
 import { Result, success } from "../repositories/result";
 
-export const GLOBAL_LEAGUE_ID = "global";
+// Re-exported for existing importers; the source of truth lives in the shared
+// model so the frontend can reason about the same league without duplicating
+// the id.
+export { GLOBAL_LEAGUE_ID };
 
 /**
  * Map a domain League to the LeagueDTO shape returned by the API.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,6 +4,10 @@
     <!-- The tour narrates real pages, so it lives above the outlet rather than
          inside any one view: it has to survive the navigation it triggers. -->
     <tour-dock />
+    <!-- Guards the whole app against a teamless authenticated player (an
+         interrupted first run); lives here for the same reason the tour does —
+         it must outlast the page it sends the player to. -->
+    <team-required-modal />
   </ion-app>
 </template>
 
@@ -11,6 +15,7 @@
 import { onMounted, onUnmounted } from "vue";
 import { IonApp, IonRouterOutlet } from "@ionic/vue";
 import TourDock from "@/components/onboarding/TourDock.vue";
+import TeamRequiredModal from "@/components/onboarding/TeamRequiredModal.vue";
 import { useAppStore } from "@/stores/app";
 
 // The store applies the resolved theme when it is created; all we own here is

--- a/frontend/src/components/onboarding/TeamRequiredModal.vue
+++ b/frontend/src/components/onboarding/TeamRequiredModal.vue
@@ -1,0 +1,114 @@
+<template>
+  <!--
+    Re-proposes an interrupted first run. A brand-new player is sent to
+    `/team-creation` by the auth callback, but that is a one-shot signal
+    (`?new=1`): a player who closes the browser mid-onboarding, before naming a
+    team, comes back authenticated with no team in any league and nothing to
+    prompt them again — the dashboard just shows its "no league" card and the
+    game is unreachable (issue #475).
+
+    This modal closes that gap from state rather than from a URL flag: whenever
+    an authenticated player is known to have no team, it stands in front of the
+    app until they go create one. Membership, not a query param, is the trigger,
+    so it works no matter how the session was restored (fresh login *or* an
+    existing cookie on app boot).
+  -->
+  <ion-modal
+    :is-open="isOpen"
+    css-class="login-modal"
+    :backdrop-dismiss="false"
+    :keyboard-close="false"
+  >
+    <div class="team-required-card">
+      <ion-icon :icon="trophyOutline" class="team-required-icon" />
+      <h2 class="team-required-title">
+        {{ t("onboarding.teamRequired.title") }}
+      </h2>
+      <ion-text color="medium" class="team-required-lede">
+        <p>{{ t("onboarding.teamRequired.body") }}</p>
+      </ion-text>
+      <ion-button
+        expand="block"
+        class="team-required-cta"
+        @click="goToTeamCreation"
+      >
+        {{ t("onboarding.teamRequired.cta") }}
+      </ion-button>
+    </div>
+  </ion-modal>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { IonModal, IonButton, IonIcon, IonText } from "@ionic/vue";
+import { trophyOutline } from "ionicons/icons";
+import { useI18n } from "vue-i18n";
+import { useAppStore } from "@/stores/app";
+import { useLeagueStore } from "@/stores/league";
+
+const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
+const appStore = useAppStore();
+const leagueStore = useLeagueStore();
+
+// Only the in-app screens that assume a team: the dashboard, the pitch, the
+// market and the league list. Public pages (landing, guide, legal) and the
+// team-creation flow itself are left alone, so the prompt reaches the player
+// where the missing team actually blocks them rather than the instant they sign
+// in. Naming the routes that opt *in* keeps a new public page from accidentally
+// inheriting the block.
+const TEAM_SCOPED_ROUTES = new Set(["Dashboard", "Leagues", "Team", "Market"]);
+
+// `hasGlobalTeam` is undefined until the league list has been fetched, which
+// keeps the modal from flashing on the not-yet-loaded state.
+const isOpen = computed(
+  () =>
+    appStore.isAuthenticated &&
+    leagueStore.hasGlobalTeam === false &&
+    typeof route.name === "string" &&
+    TEAM_SCOPED_ROUTES.has(route.name)
+);
+
+function goToTeamCreation() {
+  router.push("/team-creation");
+}
+</script>
+
+<style scoped>
+.team-required-card {
+  padding: 2.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.25rem;
+}
+
+.team-required-icon {
+  font-size: 3.5rem;
+  color: var(--ion-color-primary);
+}
+
+.team-required-title {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.team-required-lede {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.team-required-lede p {
+  margin: 0;
+}
+
+.team-required-cta {
+  width: 100%;
+  --border-radius: 8px;
+  height: 48px;
+}
+</style>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -475,6 +475,11 @@
       "formTitle": "Name your team",
       "formHint": "Next stop is your dashboard, with the tour running beside it."
     },
+    "teamRequired": {
+      "title": "Create your team to start playing",
+      "body": "You are signed in but have not named a team yet. Create one to join the Global League and start playing.",
+      "cta": "Create my team"
+    },
     "loop": {
       "caption": "How a day scores",
       "holdValue": "1 article",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -475,6 +475,11 @@
       "formTitle": "Dai un nome alla squadra",
       "formHint": "Subito dopo arrivi alla tua dashboard, con il tour al fianco."
     },
+    "teamRequired": {
+      "title": "Crea la tua squadra per iniziare",
+      "body": "Hai effettuato l'accesso ma non hai ancora dato un nome a una squadra. Creane una per entrare nella Lega Globale e iniziare a giocare.",
+      "cta": "Crea la mia squadra"
+    },
     "loop": {
       "caption": "Come si segna in un giorno",
       "holdValue": "1 articolo",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -15,6 +15,7 @@ import ReportProblemPage from "@/views/ReportProblemPage.vue";
 import NotFoundPage from "@/views/NotFoundPage.vue";
 import { useAppStore } from "@/stores/app";
 import { useLeagueStore } from "@/stores/league";
+import { GLOBAL_LEAGUE_ID } from "../../../model/league";
 
 /**
  * Keeps team creation out of reach of a player who has nothing left to create.
@@ -31,6 +32,12 @@ import { useLeagueStore } from "@/stores/league";
  * fetch leaves that list empty and lets the player through on purpose: the
  * backend still refuses a duplicate, whereas redirecting on error would lock a
  * genuinely new player out of the only screen that starts the game.
+ *
+ * The league the entry is checked against is the one the page will actually
+ * create in: the route's when it names one, the Global League otherwise. It is
+ * deliberately not "is in any league" — that reading would turn away a player
+ * who holds a team elsewhere but still owes their Global League one, which is
+ * exactly who TeamRequiredModal sends here.
  */
 async function rejectIfTeamAlreadyExists(to: RouteLocationNormalized) {
   const leagueStore = useLeagueStore();
@@ -38,10 +45,11 @@ async function rejectIfTeamAlreadyExists(to: RouteLocationNormalized) {
     await leagueStore.fetchLeagues();
   }
 
-  const leagueId = to.params.leagueId as string | undefined;
-  const alreadyPlaying = leagueId
-    ? leagueStore.availableLeagues.some((lg) => lg.id === leagueId)
-    : leagueStore.availableLeagues.length > 0;
+  const leagueId =
+    (to.params.leagueId as string | undefined) ?? GLOBAL_LEAGUE_ID;
+  const alreadyPlaying = leagueStore.availableLeagues.some(
+    (lg) => lg.id === leagueId
+  );
 
   return alreadyPlaying ? "/dashboard" : true;
 }

--- a/frontend/src/stores/league.ts
+++ b/frontend/src/stores/league.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 import api, { deserializeLeague } from "@/services/api";
 import { LeagueDTO } from "../../../dto/leagueDTO";
+import { GLOBAL_LEAGUE_ID } from "../../../model/league";
 import { Temporal } from "@js-temporal/polyfill";
 import Now = Temporal.Now;
 
@@ -31,6 +32,13 @@ export const useLeagueStore = defineStore("league", () => {
   const currentLeague = ref<LeagueDTO>();
   const availableLeagues = ref<LeagueDTO[]>([]);
   const isLoading = ref(false);
+  // Whether the league list has been fetched *successfully* at least once this
+  // session. An empty `availableLeagues` is ambiguous on its own — it reads the
+  // same before the first fetch, after a failed one, and for a player who
+  // genuinely has no team — so this flag is what lets callers (e.g. the "create
+  // your team" prompt) tell them apart instead of firing on a state they only
+  // believe because the request never came back.
+  const hasLoaded = ref(false);
   const error = ref<string | null>(null);
 
   // ── Getters ────────────────────────────────────────────────────────────────
@@ -39,6 +47,18 @@ export const useLeagueStore = defineStore("league", () => {
 
   const currentLeagueName = computed(
     () => currentLeague.value?.title ?? "No League Selected"
+  );
+
+  // Whether the player has completed onboarding: a team in the Global League,
+  // the one membership the first run creates. Deliberately *not* "is in any
+  // league" — once a player can join further leagues, someone could hold a team
+  // elsewhere while still owing their Global League team, and that player is
+  // exactly who the re-prompt is for. Undefined until the first fetch resolves,
+  // so callers can distinguish "no team" from "not known yet".
+  const hasGlobalTeam = computed(() =>
+    hasLoaded.value
+      ? availableLeagues.value.some((lg) => lg.id === GLOBAL_LEAGUE_ID)
+      : undefined
   );
 
   // ── Helpers ────────────────────────────────────────────────────────────────
@@ -81,6 +101,10 @@ export const useLeagueStore = defineStore("league", () => {
     try {
       availableLeagues.value = await api.leagues.getAll();
       _resolveCurrentLeague();
+      // Success only: a failed fetch leaves `availableLeagues` empty, which is
+      // indistinguishable from "player has no team". Marking that as loaded
+      // would tell an established player they own nothing — see `hasGlobalTeam`.
+      hasLoaded.value = true;
     } catch (err) {
       error.value =
         err instanceof Error ? err.message : "Failed to fetch leagues";
@@ -132,10 +156,12 @@ export const useLeagueStore = defineStore("league", () => {
     currentLeague,
     availableLeagues,
     isLoading,
+    hasLoaded,
     error,
     // Getters
     currentLeagueId,
     currentLeagueName,
+    hasGlobalTeam,
     // Actions
     setCurrentLeague,
     fetchLeagues,

--- a/frontend/src/tests/TeamCreationGuard.spec.ts
+++ b/frontend/src/tests/TeamCreationGuard.spec.ts
@@ -53,6 +53,16 @@ describe("team creation route guard", () => {
     expect(await typePath("/team-creation")).toBe("/team-creation");
   });
 
+  it("lets a player who still owes their Global League team into signup", async () => {
+    // Signup creates in the Global League, so that is the only membership that
+    // can make it pointless. A team in another league does not — and this is
+    // the player TeamRequiredModal sends here, so turning them away would bounce
+    // them straight back into a modal they cannot dismiss.
+    mockMyLeagues(["italy"]);
+
+    expect(await typePath("/team-creation")).toBe("/team-creation");
+  });
+
   it("keeps a league the player is already in away from them", async () => {
     mockMyLeagues(["global", "italy"]);
 

--- a/frontend/src/tests/TeamRequiredModal.spec.ts
+++ b/frontend/src/tests/TeamRequiredModal.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+import { http, HttpResponse } from "msw";
+import { server } from "@/mocks/server";
+import { IonModal } from "@ionic/vue";
+import router from "@/router/index";
+import TeamRequiredModal from "@/components/onboarding/TeamRequiredModal.vue";
+import { useAppStore } from "@/stores/app";
+import { useLeagueStore } from "@/stores/league";
+import type { LeagueDTO } from "../../../dto/leagueDTO";
+import { GLOBAL_LEAGUE_ID } from "../../../model/league";
+
+/**
+ * The modal is the safety net for an interrupted first run (issue #475): a
+ * player who signs in but never names a team is stranded with no team in any
+ * league, and the one-shot `?new=1` signal that first routed them to signup is
+ * long gone. It re-proposes team creation from membership state, so these tests
+ * drive the league store directly rather than the route.
+ */
+let pinia: Pinia;
+
+function signIn() {
+  useAppStore().setUserFromData({
+    sub: "player-1",
+    email: "player@example.com",
+    name: "Player One",
+    picture: "",
+  });
+}
+
+/** Mark the league list as fetched, with or without a team in it. */
+function setTeams(leagues: LeagueDTO[]) {
+  const store = useLeagueStore();
+  store.availableLeagues = leagues;
+  store.hasLoaded = true;
+}
+
+/** Mount on whatever route the router is currently on. */
+async function mountHere() {
+  const wrapper = mount(TeamRequiredModal, {
+    global: { plugins: [pinia, router] },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+async function mountModal(path = "/dashboard") {
+  await router.push(path);
+  await router.isReady();
+  return mountHere();
+}
+
+function isOpen(wrapper: Awaited<ReturnType<typeof mountModal>>) {
+  return wrapper.findComponent(IonModal).props("isOpen");
+}
+
+describe("TeamRequiredModal.vue", () => {
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    localStorage.clear();
+  });
+
+  it("prompts an authenticated player who has no team", async () => {
+    signIn();
+    setTeams([]);
+
+    expect(isOpen(await mountModal())).toBe(true);
+  });
+
+  it("prompts a player who is in another league but not the Global League", async () => {
+    // Forward-looking: joining further leagues is coming, and a player can hold
+    // a team elsewhere while still owing their mandatory Global League team.
+    // That player has not finished onboarding, so they are still prompted.
+    signIn();
+    setTeams([{ id: "italy" } as LeagueDTO]);
+
+    expect(isOpen(await mountModal())).toBe(true);
+  });
+
+  it("stays hidden while the league list has not been fetched yet", async () => {
+    // Empty-and-unloaded reads the same as empty-and-teamless; the modal must
+    // wait for the fetch rather than flash on the initial state.
+    signIn();
+
+    expect(isOpen(await mountModal())).toBe(false);
+  });
+
+  it("stays hidden when the league list could not be fetched", async () => {
+    // A failed fetch leaves the list empty, which reads exactly like "no team".
+    // Prompting on it would put an established player behind a modal they
+    // cannot dismiss, whose only exit is a form the backend then rejects.
+    server.use(http.get("*/api/leagues", () => HttpResponse.error()));
+    signIn();
+    await useLeagueStore().fetchLeagues();
+
+    expect(isOpen(await mountModal())).toBe(false);
+  });
+
+  it("stays hidden for a player who has their Global League team", async () => {
+    signIn();
+    setTeams([{ id: GLOBAL_LEAGUE_ID } as LeagueDTO]);
+
+    expect(isOpen(await mountModal())).toBe(false);
+  });
+
+  it("stays hidden for a signed-out visitor", async () => {
+    // The route has to be a team-scoped one for this to test anything: pushing
+    // /dashboard while signed out is bounced to /home by the auth guard, and
+    // "Home" is out of TEAM_SCOPED_ROUTES anyway, so the assertion would hold
+    // with the authentication check deleted. Navigate first, sign out after.
+    signIn();
+    setTeams([]);
+    await router.push("/dashboard");
+    useAppStore().isAuthenticated = false;
+
+    const wrapper = await mountHere();
+
+    expect(router.currentRoute.value.name).toBe("Dashboard");
+    expect(isOpen(wrapper)).toBe(false);
+  });
+
+  it("does not cover the team-creation page it sends the player to", async () => {
+    // The team-creation guard re-fetches the league list to decide entry; a
+    // teamless player has none, which is what lets them onto the page.
+    server.use(http.get("*/api/leagues", () => HttpResponse.json([])));
+    signIn();
+    setTeams([]);
+
+    expect(isOpen(await mountModal("/team-creation"))).toBe(false);
+  });
+
+  it("stays out of public pages like the landing page", async () => {
+    // The prompt belongs on the in-app screens a team is needed for, not the
+    // moment a teamless player lands on the marketing home.
+    signIn();
+    setTeams([]);
+
+    expect(isOpen(await mountModal("/home"))).toBe(false);
+  });
+
+  it("guards the team-scoped screens a player without a team reaches", async () => {
+    signIn();
+    setTeams([]);
+
+    for (const path of ["/dashboard", "/team", "/market", "/leagues"]) {
+      expect(isOpen(await mountModal(path)), path).toBe(true);
+    }
+  });
+});

--- a/model/league.ts
+++ b/model/league.ts
@@ -1,5 +1,15 @@
 import { Temporal } from "@js-temporal/polyfill";
 
+/**
+ * The league every player is enrolled in by naming their first team; it is the
+ * one league membership onboarding is responsible for. Its id is fixed rather
+ * than discovered so both sides of the API agree on which league "the Global
+ * League" is without a round-trip. Kept here, in the shared model, because
+ * backend and frontend both reason about it (creation, and enforcing that a
+ * first-run player has a team in it) and must not drift apart.
+ */
+export const GLOBAL_LEAGUE_ID = "global";
+
 export interface League {
   id: string;
   name: string;


### PR DESCRIPTION
* chore(deps): update dependency @ionic/vue to v8.8.16 (#497)



* fix(frontend): re-prompt team creation for a teamless player

A player who signs in for the first time but closes the browser during onboarding, before naming a team, comes back authenticated with no team in any league. The only signal that routed them to team creation is the one-shot `?new=1` query param on the auth callback, so on their next visit they land on the app with nothing to prompt them again and the Global League is unreachable (issue #475).

Add a global, non-dismissible "create your team" modal that stands in front of the app whenever an authenticated player is known to have no team, driven by membership state rather than a URL flag so it works however the session was restored (fresh login or an existing cookie on app boot). It suppresses itself on the team-creation routes it sends the player to, and waits for the league list to load before appearing so it never flashes on the not-yet-fetched state.


Claude-Session: https://claude.ai/code/session_01Vzq1UKtXyczymPo2DuXud1

* refactor: key the team re-prompt on the Global League, not any league

A player will be able to join multiple leagues in the future, so "is in any league" no longer means "has completed onboarding": someone could hold a team in another league while still owing their mandatory Global League team. That player is exactly who the re-prompt is for.

Check membership of the Global League specifically instead of a non-empty league list. The Global League id becomes a single source of truth in the shared model (`GLOBAL_LEAGUE_ID`), re-exported from the backend league service so existing importers keep working and the frontend reasons about the same league without duplicating the id.


Claude-Session: https://claude.ai/code/session_01Vzq1UKtXyczymPo2DuXud1

* fix(frontend): scope the team re-prompt to the in-app team screens

The prompt was standing in front of every authenticated screen, including the public landing page and the guide, the moment a teamless player signed in. Restrict it to the routes that actually assume a team — dashboard, pitch, market and league list — via an opt-in allow-list, so a new public page can't accidentally inherit the block and the prompt reaches the player where the missing team blocks them.


Claude-Session: https://claude.ai/code/session_01Vzq1UKtXyczymPo2DuXud1

* fix(frontend): keep the team re-prompt off states it cannot back up

Two ways the non-dismissible prompt could trap a player who has nothing to create:

- `hasLoaded` was set in a `finally`, so a failed `/api/leagues` fetch counted as loaded. The empty list that a failure leaves behind reads exactly like "no team", so a transient outage put an established player behind the modal, whose only exit is a form the backend then rejects (`teams` is `UNIQUE (playerId, leagueId)`). It now flips on success only, leaving `hasGlobalTeam` undefined and the modal closed.

- `rejectIfTeamAlreadyExists` read the param-less route as "is in any league", while the modal targets "owes the Global League team". A player holding a team elsewhere was bounced from the page the modal sends them to, straight back into the modal. The guard now checks the league the page actually creates in: the route's, or the Global League.

Also fixes the signed-out modal test, which the auth guard redirected to /home — a route outside TEAM_SCOPED_ROUTES, so it passed without ever exercising the `isAuthenticated` term.



---------