### PR TITLE
feat: add the Article Genie for finding articles in the market 

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -121,6 +121,18 @@ _Avoid_: budget cap, hard cap
 A **+10%-per-consecutive-renewal** cost premium on holding the same article, resetting after dropping it for at least one cycle (ADR 0003, retained). The economy's anti-hoard sink — unaffected by the removal of the transaction fee, since it solves a different problem (hoarding one article vs. daily churn).
 _Avoid_: tax, penalty
 
+**Article Genie**:
+The market-page assistant that finds articles a player cannot name exactly (ADR 0006). It serves two intents through one input: **chemistry scouting** ("find me a relation between OpenAI and Portugal") and **tip-of-the-tongue recall** ("the female mathematician who worked at NASA"). It never invents a title — it seeds a bounded list of real articles from search and uses an LLM only to narrow it through questions. When the daily model quota is exhausted the Genie is **asleep** and the market falls back to the ordinary search bar.
+_Avoid_: Akinator assistant, AI search, chatbot
+
+**Genie Turn**:
+One question-and-answer exchange with the **Article Genie**, carrying the surviving **Candidate Set** forward. A turn asks either a *filter* question, which partitions the set, or a *preference* question, which only re-ranks it.
+_Avoid_: prompt, message, round
+
+**Candidate Set**:
+The bounded list of real article titles the **Article Genie** narrows. Seeded from search results and, when the player names anchors, from articles linked in either direction with those anchors. Ranked by mutual links first and **Contract Price** second, so cheap well-connected articles outrank expensive ones with the same chemistry.
+_Avoid_: candidates (bare), search results, shortlist
+
 ## Relationships
 
 - A **Top Read Snapshot** belongs to exactly one **Project Domain**
@@ -139,6 +151,8 @@ _Avoid_: tax, penalty
 - A **Formation Schema** defines a set of **Positions** and **Chemistry Links**
 - A **Chemistry Link** connects exactly two **Positions**
 - A **Formation** assigns a contract to each required **Position** and carries a **Chemistry Level** for each **Chemistry Link**
+- The **Article Genie** narrows a **Candidate Set** through successive **Genie Turns**
+- A **Candidate Set** contains article titles, never invented ones, and is ranked by mutual links then **Contract Price**
 
 ## Example dialogue
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,7 +7,9 @@ import session from "./routes/session";
 import leagues from "./routes/leagues";
 import notifications from "./routes/notifications";
 import player from "./routes/player";
+import me from "./routes/me";
 import reports from "./routes/reports";
+import type { WorkersAiBinding } from "./services/llmClient";
 import internal from "./routes/internal";
 import type { ContractSettlementParams } from "./workflows/contractSettlement";
 
@@ -25,6 +27,10 @@ type Bindings = {
   GITHUB_REPO: string;
   ENVIRONMENT: string;
   REPORT_RATE_LIMITER: {
+    limit(o: { key: string }): Promise<{ success: boolean }>;
+  };
+  AI: WorkersAiBinding;
+  GENIE_RATE_LIMITER: {
     limit(o: { key: string }): Promise<{ success: boolean }>;
   };
   CONTRACT_SETTLEMENT_WORKFLOW: Workflow<ContractSettlementParams>;
@@ -74,6 +80,9 @@ app.route("/api/notifications", notifications);
 
 // Mount player routes
 app.route("/api/player", player);
+
+// Mount self-scoped player routes (/api/me — identity from the JWT)
+app.route("/api/me", me);
 
 // Mount problem report routes
 app.route("/api/reports", reports);

--- a/backend/src/routes/me.ts
+++ b/backend/src/routes/me.ts
@@ -1,0 +1,134 @@
+import { Hono } from "hono";
+import {
+  GENIE_ERRORS,
+  GenieSeedRequest,
+  GenieTurnRequest,
+} from "../../../dto/genieDTO";
+import { ArticleGenieService } from "../services/articleGenie";
+import { WorkersAiBinding, createLlmClient } from "../services/llmClient";
+import { playerErrorStatus, resolveCurrentPlayer } from "./helpers";
+
+interface RateLimiter {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+type Bindings = {
+  db: D1Database;
+  AI: WorkersAiBinding;
+  GENIE_RATE_LIMITER: RateLimiter;
+};
+
+/**
+ * Self-scoped routes for the authenticated player: identity comes from the JWT
+ * and no `playerId` is ever accepted from the client
+ * (docs/development/api-naming-rules.md).
+ */
+const me = new Hono<{ Bindings: Bindings }>();
+
+/**
+ * Everything the client got wrong about its own request. The Genie is additive,
+ * so none of these should ever reach a player — they mean the frontend built a
+ * payload it shouldn't have, and a 400 says so instead of burning a model call.
+ */
+const VALIDATION_ERRORS: string[] = [
+  GENIE_ERRORS.MALFORMED_BODY,
+  GENIE_ERRORS.QUERY_REQUIRED,
+  GENIE_ERRORS.QUERY_TOO_LONG,
+  GENIE_ERRORS.TOO_MANY_CANDIDATES,
+  GENIE_ERRORS.NO_CANDIDATES,
+  GENIE_ERRORS.HISTORY_TOO_LONG,
+  GENIE_ERRORS.INVALID_BUCKET,
+  GENIE_ERRORS.DUPLICATE_CANDIDATE_ID,
+];
+
+/**
+ * Reads the player's opening text into the searches that seed the candidate
+ * set, so the browser can go and run them.
+ *
+ * Separate from a turn only because of ordering: a turn is defined over a
+ * candidate list, and there is no list until the query has been read. Seeding a
+ * chemistry query on keywords alone would have the Genie open with a question
+ * about articles *describing* OpenAI rather than ones relating it to Portugal.
+ */
+me.post("/genie-seeds", async (c) => {
+  const playerResult = await resolveCurrentPlayer(c);
+  if (!playerResult.ok) {
+    return c.json(
+      { error: playerResult.error },
+      playerErrorStatus(playerResult.error),
+    );
+  }
+
+  const { success } = await c.env.GENIE_RATE_LIMITER.limit({
+    key: playerResult.value.id,
+  });
+  if (!success) {
+    return c.json({ error: GENIE_ERRORS.RATE_LIMITED }, 429);
+  }
+
+  let request: GenieSeedRequest;
+  try {
+    request = await c.req.json<GenieSeedRequest>();
+  } catch {
+    return c.json({ error: GENIE_ERRORS.MALFORMED_BODY }, 400);
+  }
+
+  const service = new ArticleGenieService(createLlmClient(c.env.AI));
+  const result = await service.seed(request);
+
+  if (!result.ok) {
+    const status = VALIDATION_ERRORS.includes(result.error) ? 400 : 503;
+    return c.json({ error: result.error }, status);
+  }
+
+  return c.json(result.value);
+});
+
+/**
+ * One turn of the Article Genie (ADR 0006). The Worker does exactly one thing
+ * here — call the model — because every other part of the feature is cheaper in
+ * the browser: the Wikimedia search and link fetches run against the client's
+ * 7-day cache, where neither the 50-subrequest nor the 10 ms CPU limit applies.
+ *
+ * A session is several requests in quick succession, so the rate limiter is
+ * sized for real play rather than for abuse; the day's neuron allocation is the
+ * real ceiling, and it fails closed on its own.
+ */
+me.post("/genie-turns", async (c) => {
+  const playerResult = await resolveCurrentPlayer(c);
+  if (!playerResult.ok) {
+    return c.json(
+      { error: playerResult.error },
+      playerErrorStatus(playerResult.error),
+    );
+  }
+
+  const { success } = await c.env.GENIE_RATE_LIMITER.limit({
+    key: playerResult.value.id,
+  });
+  if (!success) {
+    return c.json({ error: GENIE_ERRORS.RATE_LIMITED }, 429);
+  }
+
+  let request: GenieTurnRequest;
+  try {
+    request = await c.req.json<GenieTurnRequest>();
+  } catch {
+    return c.json({ error: GENIE_ERRORS.MALFORMED_BODY }, 400);
+  }
+
+  const service = new ArticleGenieService(createLlmClient(c.env.AI));
+  const result = await service.takeTurn(request);
+
+  if (!result.ok) {
+    // Anything that is not the client's fault is the genie being asleep, which
+    // the frontend answers by dismissing to the ordinary search bar. 503 rather
+    // than 502: the day's allocation coming back is a matter of waiting.
+    const status = VALIDATION_ERRORS.includes(result.error) ? 400 : 503;
+    return c.json({ error: result.error }, status);
+  }
+
+  return c.json(result.value);
+});
+
+export default me;

--- a/backend/src/services/articleGenie.ts
+++ b/backend/src/services/articleGenie.ts
@@ -1,0 +1,462 @@
+import {
+  GENIE_ERRORS,
+  GENIE_MAX_ANCHORS,
+  GENIE_MAX_CANDIDATES,
+  GENIE_MAX_HISTORY,
+  GENIE_MAX_QUERY_CHARS,
+  GENIE_UNSURE_ANSWER,
+  GenieCandidateDTO,
+  GenieQuestionKind,
+  GenieSeedRequest,
+  GenieSeedResponse,
+  GenieTurnRequest,
+  GenieTurnResponse,
+  isGenieBucket,
+  isGenieQuestionKind,
+} from "../../../dto/genieDTO";
+import { Result, failure, success } from "../repositories/result";
+import { LlmClient, LlmMessage } from "./llmClient";
+
+/**
+ * Runs one turn of the Article Genie: the model is handed a bounded list of
+ * *real* Wikipedia articles and asked to narrow it, never to name one.
+ * Hallucinating a title is impossible by construction (ADR 0006), which leaves
+ * misclassification as the failure mode this service defends against.
+ *
+ * The defences are here rather than in the prompt because a prompt is a request
+ * and this is a guarantee:
+ *
+ * - ids outside the supplied list are discarded, not trusted;
+ * - a *preference* question keeps everything, so it can only ever re-rank;
+ * - an "unsure" answer keeps everything, so a question the player cannot answer
+ *   never costs them the article;
+ * - a turn that would empty the set restores it instead.
+ */
+export class ArticleGenieService {
+  constructor(private readonly llm: LlmClient) {}
+
+  /**
+   * Reads the opening text into the searches that seed the candidate set.
+   *
+   * The keyword query is never omitted, even when anchors are found: both
+   * searches run and are merged, so a misparse costs surplus candidates that
+   * the narrowing loop already exists to strip, rather than silently deleting
+   * the article the player wanted.
+   *
+   * Falls back to the raw query as keywords rather than failing — a query the
+   * model could not parse is still a perfectly good search term.
+   */
+  async seed(request: GenieSeedRequest): Promise<Result<GenieSeedResponse>> {
+    const query = request?.query?.trim() ?? "";
+    if (query.length === 0) {
+      return failure(GENIE_ERRORS.QUERY_REQUIRED);
+    }
+    if (query.length > GENIE_MAX_QUERY_CHARS) {
+      return failure(GENIE_ERRORS.QUERY_TOO_LONG);
+    }
+
+    let raw: string;
+    try {
+      raw = await this.llm.ask([
+        { role: "system", content: SEED_PROMPT },
+        { role: "user", content: query },
+      ]);
+    } catch {
+      return failure(GENIE_ERRORS.ASLEEP);
+    }
+
+    return success(parseSeed(raw, query));
+  }
+
+  async takeTurn(
+    request: GenieTurnRequest,
+  ): Promise<Result<GenieTurnResponse>> {
+    const validation = validate(request);
+    if (!validation.ok) {
+      return validation;
+    }
+
+    const messages = buildMessages(request);
+
+    // One retry, for the two things worth asking again about: a reply that was
+    // not JSON, and a question the Genie has already asked. Both are usually
+    // fixed by being told so. A quota or transport failure is not retried —
+    // it would fail again identically and only spend the player's wait.
+    let raw: string;
+    try {
+      raw = await this.llm.ask(messages);
+    } catch {
+      return failure(GENIE_ERRORS.ASLEEP);
+    }
+
+    let parsed = parseTurn(raw);
+    const instruction = !parsed
+      ? RETRY_INSTRUCTION
+      : isRepeat(parsed, request)
+        ? REPEAT_INSTRUCTION
+        : null;
+
+    if (instruction) {
+      try {
+        raw = await this.llm.ask([
+          ...messages,
+          { role: "assistant", content: raw },
+          { role: "user", content: instruction },
+        ]);
+      } catch {
+        return failure(GENIE_ERRORS.ASLEEP);
+      }
+      // Keep the retry only if it parsed; a second failure leaves the first
+      // attempt, which for a repeat is still a usable turn.
+      parsed = parseTurn(raw) ?? parsed;
+    }
+
+    if (!parsed) {
+      return failure(GENIE_ERRORS.ASLEEP);
+    }
+
+    // Asked twice and still repeating itself: the model has run out of ways to
+    // split this set, which is what `done` means. Better to show the player
+    // what is left than to put the same question in front of them again.
+    if (isRepeat(parsed, request)) {
+      parsed = { ...parsed, done: true };
+    }
+
+    return success(sanitize(parsed, request));
+  }
+}
+
+function validate(request: GenieTurnRequest): Result<true> {
+  const query = request?.query?.trim() ?? "";
+  if (query.length === 0) {
+    return failure(GENIE_ERRORS.QUERY_REQUIRED);
+  }
+  if (query.length > GENIE_MAX_QUERY_CHARS) {
+    return failure(GENIE_ERRORS.QUERY_TOO_LONG);
+  }
+
+  const candidates = request.candidates;
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    return failure(GENIE_ERRORS.NO_CANDIDATES);
+  }
+  if (candidates.length > GENIE_MAX_CANDIDATES) {
+    return failure(GENIE_ERRORS.TOO_MANY_CANDIDATES);
+  }
+
+  // Duplicate ids would make `keep` ambiguous — two different articles would
+  // survive or die together, and which one the player ended up with would
+  // depend on array order.
+  const ids = new Set(candidates.map((candidate) => candidate.id));
+  if (ids.size !== candidates.length) {
+    return failure(GENIE_ERRORS.DUPLICATE_CANDIDATE_ID);
+  }
+
+  if (!Array.isArray(request.history)) {
+    return failure(GENIE_ERRORS.MALFORMED_BODY);
+  }
+  if (request.history.length > GENIE_MAX_HISTORY) {
+    return failure(GENIE_ERRORS.HISTORY_TOO_LONG);
+  }
+
+  if (!isGenieBucket(request.bucket)) {
+    return failure(GENIE_ERRORS.INVALID_BUCKET);
+  }
+
+  return success(true);
+}
+
+const SEED_PROMPT = `You turn a player's description of a Wikipedia article they are hunting for \
+into search inputs. Reply with a single JSON object and nothing else:
+
+{"keywords": "the search terms to look the article up by", "anchors": ["Wikipedia article titles \
+the player named explicitly"]}
+
+- "keywords" is never empty. Strip the filler ("find me", "the one that", "I'm looking for") and \
+keep the describing words.
+- "anchors" holds articles the player named as things to relate to, e.g. "find me a relation \
+between OpenAI and Portugal" gives ["OpenAI", "Portugal"]. Use the article title as Wikipedia \
+would spell it.
+- When the player is describing an article rather than naming ones to connect, e.g. "the female \
+mathematician who worked at NASA", anchors is empty. Do not guess the answer and do not put your \
+guess in anchors.
+- List every article the player named to relate, not just the first two.`;
+
+/**
+ * Reads the seed out of the model's reply, falling back to the player's own
+ * words as keywords. There is no retry here: an unparseable reply still leaves a
+ * usable keyword search, so a second call would spend a neuron and a wait to
+ * improve a query that already works.
+ */
+export function parseSeed(raw: string, query: string): GenieSeedResponse {
+  const source = extractJsonObject(raw);
+  let record: Record<string, unknown> = {};
+
+  if (source) {
+    try {
+      const value: unknown = JSON.parse(source);
+      if (typeof value === "object" && value !== null) {
+        record = value as Record<string, unknown>;
+      }
+    } catch {
+      // Falls through to the raw query below.
+    }
+  }
+
+  const keywords =
+    typeof record.keywords === "string" && record.keywords.trim().length > 0
+      ? record.keywords.trim()
+      : query;
+
+  const anchors = Array.isArray(record.anchors)
+    ? record.anchors
+        .filter(
+          (anchor): anchor is string =>
+            typeof anchor === "string" && anchor.trim().length > 0,
+        )
+        .map((anchor) => anchor.trim())
+        .slice(0, GENIE_MAX_ANCHORS)
+    : [];
+
+  return { keywords, anchors };
+}
+
+const RETRY_INSTRUCTION =
+  "That was not valid JSON. Reply with the JSON object only — no prose, no " +
+  "code fences, no explanation.";
+
+const REPEAT_INSTRUCTION =
+  "You have already asked that. Ask a different question, about something you " +
+  "have not covered yet, and word your reply differently. JSON object only.";
+
+/**
+ * Folds a question to a comparison key. Deliberately not aggressive — only case,
+ * whitespace and trailing punctuation — so it stays correct in languages whose
+ * questions this would otherwise strip to nothing.
+ */
+function questionKey(question: string): string {
+  return question
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[?!.]+$/, "");
+}
+
+/**
+ * Has the Genie asked this before?
+ *
+ * Checked against the whole history rather than just the previous turn: asking
+ * the same thing again is no better at turn six than at turn two, and it is
+ * always a wasted question, since a set already split on that answer cannot
+ * split on it twice.
+ *
+ * Only the question is compared, because only the question is in the history —
+ * the flavour around it is display-only and never sent back. In practice that
+ * is enough: a repeated question is what makes the sentence the player reads
+ * repeat.
+ */
+function isRepeat(parsed: ParsedTurn, request: GenieTurnRequest): boolean {
+  const asked = new Set(
+    request.history.map((exchange) => questionKey(exchange.question)),
+  );
+  return asked.has(questionKey(parsed.question));
+}
+
+const SYSTEM_PROMPT = `You are the Article Genie in a fantasy game played over Wikipedia articles. \
+A player is hunting for an article they cannot name, and you help by narrowing a list of REAL \
+articles they give you.
+
+Rules you must follow:
+- Never invent, suggest or name an article that is not in the candidate list.
+- Refer to candidates ONLY by their numeric id.
+- Ask exactly ONE short question per turn, in character: warm, playful, a single sentence.
+- NEVER ask something you have already asked, and never reuse the same wording twice in a row — \
+vary the flavour every turn. If you cannot think of a genuinely new question, set done to true \
+instead of repeating yourself.
+- Judge candidates ONLY from their title and description. Many of these articles are newer than \
+anything you know, so the description is your evidence — never rely on recognising a name.
+- Never state, imply or hint at how many candidates are left. You are given a mood word for that; \
+weave that word in instead of any number.
+
+Two kinds of question, and the difference matters:
+- "filter": splits the list, e.g. "Is it a person?". Only ask one when you can answer it for every \
+candidate from its title and description.
+- "preference": only reorders, e.g. "Something famous, or something obscure?". It never removes \
+anything, so put EVERY id in keep when you ask one. Prefer these once the list is short.
+
+Answer with a single JSON object and nothing else:
+{"utterance": "one sentence of flavour plus your question", "keep": [ids that survive the player's \
+LAST answer], "options": ["2-4 short tap answers to your question"], "kind": "filter" | \
+"preference", "done": true when you cannot usefully narrow further}
+
+On the very first turn there is no answer to apply yet: put every id in keep and just ask your \
+opening question.`;
+
+function buildMessages(request: GenieTurnRequest): LlmMessage[] {
+  const listing = request.candidates
+    .map((candidate) => formatCandidate(candidate))
+    .join("\n");
+
+  const history = request.history.length
+    ? request.history
+        .map((exchange, index) => {
+          const answer =
+            exchange.answer === GENIE_UNSURE_ANSWER
+              ? "the player did not know"
+              : exchange.answer;
+          return `${index + 1}. You asked: ${exchange.question} — They answered: ${answer}`;
+        })
+        .join("\n")
+    : "(nothing yet — this is your opening question)";
+
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    {
+      role: "user",
+      content: [
+        `The player is looking for: ${request.query.trim()}`,
+        "",
+        "So far:",
+        history,
+        "",
+        "Candidates still standing:",
+        listing,
+        "",
+        `How many are left, as a mood: ${request.bucket}`,
+      ].join("\n"),
+    },
+  ];
+}
+
+function formatCandidate(candidate: GenieCandidateDTO): string {
+  const description = candidate.description?.trim();
+  return description
+    ? `${candidate.id}. ${candidate.title} — ${description}`
+    : `${candidate.id}. ${candidate.title}`;
+}
+
+interface ParsedTurn {
+  utterance: string;
+  question: string;
+  keep: number[];
+  options: string[];
+  kind: GenieQuestionKind;
+  done: boolean;
+}
+
+/**
+ * Pulls the turn out of the model's reply, tolerating the two things it does
+ * even when told not to: wrapping the object in a code fence, and padding it
+ * with a sentence of prose. Returns null when nothing usable is there, which is
+ * what triggers the single retry.
+ */
+export function parseTurn(raw: string): ParsedTurn | null {
+  const source = extractJsonObject(raw);
+  if (!source) return null;
+
+  let value: unknown;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    return null;
+  }
+
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+
+  const utterance = record.utterance;
+  if (typeof utterance !== "string" || utterance.trim().length === 0) {
+    return null;
+  }
+  if (!Array.isArray(record.keep)) {
+    return null;
+  }
+
+  const keep = record.keep.filter(
+    (id): id is number => typeof id === "number" && Number.isInteger(id),
+  );
+
+  const options = Array.isArray(record.options)
+    ? record.options.filter(
+        (option): option is string =>
+          typeof option === "string" && option.trim().length > 0,
+      )
+    : [];
+
+  return {
+    utterance: utterance.trim(),
+    // Only the question is ever written back into history, so a model that
+    // skips it falls back to the whole utterance rather than to nothing.
+    question:
+      typeof record.question === "string" && record.question.trim().length > 0
+        ? record.question.trim()
+        : utterance.trim(),
+    keep,
+    options,
+    kind: isGenieQuestionKind(record.kind) ? record.kind : "filter",
+    done: record.done === true,
+  };
+}
+
+function extractJsonObject(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    return trimmed;
+  }
+
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    return null;
+  }
+  return trimmed.slice(start, end + 1);
+}
+
+/** Answers that must not be allowed to narrow anything. */
+function isNonCommittal(answer: string | undefined): boolean {
+  return answer?.trim().toLowerCase() === GENIE_UNSURE_ANSWER;
+}
+
+/**
+ * Turns what the model said into what the player gets. Everything the model
+ * could get wrong is corrected against the request it was answering, so a bad
+ * turn costs a wasted question rather than the article the player was after.
+ */
+function sanitize(
+  parsed: ParsedTurn,
+  request: GenieTurnRequest,
+): GenieTurnResponse {
+  const allIds = request.candidates.map((candidate) => candidate.id);
+  const supplied = new Set(allIds);
+
+  // Ids the model made up are dropped rather than trusted; a hallucinated id
+  // has no article behind it and would surface as an empty row.
+  let keep = [...new Set(parsed.keep)].filter((id) => supplied.has(id));
+
+  const lastAnswer = request.history.at(-1)?.answer;
+
+  if (parsed.kind === "preference" || isNonCommittal(lastAnswer)) {
+    // Both promises are kept here, not in the prompt: a preference question
+    // only re-ranks, and a question the player could not answer must never be
+    // the reason their article disappeared.
+    keep = allIds;
+  }
+
+  if (keep.length === 0) {
+    // The model filtered the set out of existence. The previous turn's list is
+    // exactly what it was sent, so restoring it costs one wasted question
+    // instead of ending the session with nothing.
+    keep = allIds;
+  }
+
+  return {
+    utterance: parsed.utterance,
+    question: parsed.question,
+    keep,
+    options: parsed.options.length > 0 ? parsed.options : DEFAULT_OPTIONS,
+    kind: parsed.kind,
+    done: parsed.done,
+  };
+}
+
+/** A filter question the model forgot to give taps for is still yes/no. */
+const DEFAULT_OPTIONS = ["Yes", "No"];

--- a/backend/src/services/llmClient.ts
+++ b/backend/src/services/llmClient.ts
@@ -1,0 +1,82 @@
+/**
+ * The seam between the Article Genie and whatever language model is behind it.
+ *
+ * One method, deliberately: the provider stays swappable (ADR 0006 keeps Gemini
+ * as a drop-in escape hatch behind this interface if the free Workers AI
+ * allocation ever stops being enough) and, more practically, a one-method
+ * interface is trivial to substitute in a test.
+ *
+ * That substitution has to happen through a *constructor parameter*, not
+ * `vi.mock`: under `@cloudflare/vitest-pool-workers` a mocked module silently
+ * resolves to the real one, so a test that appears to stub the model would
+ * quietly spend real neurons and assert against real output.
+ */
+export interface LlmMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface LlmClient {
+  /** Resolves to the model's raw text. Throws on any provider failure. */
+  ask(messages: LlmMessage[]): Promise<string>;
+}
+
+/**
+ * Mistral Small 24B, fixed by measurement rather than by cost (ADR 0006). The
+ * obvious cheap pick — Llama 3.1 8B — cannot hold the narrowing loop: ~92%
+ * per-turn recall compounds to losing the correct article in roughly a third of
+ * five-turn sessions. 24B survived 40/40 at ~77 neurons, and 70B is no better
+ * for 30% more. Re-run the fidelity probe in the architecture doc if this
+ * changes.
+ */
+export const GENIE_MODEL = "@cf/mistralai/mistral-small-3.1-24b-instruct";
+
+/**
+ * The subset of the Workers AI binding this client uses. Narrower than the
+ * generated `Ai` type so a test double is a two-line object literal.
+ */
+export interface WorkersAiBinding {
+  run(
+    model: string,
+    input: { messages: LlmMessage[]; max_tokens?: number },
+  ): Promise<unknown>;
+}
+
+/** Keeps a runaway generation from burning the day's allocation in one call. */
+const MAX_TOKENS = 512;
+
+export function createLlmClient(ai: WorkersAiBinding): LlmClient {
+  return {
+    async ask(messages: LlmMessage[]): Promise<string> {
+      const result = await ai.run(GENIE_MODEL, {
+        messages,
+        max_tokens: MAX_TOKENS,
+      });
+      return extractResponseText(result);
+    },
+  };
+}
+
+/**
+ * Workers AI usually answers `{ response: "..." }`, but when the generation is
+ * pure JSON it pre-parses it and `response` arrives as an object. Both are
+ * normalised back to text here so the service has exactly one thing to parse —
+ * this is also why JSON mode is not needed (ADR 0006: it costs 3.3x more input
+ * for a guarantee Cloudflare declines to make).
+ */
+export function extractResponseText(result: unknown): string {
+  if (typeof result === "string") {
+    return result;
+  }
+
+  const response = (result as { response?: unknown } | null)?.response;
+
+  if (typeof response === "string") {
+    return response;
+  }
+  if (response !== undefined && response !== null) {
+    return JSON.stringify(response);
+  }
+
+  throw new Error("Workers AI returned no response field");
+}

--- a/backend/src/tests/articleGenie.spec.ts
+++ b/backend/src/tests/articleGenie.spec.ts
@@ -1,0 +1,587 @@
+import { describe, it, expect } from "vitest";
+import {
+  GENIE_ERRORS,
+  GENIE_MAX_ANCHORS,
+  GENIE_MAX_CANDIDATES,
+  GENIE_MAX_HISTORY,
+  GENIE_MAX_QUERY_CHARS,
+  GENIE_UNSURE_ANSWER,
+  GenieTurnRequest,
+} from "../../../dto/genieDTO";
+import { ArticleGenieService } from "../services/articleGenie";
+import { LlmClient, LlmMessage } from "../services/llmClient";
+
+/**
+ * The model is substituted through the constructor, never through `vi.mock`:
+ * under `@cloudflare/vitest-pool-workers` a mocked module silently resolves to
+ * the real one, so a test written that way would spend real neurons against the
+ * live binding and assert on whatever the model happened to say.
+ */
+function stubLlm(...replies: string[]): LlmClient & { calls: LlmMessage[][] } {
+  const calls: LlmMessage[][] = [];
+  let index = 0;
+  return {
+    calls,
+    async ask(messages: LlmMessage[]) {
+      calls.push(messages);
+      const reply = replies[Math.min(index, replies.length - 1)];
+      index += 1;
+      return reply;
+    },
+  };
+}
+
+function failingLlm(): LlmClient {
+  return {
+    async ask() {
+      throw new Error("Workers AI: out of neurons");
+    },
+  };
+}
+
+function turn(overrides: Partial<GenieTurnRequest> = {}): GenieTurnRequest {
+  return {
+    query: "the female mathematician who worked at NASA",
+    history: [],
+    candidates: [
+      {
+        id: 1,
+        title: "Katherine Johnson",
+        description: "American mathematician",
+      },
+      { id: 2, title: "Apollo 11", description: "1969 crewed spaceflight" },
+      {
+        id: 3,
+        title: "Dorothy Vaughan",
+        description: "American mathematician",
+      },
+    ],
+    bucket: "a handful",
+    ...overrides,
+  };
+}
+
+const GOOD_REPLY = JSON.stringify({
+  utterance: "A fine hunt — is it a person?",
+  keep: [1, 3],
+  options: ["Yes", "No"],
+  kind: "filter",
+  done: false,
+});
+
+describe("ArticleGenieService.seed", () => {
+  it("reads anchors out of a chemistry query", async () => {
+    const result = await new ArticleGenieService(
+      stubLlm(
+        JSON.stringify({
+          keywords: "relation OpenAI Portugal",
+          anchors: ["OpenAI", "Portugal"],
+        }),
+      ),
+    ).seed({ query: "find me a relation between OpenAI and Portugal" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({
+      keywords: "relation OpenAI Portugal",
+      anchors: ["OpenAI", "Portugal"],
+    });
+  });
+
+  it("leaves anchors empty for a tip-of-the-tongue query", async () => {
+    const result = await new ArticleGenieService(
+      stubLlm(
+        JSON.stringify({
+          keywords: "female mathematician NASA",
+          anchors: [],
+        }),
+      ),
+    ).seed({ query: "the female mathematician who worked at NASA" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.anchors).toEqual([]);
+  });
+
+  it("carries more than two anchors — the pipeline is not written for pairs", async () => {
+    const result = await new ArticleGenieService(
+      stubLlm(
+        JSON.stringify({
+          keywords: "Italy France Spain",
+          anchors: ["Italy", "France", "Spain"],
+        }),
+      ),
+    ).seed({ query: "something linking Italy, France and Spain" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.anchors).toEqual(["Italy", "France", "Spain"]);
+  });
+
+  it("caps a runaway anchor list rather than fanning out without bound", async () => {
+    const result = await new ArticleGenieService(
+      stubLlm(
+        JSON.stringify({
+          keywords: "everything",
+          anchors: ["A", "B", "C", "D", "E"],
+        }),
+      ),
+    ).seed({ query: "link A and B and C and D and E" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.anchors).toHaveLength(GENIE_MAX_ANCHORS);
+    // Dropping the tail narrows the seed rather than emptying it: the keyword
+    // search runs alongside the anchor search regardless.
+    expect(result.value.keywords).toBe("everything");
+  });
+
+  it("falls back to the player's own words when the reply is unusable", async () => {
+    const result = await new ArticleGenieService(
+      stubLlm("I'd guess Katherine Johnson"),
+    ).seed({ query: "the female mathematician who worked at NASA" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // An unparseable reply still leaves a perfectly good search term, so there
+    // is nothing worth spending a retry on.
+    expect(result.value).toEqual({
+      keywords: "the female mathematician who worked at NASA",
+      anchors: [],
+    });
+  });
+
+  it("rejects an oversized query and falls asleep when the model throws", async () => {
+    const service = new ArticleGenieService(failingLlm());
+
+    expect(
+      await service.seed({ query: "x".repeat(GENIE_MAX_QUERY_CHARS + 1) }),
+    ).toEqual({ ok: false, error: GENIE_ERRORS.QUERY_TOO_LONG });
+
+    expect(await service.seed({ query: "anything" })).toEqual({
+      ok: false,
+      error: GENIE_ERRORS.ASLEEP,
+    });
+  });
+});
+
+describe("ArticleGenieService", () => {
+  describe("validation", () => {
+    it("rejects an empty query without calling the model", async () => {
+      const llm = stubLlm(GOOD_REPLY);
+      const result = await new ArticleGenieService(llm).takeTurn(
+        turn({ query: "   " }),
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: GENIE_ERRORS.QUERY_REQUIRED,
+      });
+      expect(llm.calls).toHaveLength(0);
+    });
+
+    it("rejects an oversized query rather than truncating it", async () => {
+      const llm = stubLlm(GOOD_REPLY);
+      const result = await new ArticleGenieService(llm).takeTurn(
+        turn({ query: "x".repeat(GENIE_MAX_QUERY_CHARS + 1) }),
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: GENIE_ERRORS.QUERY_TOO_LONG,
+      });
+      // Truncating would hide a client bug and make the answer depend on state
+      // nobody can see, so nothing reaches the model at all.
+      expect(llm.calls).toHaveLength(0);
+    });
+
+    it("rejects an oversized candidate list", async () => {
+      const candidates = Array.from(
+        { length: GENIE_MAX_CANDIDATES + 1 },
+        (_, index) => ({ id: index, title: `Article ${index}` }),
+      );
+
+      const result = await new ArticleGenieService(
+        stubLlm(GOOD_REPLY),
+      ).takeTurn(turn({ candidates }));
+
+      expect(result).toEqual({
+        ok: false,
+        error: GENIE_ERRORS.TOO_MANY_CANDIDATES,
+      });
+    });
+
+    it("rejects an empty candidate list", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(GOOD_REPLY),
+      ).takeTurn(turn({ candidates: [] }));
+
+      expect(result).toEqual({
+        ok: false,
+        error: GENIE_ERRORS.NO_CANDIDATES,
+      });
+    });
+
+    it("rejects duplicate candidate ids, which would make `keep` ambiguous", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(GOOD_REPLY),
+      ).takeTurn(
+        turn({
+          candidates: [
+            { id: 1, title: "Katherine Johnson" },
+            { id: 1, title: "Dorothy Vaughan" },
+          ],
+        }),
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: GENIE_ERRORS.DUPLICATE_CANDIDATE_ID,
+      });
+    });
+
+    it("rejects a history past the soft cap plus its extension", async () => {
+      const history = Array.from(
+        { length: GENIE_MAX_HISTORY + 1 },
+        (_, index) => ({ question: `q${index}`, answer: "Yes" }),
+      );
+
+      const result = await new ArticleGenieService(
+        stubLlm(GOOD_REPLY),
+      ).takeTurn(turn({ history }));
+
+      expect(result).toEqual({
+        ok: false,
+        error: GENIE_ERRORS.HISTORY_TOO_LONG,
+      });
+    });
+
+    it("rejects a bucket that is not one of the agreed words", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(GOOD_REPLY),
+      ).takeTurn(turn({ bucket: "31 articles" as GenieTurnRequest["bucket"] }));
+
+      expect(result).toEqual({
+        ok: false,
+        error: GENIE_ERRORS.INVALID_BUCKET,
+      });
+    });
+  });
+
+  describe("the prompt", () => {
+    it("carries each candidate's description, which is what makes recency work", async () => {
+      const llm = stubLlm(GOOD_REPLY);
+      await new ArticleGenieService(llm).takeTurn(turn());
+
+      const prompt = llm.calls[0].map((m) => m.content).join("\n");
+      // Titles alone lose ~15% of the people the model has never heard of
+      // (ADR 0006), and the game trades on articles newer than its cutoff.
+      expect(prompt).toContain("Katherine Johnson — American mathematician");
+    });
+
+    it("passes the bucket word and never a count", async () => {
+      const llm = stubLlm(GOOD_REPLY);
+      await new ArticleGenieService(llm).takeTurn(turn());
+
+      const prompt = llm.calls[0].map((m) => m.content).join("\n");
+      expect(prompt).toContain("a handful");
+      expect(prompt).not.toMatch(/\b3 candidates\b/);
+    });
+  });
+
+  describe("a well-formed turn", () => {
+    it("returns the model's utterance and the surviving ids", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(GOOD_REPLY),
+      ).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toEqual({
+        utterance: "A fine hunt — is it a person?",
+        // GOOD_REPLY carries no bare question, so it falls back to the whole
+        // utterance rather than leaving history empty.
+        question: "A fine hunt — is it a person?",
+        keep: [1, 3],
+        options: ["Yes", "No"],
+        kind: "filter",
+        done: false,
+      });
+    });
+
+    it("reads the object out of a fenced or padded reply", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm("Here you go!\n```json\n" + GOOD_REPLY + "\n```"),
+      ).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.keep).toEqual([1, 3]);
+    });
+  });
+
+  describe("what the model gets wrong", () => {
+    it("discards ids that were never in the candidate list", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(
+          JSON.stringify({
+            utterance: "Is it a person?",
+            keep: [1, 99, 3],
+            options: ["Yes", "No"],
+            kind: "filter",
+            done: false,
+          }),
+        ),
+      ).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // 99 has no article behind it and would render as an empty row.
+      expect(result.value.keep).toEqual([1, 3]);
+    });
+
+    it("keeps everything when the question was a preference", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(
+          JSON.stringify({
+            utterance: "Something famous, or something obscure?",
+            keep: [1],
+            options: ["Famous", "Obscure"],
+            kind: "preference",
+            done: false,
+          }),
+        ),
+      ).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // A preference only re-ranks. Honoured here rather than in the prompt,
+      // because it is a guarantee and a prompt is only a request.
+      expect(result.value.keep).toEqual([1, 2, 3]);
+    });
+
+    it("keeps everything when the player answered that they did not know", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(
+          JSON.stringify({
+            utterance: "Is it a person?",
+            keep: [1],
+            options: ["Yes", "No"],
+            kind: "filter",
+            done: false,
+          }),
+        ),
+      ).takeTurn(
+        turn({
+          history: [
+            { question: "Is it a person?", answer: GENIE_UNSURE_ANSWER },
+          ],
+        }),
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // A question the player could not answer must never be the reason their
+      // article vanished.
+      expect(result.value.keep).toEqual([1, 2, 3]);
+    });
+
+    it("restores the set when a turn would empty it", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(
+          JSON.stringify({
+            utterance: "Is it a person?",
+            keep: [],
+            options: ["Yes", "No"],
+            kind: "filter",
+            done: false,
+          }),
+        ),
+      ).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Costs one wasted question instead of ending the session with nothing.
+      expect(result.value.keep).toEqual([1, 2, 3]);
+    });
+
+    it("returns the bare question apart from the flavour around it", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(
+          JSON.stringify({
+            utterance: "Mhh, a fine hunt — is it a person?",
+            question: "Is it a person?",
+            keep: [1, 3],
+            options: ["Yes", "No"],
+            kind: "filter",
+            done: false,
+          }),
+        ),
+      ).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Only this goes into history. Feeding the flavour back would grow the
+      // prompt every turn with narration that says nothing about the article.
+      expect(result.value.question).toBe("Is it a person?");
+      expect(result.value.utterance).toBe("Mhh, a fine hunt — is it a person?");
+    });
+
+    it("falls back to the whole utterance when the bare question is missing", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(GOOD_REPLY),
+      ).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // A slightly noisy history beats an empty one.
+      expect(result.value.question).toBe("A fine hunt — is it a person?");
+    });
+
+    it("asks again when the model repeats a question it already asked", async () => {
+      const repeated = JSON.stringify({
+        utterance: "Mhh — is it a person?",
+        question: "Is it a person?",
+        keep: [1, 3],
+        options: ["Yes", "No"],
+        kind: "filter",
+        done: false,
+      });
+      const fresh = JSON.stringify({
+        utterance: "Then tell me — was she a scientist?",
+        question: "Was she a scientist?",
+        keep: [1],
+        options: ["Yes", "No"],
+        kind: "filter",
+        done: false,
+      });
+
+      const llm = stubLlm(repeated, fresh);
+      const result = await new ArticleGenieService(llm).takeTurn(
+        turn({
+          history: [{ question: "Is it a person?", answer: "Yes" }],
+        }),
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.question).toBe("Was she a scientist?");
+      expect(result.value.utterance).toBe(
+        "Then tell me — was she a scientist?",
+      );
+      expect(llm.calls).toHaveLength(2);
+      expect(llm.calls[1].at(-1)?.content).toContain("already asked");
+    });
+
+    it("treats punctuation and casing as the same question", async () => {
+      const llm = stubLlm(
+        JSON.stringify({
+          utterance: "Is it a person",
+          question: "is it a person",
+          keep: [1],
+          options: ["Yes", "No"],
+          kind: "filter",
+          done: false,
+        }),
+      );
+      await new ArticleGenieService(llm).takeTurn(
+        turn({ history: [{ question: "Is it a person?", answer: "Yes" }] }),
+      );
+
+      expect(llm.calls).toHaveLength(2);
+    });
+
+    it("stops rather than asking the same question a third time", async () => {
+      const repeated = JSON.stringify({
+        utterance: "Mhh — is it a person?",
+        question: "Is it a person?",
+        keep: [1, 3],
+        options: ["Yes", "No"],
+        kind: "filter",
+        done: false,
+      });
+
+      // The stub keeps returning the same thing, so the retry repeats too.
+      const result = await new ArticleGenieService(stubLlm(repeated)).takeTurn(
+        turn({ history: [{ question: "Is it a person?", answer: "Yes" }] }),
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Out of ways to split the set is what `done` means — better to show what
+      // is left than to put the same question up again.
+      expect(result.value.done).toBe(true);
+    });
+
+    it("leaves a genuinely new question alone", async () => {
+      const llm = stubLlm(
+        JSON.stringify({
+          utterance: "And was she a scientist?",
+          question: "Was she a scientist?",
+          keep: [1],
+          options: ["Yes", "No"],
+          kind: "filter",
+          done: false,
+        }),
+      );
+      const result = await new ArticleGenieService(llm).takeTurn(
+        turn({ history: [{ question: "Is it a person?", answer: "Yes" }] }),
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.done).toBe(false);
+      // No retry: a new question costs nothing extra.
+      expect(llm.calls).toHaveLength(1);
+    });
+
+    it("falls back to yes/no when no taps were offered", async () => {
+      const result = await new ArticleGenieService(
+        stubLlm(
+          JSON.stringify({
+            utterance: "Is it a person?",
+            keep: [1, 3],
+            kind: "filter",
+            done: false,
+          }),
+        ),
+      ).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.options).toEqual(["Yes", "No"]);
+    });
+  });
+
+  describe("failure", () => {
+    it("retries once when the reply is not JSON, and uses the retry", async () => {
+      const llm = stubLlm("I think it's Katherine Johnson!", GOOD_REPLY);
+      const result = await new ArticleGenieService(llm).takeTurn(turn());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.keep).toEqual([1, 3]);
+      expect(llm.calls).toHaveLength(2);
+      // The retry shows the model its own bad reply and says what was wrong.
+      expect(llm.calls[1].at(-1)?.content).toContain("valid JSON");
+    });
+
+    it("falls asleep when the reply is malformed twice", async () => {
+      const llm = stubLlm("nope", "still nope");
+      const result = await new ArticleGenieService(llm).takeTurn(turn());
+
+      expect(result).toEqual({ ok: false, error: GENIE_ERRORS.ASLEEP });
+      expect(llm.calls).toHaveLength(2);
+    });
+
+    it("falls asleep when the model call throws, without retrying", async () => {
+      const result = await new ArticleGenieService(failingLlm()).takeTurn(
+        turn(),
+      );
+
+      // Quota exhaustion is the expected way this fails on the free plan: it
+      // would fail identically on a retry and only spend the player's wait.
+      expect(result).toEqual({ ok: false, error: GENIE_ERRORS.ASLEEP });
+    });
+  });
+});

--- a/backend/src/tests/cloudflare-env.d.ts
+++ b/backend/src/tests/cloudflare-env.d.ts
@@ -3,5 +3,11 @@ declare namespace Cloudflare {
     JWT_SECRET: string;
     GOOGLE_CLIENT_SECRET: string;
     TEST_MIGRATIONS: import("cloudflare:test").D1Migration[];
+    /**
+     * Declared so tests can swap the Article Genie's model out. They must: the
+     * AI binding reaches remote Workers AI even under `vitest dev`, so a test
+     * that left it in place would spend the day's neuron allocation.
+     */
+    AI: Ai;
   }
 }

--- a/backend/src/tests/integration/genieRoute.integration.test.ts
+++ b/backend/src/tests/integration/genieRoute.integration.test.ts
@@ -1,0 +1,191 @@
+import { env } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { GENIE_ERRORS } from "../../../../dto/genieDTO";
+import me from "../../routes/me";
+import { PlayerService } from "../../services/player";
+
+/**
+ * The AI binding is supplied by the test, not by the platform: the `test`
+ * environment in wrangler.jsonc deliberately omits it, because Workers AI has
+ * no local simulator and its mere presence makes the pool demand a
+ * CLOUDFLARE_API_TOKEN that CI does not have.
+ *
+ * Stubbing it is what a test wants regardless — the real binding reaches remote
+ * Workers AI even in local dev, so letting it through would spend the day's
+ * neuron allocation and assert against whatever the model happened to say.
+ * `vi.mock` is no help: this pool resolves a mocked module to the real one
+ * without complaining.
+ */
+const realAi = env.AI;
+let aiCalls: unknown[] = [];
+
+function stubAi(reply: unknown | (() => never)) {
+  Object.assign(env, {
+    AI: {
+      async run(model: string, input: unknown) {
+        aiCalls.push({ model, input });
+        if (typeof reply === "function") {
+          return (reply as () => never)();
+        }
+        return { response: reply };
+      },
+    },
+  });
+}
+
+afterEach(() => {
+  Object.assign(env, { AI: realAi });
+  aiCalls = [];
+});
+
+function appFor(googleAccountId: string) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("jwtPayload", { sub: googleAccountId });
+    await next();
+  });
+  app.route("/api/me", me);
+  return app;
+}
+
+function post(app: Hono, body: unknown) {
+  return app.request(
+    "/api/me/genie-turns",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+const VALID_TURN = {
+  query: "find me a relation between OpenAI and Portugal",
+  history: [],
+  candidates: [
+    { id: 1, title: "Google", description: "American technology company" },
+    {
+      id: 2,
+      title: "Artificial intelligence arms race",
+      description: "Competition between states over AI",
+    },
+  ],
+  bucket: "a handful",
+};
+
+const GOOD_REPLY = JSON.stringify({
+  utterance: "Curious pairing — is it about a company?",
+  question: "Is it about a company?",
+  keep: [2],
+  options: ["Yes", "No"],
+  kind: "filter",
+  done: false,
+});
+
+describe("POST /api/me/genie-turns", () => {
+  let app: Hono;
+
+  beforeEach(async () => {
+    // A fresh account per test: the rate limiter is real in this pool and keys
+    // on the player, so a reused id leaks quota between tests.
+    const accountId = `account-genie-${crypto.randomUUID()}`;
+    const player = await new PlayerService(env.db).createPlayer(
+      `seeker-${crypto.randomUUID()}`,
+      "seeker@example.com",
+      accountId,
+    );
+    expect(player.ok).toBe(true);
+    app = appFor(accountId);
+  });
+
+  it("returns the turn and asks the model that ADR 0006 settled on", async () => {
+    stubAi(GOOD_REPLY);
+
+    const response = await post(app, VALID_TURN);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      utterance: "Curious pairing — is it about a company?",
+      question: "Is it about a company?",
+      keep: [2],
+      options: ["Yes", "No"],
+      kind: "filter",
+      done: false,
+    });
+    expect(aiCalls).toHaveLength(1);
+    expect((aiCalls[0] as { model: string }).model).toBe(
+      "@cf/mistralai/mistral-small-3.1-24b-instruct",
+    );
+  });
+
+  it("accepts a reply Workers AI already parsed into an object", async () => {
+    // Workers AI pre-parses the generation when it is pure JSON, which is why
+    // JSON mode is not needed (ADR 0006). Both shapes must work.
+    stubAi(JSON.parse(GOOD_REPLY));
+
+    const response = await post(app, VALID_TURN);
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { keep: number[] };
+    expect(body.keep).toEqual([2]);
+  });
+
+  it("answers 400 for a payload the client should never have built", async () => {
+    stubAi(GOOD_REPLY);
+
+    const response = await post(app, { ...VALID_TURN, candidates: [] });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: GENIE_ERRORS.NO_CANDIDATES,
+    });
+    // Validation runs before the model, so a bad payload costs no neurons.
+    expect(aiCalls).toHaveLength(0);
+  });
+
+  it("answers 400 for a body that is not JSON", async () => {
+    stubAi(GOOD_REPLY);
+
+    const response = await app.request(
+      "/api/me/genie-turns",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: GENIE_ERRORS.MALFORMED_BODY,
+    });
+  });
+
+  it("answers 503 with the asleep code when the model fails", async () => {
+    stubAi(() => {
+      throw new Error("Workers AI: daily neuron allocation exhausted");
+    });
+
+    const response = await post(app, VALID_TURN);
+
+    // The frontend answers this by dismissing to the ordinary search bar; the
+    // feature is additive, so buying an article never depends on it.
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: GENIE_ERRORS.ASLEEP });
+  });
+
+  it("answers 404 when the session has no player behind it", async () => {
+    stubAi(GOOD_REPLY);
+
+    const response = await post(
+      appFor("account-that-does-not-exist"),
+      VALID_TURN,
+    );
+
+    expect(response.status).toBe(404);
+    expect(aiCalls).toHaveLength(0);
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
     cloudflareTest({
       wrangler: {
         configPath: "./wrangler.jsonc",
-        environment: "production",
+        // Mirrors `production` minus the Workers AI binding — see the comment on
+        // that environment in wrangler.jsonc. AI has no local simulator, so its
+        // presence makes the pool require Cloudflare credentials that CI does
+        // not have.
+        environment: "test",
       },
       miniflare: {
         d1Persist: false,

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -4,6 +4,59 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-03-17",
   "env": {
+    // What the integration tests load (see vitest.config.ts). It mirrors
+    // `production` except for the `ai` binding, which is deliberately absent:
+    // Workers AI has **no local simulator**, so declaring it makes the pool open
+    // a remote proxy session and demand a CLOUDFLARE_API_TOKEN. CI runs
+    // `./gradlew check` with no Cloudflare credentials, so the whole backend
+    // suite — not just the Genie's tests — would fail to start.
+    //
+    // Nothing is lost by leaving it out. A test must never reach the real model
+    // anyway (it would spend the day's neuron allocation and assert against
+    // whatever the model happened to say), so the Genie's tests substitute
+    // `env.AI` with a stub of their own.
+    "test": {
+      "name": "backend-test",
+      "d1_databases": [
+        {
+          "binding": "db",
+          "database_name": "db",
+          "database_id": "640d7014-0bf9-44f6-8026-15bf2a18cdda",
+        },
+      ],
+      "workflows": [
+        {
+          "binding": "CONTRACT_SETTLEMENT_WORKFLOW",
+          "name": "contract-settlement",
+          "class_name": "ContractSettlementWorkflow",
+        },
+      ],
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "REPORT_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1001",
+            "simple": { "limit": 3, "period": 60 },
+          },
+          {
+            "name": "GENIE_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1002",
+            "simple": { "limit": 20, "period": 60 },
+          },
+        ],
+      },
+      "triggers": {
+        "crons": ["0 5 * * *"],
+      },
+      "vars": {
+        "GITHUB_REPO": "FantasyWiki/FantasyWiki",
+        "ENVIRONMENT": "production",
+        "GH_APP_ID": "4298123",
+        "GH_APP_INSTALLATION_ID": "146572827",
+      },
+    },
     "production": {
       "name": "backend",
       "d1_databases": [
@@ -33,7 +86,24 @@
             "namespace_id": "1001",
             "simple": { "limit": 3, "period": 60 },
           },
+          // Sized for a real Article Genie session, not for abuse: one session
+          // is ~5 turns fired within a minute or two, so the report limiter's
+          // 3/60 would cut a legitimate player off mid-interrogation. The day's
+          // Workers AI neuron allocation is the actual ceiling and fails closed
+          // on its own (ADR 0006) — this only stops a script from spending it
+          // all in one burst.
+          {
+            "name": "GENIE_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1002",
+            "simple": { "limit": 20, "period": 60 },
+          },
         ],
+      },
+      // Workers AI. No API key and no per-environment secret: the binding is
+      // the credential, which is most of why it was chosen over Groq/Gemini.
+      "ai": {
+        "binding": "AI",
       },
       "triggers": {
         "crons": ["0 5 * * *"],
@@ -73,7 +143,16 @@
             "namespace_id": "1001",
             "simple": { "limit": 3, "period": 60 },
           },
+          {
+            "name": "GENIE_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1002",
+            "simple": { "limit": 20, "period": 60 },
+          },
         ],
+      },
+      "ai": {
+        "binding": "AI",
       },
       "triggers": {
         "crons": ["0 5 * * *"],
@@ -113,7 +192,16 @@
             "namespace_id": "1001",
             "simple": { "limit": 3, "period": 60 },
           },
+          {
+            "name": "GENIE_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1002",
+            "simple": { "limit": 20, "period": 60 },
+          },
         ],
+      },
+      "ai": {
+        "binding": "AI",
       },
       "triggers": {
         "crons": ["0 7 * * *"],

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ Seams, layers, and modules. The rules they implement live in `domain/`.
 | [Lineup Editing](./architecture/lineup-editing.md) | The `DraftLineup` seam and its pure mutations |
 | [Article Ownership Resolution](./architecture/article-ownership-resolution.md) | `buildArticleDetail` + the async team-context seam |
 | [Problem Reports](./architecture/problem-reports.md) | How `/report` files a GitHub issue, and what it never publishes |
+| [Article Genie LLM Integration](./architecture/article-genie-llm.md) | The Workers AI seam, turn protocol, and quota handling |
 | [Wikimedia Client Architecture](./architecture/wikimedia-client-architecture.md) | Composition root and capability modules |
 | [Wikimedia Client Behavior Extension](./architecture/wikimedia-client-behavior-extension.md) | How to add a capability |
 | [Wikimedia Client Terminology](./architecture/wikimedia-client-terminology-hierarchy.md) | Naming and hierarchy rules |
@@ -65,7 +66,8 @@ doc disagree, **the ADR wins**.
 [0002 Language Scale Factor](./adr/0002-language-scale-factor.md) ·
 [0003 Closed Trading Economy](./adr/0003-closed-trading-economy.md) ·
 [0004 Scoring Engine Platform](./adr/0004-scoring-engine-platform.md) ·
-[0005 Contract Pricing](./adr/0005-contract-pricing.md)
+[0005 Contract Pricing](./adr/0005-contract-pricing.md) ·
+[0006 Article Genie](./adr/0006-article-genie.md)
 
 ### `agents/` — machine-read repo metadata
 Issue tracker, triage labels, and domain-context layout. Skills read these at

--- a/docs/adr/0006-article-genie.md
+++ b/docs/adr/0006-article-genie.md
@@ -1,0 +1,187 @@
+---
+title: "ADR 0006: Article Genie"
+type: adr
+tags: [llm, market, discovery, chemistry, cloudflare, decision]
+---
+
+# Article Genie: narrowing a bounded candidate list, not generating guesses
+
+> **Status:** decided in design discussion and validated against live Workers AI + the Wikimedia
+> API; not yet implemented in code. Supersedes the flow described in issue #252, which is rewritten
+> to match this ADR.
+
+The **Article Genie** is the LLM-assisted discovery feature on the market page. This ADR records
+what it is, the two player intents it serves, and — most importantly — the alternatives that were
+tried and rejected with measurements rather than argument. The measurements are real: the model,
+the narrowing loop, the seeding queries, and the trending-article case were all probed live before
+this decision was locked (see *Provider and model*).
+
+## Decision
+
+The Genie **never invents an article title.** It seeds a bounded list of *real* Wikipedia titles
+from the search API, then uses the LLM only to **narrow that list** through Akinator-style
+questions. Title hallucination is impossible by construction, so no verification step is needed.
+
+It serves two player intents through **one input box and one pipeline**:
+
+| Intent | Example | Seeded by |
+|---|---|---|
+| **Chemistry scouting** | *"find me a relation between OpenAI and Portugal"* | `linksto:` search + outbound-link intersection |
+| **Tip-of-the-tongue recall** | *"the female mathematician who worked at NASA"* | plain keyword search |
+
+Both searches always run and their results are merged — see *Union seeding* below.
+
+## Why narrowing beats generating
+
+The original design (issue #252) had the LLM guess an article from world knowledge and verify the
+guesses afterwards. Narrowing a real list is better on every axis:
+
+| | Free-world generation | Bounded narrowing (chosen) |
+|---|---|---|
+| Invalid titles | possible; needs a verification pass | impossible by construction |
+| Question quality | guesses about the world | derived from the actual surviving titles |
+| Cost per session | context grows every turn | ~77 neurons (list **shrinks** each turn) |
+| Chemistry data | unavailable | exact, from real link sets |
+
+The cost point is non-obvious: because the candidate list shrinks with every answer, context
+*shrinks* as the session runs, so the more accurate design is also the cheaper one. The ~77-neuron
+figure is measured on the chosen 24B model with the list capped at ~40 (see *Model choice*).
+
+## Union seeding, not routing
+
+The parse call always emits a keyword query, and *additionally* emits anchors when it finds them.
+**Both searches run; results are merged and deduped. There is no routing decision.**
+
+Routing to a single mode was rejected because a misparse is silent and unrecoverable: *"the
+Portuguese explorer who reached India"* misread as an anchor query would drop Vasco da Gama from
+the candidate list entirely, and the player would see only a Genie that failed. With union
+seeding a misparse can only *add* surplus candidates — which the narrowing loop already exists to
+strip.
+
+## Both link directions are candidates
+
+A **Chemistry Link** is GOOD when a link exists in *either* direction (see
+[Chemistry Links](../domain/chemistry-links.md)), so the candidate space for anchors A and B is
+`(linksto:A ∪ outbound(A)) ∩ (linksto:B ∪ outbound(B))`. In practice two cheap sets:
+
+- **S1** — `linksto:A linksto:B`, one search call, ≤100 results
+- **S2** — `outbound(A) ∩ outbound(B)`, from link sets the client already caches
+
+**Outbound-only intersection was tried first and is insufficient alone.** Measured on the
+flagship query, `outbound(Portugal) ∩ outbound(OpenAI)` returns 9 items, 7 of which are
+citation-identifier redirects (ArXiv, Bibcode, Doi, ISSN, OCLC, PMID) plus Austria and
+Switzerland — nothing a player would want. The interesting relations run the other way: articles
+that link *to* both anchors. CirrusSearch's `linksto:` operator [1] supplies exactly that in a
+single call, and the REST endpoint the Wikimedia Client already uses accepts it (verified
+identical to the Action API).
+
+**S2 is retained anyway, and must not be filtered out.** Those cheap, low-traffic articles are
+strategically valuable: they cost almost nothing and still carry chemistry. Discarding them as
+"boilerplate" would remove the most efficient plays in the game.
+
+## Rank, never filter
+
+No interestingness heuristic, no dropping of years, lists, or hub articles. Candidates are
+ordered by **(mutual links desc, price asc)** and let to compete. Measured for Portugal/OpenAI:
+
+| Article | vs Portugal | vs OpenAI | avg views/day |
+|---|---|---|---|
+| Google | GOOD | **EXCELLENT** | 24,501 |
+| Albania | **EXCELLENT** | GOOD | 6,693 |
+| International Mathematical Olympiad | GOOD | **EXCELLENT** | 492 |
+| **Artificial intelligence arms race** | GOOD | **EXCELLENT** | **126** |
+
+*Artificial intelligence arms race* carries the same chemistry as *Google* at 1/200th the
+traffic — and therefore a small fraction of the [Contract Price](../domain/scoring-system.md).
+Ranking surfaces it without any hand-tuned notion of "interesting".
+
+Note that **no candidate achieves EXCELLENT with both anchors.** Mutual links with two unrelated
+articles is essentially unachievable, so one mutual link plus a low price is the realistic
+optimum, and the UI should not promise otherwise.
+
+## Provider and model: Workers AI on the Free plan
+
+| Option | Verdict |
+|---|---|
+| **Cloudflare Workers AI** | **Chosen.** Native binding, no API keys, no CI/preview secrets, first-party free tier |
+| Workers AI + Groq/Gemini fallback | Rejected — doubles capacity but adds secrets to two environments and a second set of rate-limit semantics |
+| `freellmapi` self-hosted proxy | Rejected — a separate service to host, up to 28 upstream accounts to hold, and its own README scopes it to "personal experimentation only" |
+
+On the **Workers Free** plan the 10,000 neurons/day allocation is a hard ceiling: further calls
+fail with an error [2][3]. That is a feature, not a limitation — it makes overspend structurally
+impossible and turns quota exhaustion into a single `catch`, surfaced to the player as *"the genie
+is asleep"*. On Workers Paid the same allocation would silently bill at $0.011/1,000 neurons, so
+the Free plan is the safer host for this feature.
+
+### Model choice — measured, not assumed
+
+Model: **`@cf/mistralai/mistral-small-3.1-24b-instruct`**, with the candidate list capped at ~40.
+This was chosen by running the actual multi-turn interrogation against three model sizes on the
+live binding (5 scripted questions, each true of a planted target, feeding the model's own
+surviving subset forward each turn, tracking whether the correct answer survives every turn):
+
+| Model | Correct answer survived all 5 turns | neurons/session | sessions/day (free 10k) |
+|---|---|---|---|
+| `llama-3.1-8b-instruct-fp8-fast` | 2/3 — **loses the answer** | ~22 | ~450 |
+| **`mistral-small-3.1-24b-instruct`** | **40/40** | **~77** | **~130** |
+| `llama-3.3-70b-instruct-fp8-fast` | 8/8 | ~102 | ~98 |
+
+The 8B model — the obvious "cheap" pick — cannot hold the loop: per-turn recall of ~92% compounds
+to losing the correct article in roughly a third of sessions over five turns. 24B is both more
+reliable *and* cheaper than 70B, so it is the sweet spot; there is no reason to pay for 70B. JSON
+output is reliable by prompting alone (Workers AI pre-parses the response when the content is pure
+JSON), so JSON-mode-capable models — which cost 3.3x more input for a guarantee Cloudflare declines
+to make [4] — are not needed. Gemini's free tier was considered as a stronger host but rejected for
+now: it reintroduces an API key as a secret in production *and* preview/CI and a second provider's
+rate-limit semantics. The `llmClient` seam (see the architecture doc) leaves it as a drop-in future
+fallback.
+
+### Descriptions are mandatory — this is what makes the game's trending articles work
+
+The game trades on Wikipedia top-read, which is dominated by articles that **postdate the model's
+training cutoff** (a 2026 prime minister, a 2026 film, a footballer who debuted last season). The
+model cannot know them. It does not need to: each candidate carries the **one-line description the
+search API returns**, and the model classifies from that. Measured on the *actual* current
+top-read set:
+
+| single-turn "is it a person?" over unknowable 2026 articles | correct people kept | non-people dropped |
+|---|---|---|
+| titles only | 84.6% | 100% |
+| **with the live description** | **100%** | **100%** |
+
+So descriptions are a hard requirement in the candidate listing (titles-only loses ~15% of people
+the model has never heard of), and interrogation questions must be answerable from
+title + description (person / nation / woman / sport / century), not from deep world knowledge.
+
+## Consequences
+
+- **The Genie is additive.** Its output is a title handed to the existing market search path, so
+  pricing, ownership badges, and the buy flow are untouched.
+- **One new route, no schema change.** `POST /api/me/genie-turns` calls the AI binding and nothing
+  else — one subrequest, no D1, no migration. All Wikimedia work stays in the browser, where the
+  client's 7-day cache lives and neither the 50-subrequest nor the 10 ms CPU limit applies [3].
+- **Classification error replaces hallucination as the failure mode.** The model wrongly deciding
+  a surviving title does not match an answer silently deletes the right article. This is why model
+  choice was settled empirically rather than by cost: 8B fails here, 24B does not. Further
+  mitigations are specified in [Article Genie LLM Integration](../architecture/article-genie-llm.md).
+- **Capacity is bounded and modest** — ~130 sessions/day across all players on the free tier
+  (~77 neurons each). Ample at friends-scale; the "genie is asleep" popup absorbs any overflow,
+  and Gemini behind the `llmClient` seam is the escape hatch if a larger player base ever needs it.
+- **Surfaced an existing bug.** Link lists contain redirect titles (`"ArXiv (identifier)"`) while
+  `chemistryKey` matches canonical ones, so pairs linked through a redirect score WEAK instead of
+  GOOD today. Tracked separately from this ADR.
+
+## Sources
+
+1. MediaWiki — CirrusSearch `linksto:` and other search keywords: https://www.mediawiki.org/wiki/Help:CirrusSearch
+2. Cloudflare Workers AI — Pricing and free allocation: https://developers.cloudflare.com/workers-ai/platform/pricing/
+3. Cloudflare Workers — Limits (subrequests, CPU, per plan): https://developers.cloudflare.com/workers/platform/limits/
+4. Cloudflare Workers AI — JSON Mode: https://developers.cloudflare.com/workers-ai/features/json-mode/
+
+## Related
+
+- [Article Genie LLM Integration](../architecture/article-genie-llm.md)
+- [Chemistry Links](../domain/chemistry-links.md)
+- [Scoring & Economy System](../domain/scoring-system.md)
+- [Wikimedia Client Behavior Extension](../architecture/wikimedia-client-behavior-extension.md)
+- [API Naming Rules](../development/api-naming-rules.md)

--- a/docs/adr/0006-article-genie.md
+++ b/docs/adr/0006-article-genie.md
@@ -6,9 +6,10 @@ tags: [llm, market, discovery, chemistry, cloudflare, decision]
 
 # Article Genie: narrowing a bounded candidate list, not generating guesses
 
-> **Status:** decided in design discussion and validated against live Workers AI + the Wikimedia
-> API; not yet implemented in code. Supersedes the flow described in issue #252, which is rewritten
-> to match this ADR.
+> **Status:** decided in design discussion, validated against live Workers AI + the Wikimedia API,
+> and implemented (#252). Supersedes the flow described in issue #252, which is rewritten to match
+> this ADR. Two things the implementation settled that this ADR had left open are recorded under
+> *What implementation changed* below.
 
 The **Article Genie** is the LLM-assisted discovery feature on the market page. This ADR records
 what it is, the two player intents it serves, and — most importantly — the alternatives that were
@@ -153,13 +154,50 @@ So descriptions are a hard requirement in the candidate listing (titles-only los
 the model has never heard of), and interrogation questions must be answerable from
 title + description (person / nation / woman / sport / century), not from deep world knowledge.
 
+## What implementation changed
+
+Two points this ADR stated at the level of intent turned out to need a decision when built. Both
+preserve the properties the ADR was protecting; neither changes what the player sees.
+
+**Reading the query is its own call, so there are two routes, not one.** Seeding needs the anchors
+a query names, and a turn is defined over a candidate list — so the parse cannot be part of the
+first turn, because there is no list until the parse has happened. Folding it in anyway would mean
+seeding a chemistry query on keywords alone, which for *"find me a relation between OpenAI and
+Portugal"* returns articles *about* OpenAI and has the Genie open with a question about the wrong
+set. `POST /api/me/genie-seeds` therefore sits beside `POST /api/me/genie-turns`. The property that
+mattered is intact: each call is one model call, one subrequest, no D1, no migration.
+
+**Candidates are ranked on link structure while narrowing, and priced only at the end.** This ADR
+ranks by `(mutual links desc, price asc)`, which reads as if price is known during the loop. It is
+not affordable there: pricing costs one 365-day pageview request per article and the Wikimedia
+client caches those only as part of a whole search result, so pricing ~40 candidates would mean ~40
+requests before the Genie's first word — for figures all but five of them never show. The loop
+therefore ranks on mutual links, and the specified `(mutual links, price)` ordering is applied to
+the survivors, where price exists and there are at most five of them. What the player sees — the
+cheap, well-connected find above the expensive obvious one — is unchanged.
+
+**Anchors are not limited to two.** The measurements here concern a pair, but nothing in the
+pipeline is written for one: `linksto:` terms are conjoined and the outbound sets intersected over
+however many anchors a query names, and a candidate is ranked by how many of them it links mutually
+with. A cap of three exists only so a pathological query cannot fan out without bound — each anchor
+costs one paginated link fetch — and hitting it narrows the seed rather than emptying it, because
+the keyword search always runs alongside. Yield does collapse past two, as the measurements below
+predict.
+
 ## Consequences
 
 - **The Genie is additive.** Its output is a title handed to the existing market search path, so
   pricing, ownership badges, and the buy flow are untouched.
-- **One new route, no schema change.** `POST /api/me/genie-turns` calls the AI binding and nothing
-  else — one subrequest, no D1, no migration. All Wikimedia work stays in the browser, where the
-  client's 7-day cache lives and neither the 50-subrequest nor the 10 ms CPU limit applies [3].
+- **Two thin routes, no schema change.** `POST /api/me/genie-seeds` and `POST /api/me/genie-turns`
+  each call the AI binding and nothing else — one subrequest, no D1, no migration (see *What
+  implementation changed* for why reading the query is its own call). All Wikimedia work stays in
+  the browser, where the client's 7-day cache lives and neither the 50-subrequest nor the 10 ms CPU
+  limit applies [3].
+- **The AI binding cannot be tested locally.** Workers AI has no local simulator, so declaring it
+  makes `@cloudflare/vitest-pool-workers` open a remote proxy session and require a
+  `CLOUDFLARE_API_TOKEN`. CI runs `./gradlew check` with no Cloudflare credentials, so the binding
+  is omitted from the `test` environment in `wrangler.jsonc` and the tests supply their own stub —
+  which they must do regardless, or they would spend real neurons.
 - **Classification error replaces hallucination as the failure mode.** The model wrongly deciding
   a surviving title does not match an answer silently deletes the right article. This is why model
   choice was settled empirically rather than by cost: 8B fails here, 24B does not. Further

--- a/docs/architecture/article-genie-llm.md
+++ b/docs/architecture/article-genie-llm.md
@@ -1,0 +1,233 @@
+---
+title: Article Genie LLM Integration
+type: architecture
+tags: [llm, workers-ai, cloudflare, seam, testing, quota]
+---
+
+# Article Genie LLM Integration
+
+How the **Article Genie** talks to a language model: the seam, the turn protocol, the prompt
+contract, and what happens when the daily quota runs out. The *decision* behind this feature —
+and the alternatives rejected — lives in [ADR 0006](../adr/0006-article-genie.md); this document
+describes the mechanism.
+
+## Scope: the Worker does exactly one thing
+
+Everything except the model call already runs in the browser. `frontend/src/services/marketService.ts`
+calls the Wikimedia Client directly and prices with `computeContractPrice` client-side, and
+`useTeamLineup` already fetches link sets through the client's 7-day cache. The Genie inherits
+all of it.
+
+```
+BROWSER  (useGenie composable)
+  seed    S1 = search("linksto:A linksto:B" | keywords), title + description, cap ~40
+          S2 = outbound(A) ∩ outbound(B)          — from the cached link sets
+          merge + dedupe, rank by (mutual links desc, price asc)
+  loop    POST /api/me/genie-turns { history, candidates, bucket }
+          ← { utterance, keep: [ids], done }
+  finish  survivors → existing market search path → priced rows
+
+WORKER   (one route)
+  env.AI.run("@cf/mistralai/mistral-small-3.1-24b-instruct", { messages })
+  one subrequest · no D1 · no migration
+```
+
+The model id and the ~40 cap are not arbitrary — both were fixed by live testing; see
+[ADR 0006 → Provider and model](../adr/0006-article-genie.md). The 8B model that a cost-first
+reading would pick **cannot hold the loop** (it loses the correct answer ~1 session in 3); 24B
+survives 40/40 at ~77 neurons.
+
+Keeping the Wikimedia calls in the browser is deliberate: the Workers **Free** plan allows
+**50 subrequests** and **10 ms CPU** per invocation, and the browser has neither limit *and*
+already holds the cache.
+
+## The `llmClient` seam
+
+The AI binding is wrapped in a service under `backend/src/services/`, alongside `wikimediaClient`
+and `githubClient`, and is **constructor-injected** — matching
+`ArticleMarketService(db, wikimedia?, leagueRepo?)`:
+
+```ts
+export class ArticleGenieService {
+  constructor(private readonly llm: LlmClient = createLlmClient()) {}
+}
+```
+
+Injection is not stylistic here. Under `@cloudflare/vitest-pool-workers`, **`vi.mock` silently
+no-ops** — a mocked module resolves to the real one without an error, so a test that appears to
+stub the model would quietly spend real neurons and assert against real output. The constructor
+parameter is the only reliable substitution point.
+
+`LlmClient` exposes one method so the provider stays swappable:
+
+```ts
+type LlmClient = { ask(messages: Message[]): Promise<string> };
+```
+
+## Turn protocol
+
+`POST /api/me/genie-turns` — self-scoped, identity from the JWT, no `playerId` from the client
+(see [API Naming Rules](../development/api-naming-rules.md)).
+
+**Request**
+
+| Field | Notes |
+|---|---|
+| `query` | opening free text, first turn only; clamped to ~200 chars |
+| `history` | prior `{question, answer}` pairs — **questions only, never the flavour text** |
+| `candidates` | `{id, title, description}[]`, ids are small integers assigned by the client. **The description is mandatory** — see *Descriptions carry recency* |
+| `bucket` | a word, not a number — see *Progress without numbers* |
+
+**Response**
+
+| Field | Notes |
+|---|---|
+| `utterance` | one sentence: flavour plus the next question |
+| `keep` | numeric ids that survive; **numbers, not titles** |
+| `done` | model signals it is confident enough to stop |
+
+The session is **stateless** — the client carries the history. This is safe because resetting the
+history is equivalent to starting a new game, which is already free; the abuse control is the
+rate limiter, not the protocol.
+
+**Numeric ids are load-bearing for cost.** Output tokens cost far more than input, and the
+survivor list is returned every turn. Returning ids (~2 tokens each) rather than full titles
+(~6 tokens) roughly halves session cost — the difference between the chosen design and one that
+echoes titles back.
+
+## Descriptions carry recency
+
+The candidate listing sent to the model **must** include each article's one-line description, not
+just its title. The game trades on trending articles, which are mostly newer than the model's
+training cutoff — it cannot know a 2026 prime minister or a last-season footballer by name. It does
+not need to: it classifies from the description. Measured on the real current top-read set, single
+turn "is it a person?": with descriptions the model keeps 100% of the people and drops 100% of the
+non-people; **titles only drops to 84.6% recall**, silently losing people it has never heard of. A
+five-turn interrogation toward a post-cutoff target (a 2007-born footballer) survived 5/5 with
+descriptions, including a "born after 2000?" question answered by reading "born 2007" from the
+description. Consequently, interrogation questions must be answerable from title + description
+(person / nation / woman / sport / century), not from world knowledge the model may lack.
+
+## The two question kinds
+
+The model may ask either kind, and the distinction is a safety boundary:
+
+| Kind | Example | Effect | Can lose the answer? |
+|---|---|---|---|
+| **Filter** | *"Is it a person?"* | partitions the list | **Yes** — see Risks |
+| **Preference** | *"Something niche, or something famous?"* | re-ranks only, drops nothing | No |
+
+Preference questions are strictly safe and map directly onto the price axis players care about,
+so the prompt should favour them once the list is already small.
+
+## Adaptive stop
+
+Turns scale with the candidate count. The loop stops when **survivors ≤ 5**, when the model sets
+`done`, or at the soft cap of 10 turns (with one optional "+5" extension).
+
+| Seeded candidates | Expected questions |
+|---|---|
+| ~17 (anchored, narrow) | ~2 |
+| ~40 (recall query, at the cap) | ~4–5 |
+
+Showing five results is a fine outcome; the loop is not required to reach exactly one. A single
+result is shown only when the model is confident. The recall seed is capped at ~40 because the
+search API puts the intended article in roughly the top three, so 40 reliably contains it while
+keeping per-turn cost and the model's attention load low.
+
+## Progress without numbers
+
+The player must never see a raw candidate count — it reads as debug output and breaks character.
+The frontend maps the exact count to a **bucket word** (`vast`, `many`, `a dozen or so`,
+`a handful`, `almost there`) and passes only that word into the prompt; the model weaves it into
+its utterance:
+
+> *"Mhh, interesting — I'm down to a handful. Did she work on spaceflight?"*
+
+The model therefore never sees a number and cannot contradict one. The flavour is **display-only**:
+it is not written back into `history`, so it never re-enters the input on later turns.
+
+## Quota exhaustion — "the genie is asleep"
+
+On the **Workers Free** plan the 10,000 neurons/day allocation is a hard ceiling and further calls
+fail. There is no counter to maintain and no way to be billed:
+
+```ts
+try {
+  return await this.llm.ask(messages);
+} catch {
+  return failure(GENIE_ASLEEP);
+}
+```
+
+Any model failure — quota, transport, or an unparseable response after one retry — maps to the
+same player-facing state: a brief popup saying the genie is asleep, and the panel dismisses to the
+ordinary search bar. The feature is purely additive, so degrading it never blocks buying an
+article.
+
+### Neuron budget
+
+Measured on the chosen 24B model (5-turn interrogation, candidate list capped at ~40):
+
+| Scenario | neurons/session | sessions/day |
+|---|---|---|
+| Recall, ~40 candidates, ~5 turns (24B) | ~77 | ~130 |
+| Same on 8B — but 8B loses the answer 1/3 of the time | ~22 | ~450 |
+| Same on 70B — works, but no better than 24B | ~102 | ~98 |
+
+If budget ever needs reclaiming, tighten the candidate cap or the extension, or drop a Gemini
+fallback in behind the seam. The flavour narration is a small fraction of a session and is not
+worth cutting.
+
+## Input safety
+
+The opening `query` is the **only** free-text field that reaches the prompt; every later answer is
+a tap. That keeps the injection surface to one clamped field.
+
+- Clamp `query` to ~200 chars, and the candidate list to ~40 entries (also the design cap).
+- **Reject oversized payloads, do not truncate** — silent truncation hides a client bug and makes
+  the model's answer depend on invisible state.
+- Constrain the model to return ids drawn only from the supplied list; discard any id that is not
+  in it rather than trusting the response.
+- Rate-limit per player with an `unsafe` ratelimit binding, following the `REPORT_RATE_LIMITER`
+  pattern already in `wrangler.jsonc`. **Size it against a real session, not just abuse:** a
+  session fires several requests within a minute, so a tight per-minute cap throttles legitimate
+  play.
+
+## Risks
+
+- **Classification error is the real failure mode**, not hallucination. A filter question the
+  model answers wrongly deletes the right article from the survivor set, and the Genie cannot
+  recover. This is the single reason the 24B model is mandated over 8B (see the diagram note).
+  Further mitigations: allow an *unsure* bucket that is never dropped; if survivors reach zero,
+  restore the previous turn's list and tell the model it went wrong; prefer preference questions
+  once the list is small.
+- **Multi-word anchors must be underscored or quoted.** `linksto:Formula One` silently parses as
+  `linksto:Formula` plus free text and returns unrelated results; `linksto:Formula_One` is
+  correct. Enforce in the prompt *and* defensively in code.
+- **Redirect titles.** `prop=links` returns targets as written (`"ArXiv (identifier)"`), so link
+  data must be resolved to canonical titles before matching against article titles.
+
+## Testing
+
+- **Backend** — inject a stub `LlmClient`; never rely on `vi.mock` under the Workers pool.
+  Cover: valid JSON, malformed JSON then a successful retry, malformed twice → asleep, ids outside
+  the candidate list discarded, oversized payload rejected.
+- **Frontend** — MSW with `onUnhandledRequest: "error"`, per `frontend/src/tests/setup.ts`.
+  Cover: seeding merge and dedupe, ranking order, the asleep popup, and dismissal to the search
+  bar.
+- **Model fidelity — already validated against the live binding** (the load-bearing assumption
+  behind the whole loop). A scripted 5-turn interrogation over ~40 real candidates, feeding the
+  model's own surviving subset forward each turn, keeps the planted correct answer 40/40 on 24B and
+  loses it ~1/3 of the time on 8B; recency holds when descriptions are included (see *Descriptions
+  carry recency*). Re-run this probe whenever the model id or the prompt changes — it is the
+  cheapest guard against a regression that would silently start deleting correct answers.
+
+## Related
+
+- [ADR 0006: Article Genie](../adr/0006-article-genie.md)
+- [Backend Architecture](./backend-architecture.md)
+- [Wikimedia Client Behavior Extension](./wikimedia-client-behavior-extension.md)
+- [Chemistry Links Rendering](./chemistry-links-rendering.md)
+- [API Naming Rules](../development/api-naming-rules.md)
+- [Local Development Setup](../development/local-dev-setup.md)

--- a/docs/architecture/article-genie-llm.md
+++ b/docs/architecture/article-genie-llm.md
@@ -20,17 +20,33 @@ all of it.
 
 ```
 BROWSER  (useGenie composable)
-  seed    S1 = search("linksto:A linksto:B" | keywords), title + description, cap ~40
-          S2 = outbound(A) ∩ outbound(B)          — from the cached link sets
-          merge + dedupe, rank by (mutual links desc, price asc)
-  loop    POST /api/me/genie-turns { history, candidates, bucket }
-          ← { utterance, keep: [ids], done }
-  finish  survivors → existing market search path → priced rows
+  parse   POST /api/me/genie-seeds { query }
+          ← { keywords, anchors: [...] }
+  seed    S1 = searchTitles("linksto:A linksto:B"), title + description
+          S2 = searchTitles(keywords)              — always, never routed away
+          S3 = outbound(A) ∩ outbound(B)           — from the cached link sets
+          merge + dedupe, rank by mutual links, cap 40
+  loop    POST /api/me/genie-turns { query, history, candidates, bucket }
+          ← { utterance, keep: [ids], options, kind, done }
+  finish  survivors → fetchMarketArticlesByTitle → priced rows,
+          re-ranked by (mutual links desc, price asc)
 
-WORKER   (one route)
+WORKER   (two routes, one model call each)
   env.AI.run("@cf/mistralai/mistral-small-3.1-24b-instruct", { messages })
   one subrequest · no D1 · no migration
 ```
+
+**Why parsing is its own call.** A turn is defined over a candidate list, and there is no candidate
+list until the query has been read — so the parse cannot ride along with the first turn. Seeding on
+keywords alone instead would have the Genie open with a question about articles *describing* OpenAI
+rather than ones relating it to Portugal.
+
+**Why price is absent from the loop.** `searchTitles` is the search call without the per-article
+view series, added for exactly this: pricing a candidate costs one 365-day pageview request, and
+the client caches those only as part of a whole search result. Pricing ~40 candidates up front
+would be ~40 requests before the first question, for figures that all but five of them never show.
+The loop ranks on link structure; `(mutual links, price)` is applied at `finish`, over at most five
+articles.
 
 The model id and the ~40 cap are not arbitrary — both were fixed by live testing; see
 [ADR 0006 → Provider and model](../adr/0006-article-genie.md). The 8B model that a cost-first
@@ -84,7 +100,25 @@ type LlmClient = { ask(messages: Message[]): Promise<string> };
 |---|---|
 | `utterance` | one sentence: flavour plus the next question |
 | `keep` | numeric ids that survive; **numbers, not titles** |
+| `options` | the taps offered for this question; the client adds its own "not sure" |
+| `kind` | `filter` or `preference` — a safety boundary, enforced server-side |
 | `done` | model signals it is confident enough to stop |
+
+**What the backend enforces rather than asks for.** Everything the model can get wrong is corrected
+against the request it was answering, because a prompt is a request and these are guarantees:
+
+- ids not in the supplied list are discarded (a made-up id has no article behind it);
+- `kind: "preference"` keeps every id, so such a question can only ever re-rank;
+- an `unsure` answer keeps every id, so a question the player could not answer never costs them the
+  article;
+- a turn that would empty the set restores it — one wasted question beats a session ending with
+  nothing;
+- a question already in the history earns one corrective retry, and if the model repeats itself
+  again the turn is forced to `done`. A set already split on an answer cannot split on it twice, so
+  a repeat is always a wasted question — and the player, who sees the same sentence twice, reads it
+  as the Genie being stuck. Comparison is on the question rather than the utterance, since the
+  flavour is display-only and never returns in the history; in practice a repeated question is what
+  makes the repeated sentence.
 
 The session is **stateless** — the client carries the history. This is safe because resetting the
 history is equivalent to starting a new game, which is already free; the abuse control is the
@@ -213,6 +247,11 @@ a tap. That keeps the injection surface to one clamped field.
 - **Backend** — inject a stub `LlmClient`; never rely on `vi.mock` under the Workers pool.
   Cover: valid JSON, malformed JSON then a successful retry, malformed twice → asleep, ids outside
   the candidate list discarded, oversized payload rejected.
+- **The AI binding is absent from the `test` environment in `wrangler.jsonc`, on purpose.** Workers
+  AI has no local simulator, so declaring it makes the pool open a remote proxy session and demand a
+  `CLOUDFLARE_API_TOKEN` — which CI, running `./gradlew check`, does not have. With the binding
+  declared the *entire* backend suite fails to start, not just the Genie's tests. Route tests supply
+  `env.AI` themselves, which is what they should do anyway.
 - **Frontend** — MSW with `onUnhandledRequest: "error"`, per `frontend/src/tests/setup.ts`.
   Cover: seeding merge and dedupe, ranking order, the asleep popup, and dismissal to the search
   bar.

--- a/dto/genieDTO.ts
+++ b/dto/genieDTO.ts
@@ -1,0 +1,199 @@
+/**
+ * The Article Genie's turn protocol — see
+ * [ADR 0006](../docs/adr/0006-article-genie.md) for the decision and
+ * [Article Genie LLM Integration](../docs/architecture/article-genie-llm.md)
+ * for the mechanism.
+ *
+ * The session is stateless: the client carries the candidate set and the
+ * history, and each request is a complete picture of the game so far. Resetting
+ * that history is equivalent to starting a new game, which is already free, so
+ * the abuse control is the rate limiter rather than the protocol.
+ */
+
+/**
+ * A real Wikipedia article the Genie is choosing between. Ids are small
+ * integers assigned by the client, and the model answers in ids rather than
+ * titles: output tokens dominate session cost and the survivor list is returned
+ * every turn, so ids (~2 tokens) instead of titles (~6) roughly halve it.
+ */
+export interface GenieCandidateDTO {
+  id: number;
+  title: string;
+  /**
+   * The one-line blurb from the search API. **Not optional in practice** — the
+   * game trades on articles that postdate the model's training cutoff, and the
+   * blurb is the only thing that lets it classify one. Measured on the live
+   * top-read set, a single "is it a person?" turn keeps 100% of the people with
+   * blurbs and only 84.6% without, silently losing the ones it has never heard
+   * of. Typed optional solely because Wikipedia does not give every page one.
+   */
+  description?: string;
+}
+
+/**
+ * A question the Genie asked and what the player tapped back. Only the question
+ * is carried, never the flavour text wrapped around it — flavour is display-only
+ * and must not re-enter the prompt on later turns.
+ */
+export interface GenieExchangeDTO {
+  question: string;
+  answer: string;
+}
+
+/**
+ * The answer that must never cost the player the right article. A filter the
+ * player cannot answer is the classic way an Akinator-style loop deletes its own
+ * target, so this one is honoured by the backend rather than trusted to the
+ * prompt: an unsure answer keeps the whole set.
+ */
+export const GENIE_UNSURE_ANSWER = "unsure";
+
+/**
+ * How big the surviving set is, as a word. The player must never see a raw
+ * count — it reads as debug output and breaks character — so the client buckets
+ * the number and passes only the bucket. The model therefore never sees a
+ * figure and cannot contradict one.
+ */
+export const GENIE_BUCKETS = [
+  "vast",
+  "many",
+  "a dozen or so",
+  "a handful",
+  "almost there",
+] as const;
+
+export type GenieBucket = (typeof GENIE_BUCKETS)[number];
+
+export function isGenieBucket(value: unknown): value is GenieBucket {
+  return GENIE_BUCKETS.includes(value as GenieBucket);
+}
+
+/**
+ * Which of the two question kinds the model just asked. The distinction is a
+ * safety boundary, not a label: a *filter* partitions the set and can therefore
+ * drop the right article, while a *preference* only re-ranks and can never lose
+ * anything. The backend enforces that rather than trusting the model to honour
+ * it — see `ArticleGenieService`.
+ */
+export const GENIE_QUESTION_KINDS = ["filter", "preference"] as const;
+
+export type GenieQuestionKind = (typeof GENIE_QUESTION_KINDS)[number];
+
+export function isGenieQuestionKind(value: unknown): value is GenieQuestionKind {
+  return GENIE_QUESTION_KINDS.includes(value as GenieQuestionKind);
+}
+
+/**
+ * Reading the player's opening text into the searches that seed the candidate
+ * set. This is a separate call from a turn because of an ordering constraint the
+ * turn protocol cannot satisfy on its own: a turn is defined over a candidate
+ * list, and there is no candidate list until the query has been read. Folding it
+ * into the first turn would mean seeding on keywords alone, which for *"find me
+ * a relation between OpenAI and Portugal"* returns articles *about* OpenAI and
+ * lets the Genie open with a question about the wrong set entirely.
+ *
+ * It stays within what ADR 0006 asks of the Worker — one model call, one
+ * subrequest, no D1, no migration.
+ */
+export interface GenieSeedRequest {
+  query: string;
+}
+
+export interface GenieSeedResponse {
+  /**
+   * A plain keyword search, always present. Both this and the anchor search run
+   * and their results are merged: with no routing decision to get wrong, a
+   * misread query can only add surplus candidates, never drop the right one.
+   */
+  keywords: string;
+  /**
+   * Article titles the query names, when it names any. Empty for a
+   * tip-of-the-tongue query.
+   */
+  anchors: string[];
+}
+
+/**
+ * A cost guard, not a structural limit. Nothing downstream is written for
+ * pairs: the anchor search conjoins `linksto:` terms and the outbound
+ * intersection folds over however many anchors there are, and a candidate is
+ * ranked by how many of them it links mutually with. Three anchors work; they
+ * just cost one paginated link fetch each and return almost nothing, because
+ * the intersection collapses fast — ADR 0006 measured that even *two* unrelated
+ * anchors yield no candidate with mutual links to both.
+ *
+ * The cap exists so a pathological query cannot fan out without bound. It is
+ * safe to raise, and safe to hit: the keyword search runs alongside the anchor
+ * search regardless, so dropping a fourth anchor narrows the seed rather than
+ * emptying it.
+ */
+export const GENIE_MAX_ANCHORS = 3;
+
+export interface GenieTurnRequest {
+  /** The player's opening free text. The only free-text field in the session. */
+  query: string;
+  /** Prior exchanges, oldest first. Empty on the opening turn. */
+  history: GenieExchangeDTO[];
+  /** The candidates still standing. Ids must be unique within the request. */
+  candidates: GenieCandidateDTO[];
+  bucket: GenieBucket;
+}
+
+export interface GenieTurnResponse {
+  /** One sentence: flavour plus the next question, in the Genie's voice. */
+  utterance: string;
+  /**
+   * The same question stripped of its flavour — this, and never `utterance`, is
+   * what goes into `history`.
+   *
+   * Flavour is display-only. Writing it back would re-feed the model its own
+   * narration on every later turn, growing the prompt with text that carries no
+   * information about the article and inviting it to answer the flavour rather
+   * than the question. Falls back to `utterance` when the model omits it, since
+   * a slightly noisy history beats an empty one.
+   */
+  question: string;
+  /** Ids that survive the answer just given. Always a subset of what was sent. */
+  keep: number[];
+  /** The taps offered for `utterance`. The client adds its own "not sure". */
+  options: string[];
+  kind: GenieQuestionKind;
+  /** The model judges it has narrowed things as far as it usefully can. */
+  done: boolean;
+}
+
+/**
+ * Caps. Oversized payloads are **rejected, not truncated**: silently trimming
+ * hides a client bug and makes the model's answer depend on state nobody can
+ * see.
+ */
+export const GENIE_MAX_QUERY_CHARS = 200;
+/**
+ * Also the design cap on the seeded candidate set. The search API puts the
+ * intended article in roughly the top three, so 40 reliably contains it while
+ * keeping per-turn cost and the model's attention load low.
+ */
+export const GENIE_MAX_CANDIDATES = 40;
+/** The soft cap of 10 turns plus the one optional "+5" extension. */
+export const GENIE_MAX_HISTORY = 15;
+
+/** Survivors at or below this are worth showing rather than narrowing further. */
+export const GENIE_RESULT_THRESHOLD = 5;
+
+export const GENIE_ERRORS = {
+  MALFORMED_BODY: "GENIE_MALFORMED_BODY",
+  QUERY_REQUIRED: "GENIE_QUERY_REQUIRED",
+  QUERY_TOO_LONG: "GENIE_QUERY_TOO_LONG",
+  TOO_MANY_CANDIDATES: "GENIE_TOO_MANY_CANDIDATES",
+  NO_CANDIDATES: "GENIE_NO_CANDIDATES",
+  HISTORY_TOO_LONG: "GENIE_HISTORY_TOO_LONG",
+  INVALID_BUCKET: "GENIE_INVALID_BUCKET",
+  DUPLICATE_CANDIDATE_ID: "GENIE_DUPLICATE_CANDIDATE_ID",
+  RATE_LIMITED: "GENIE_RATE_LIMITED",
+  /**
+   * The single player-facing failure. Quota exhaustion, transport trouble and an
+   * unparseable response after a retry all land here, because they all mean the
+   * same thing to the player: the genie is asleep, use the search bar.
+   */
+  ASLEEP: "GENIE_ASLEEP",
+} as const;

--- a/external-apis/wikimedia/client.ts
+++ b/external-apis/wikimedia/client.ts
@@ -4,8 +4,8 @@ import {Domain} from "../../model/enums";
 import {createGetViewsByDomain, DomainResult} from "./client/getViewsByDomain";
 import {createGetLinks, articleWithLinks} from "./client/getLinks";
 import {ArticleViews, createResolveArticleViews, createResolveArticleViewsWithFallback} from "./client/articleViews";
-import {createSearchArticles} from "./client/searchArticles";
-import {TopReadEntry} from "./wikimedia";
+import {createSearchArticles, createSearchTitles} from "./client/searchArticles";
+import {ArticleSearchHit, TopReadEntry} from "./wikimedia";
 
 const DAY = 24 * 60 * 60 * 1000;
 /**
@@ -128,6 +128,13 @@ export type WikimediaClient = {
         getSummary(domain: Domain, title: string): Promise<ArticleSummary>;
         getLinkedArticles(domain: Domain, title: string): Promise<articleWithLinks>;
         search(domain: Domain, query: string, limit: number): Promise<TopReadEntry[]>;
+        /**
+         * `search` without the per-article view series: one request, titles and
+         * blurbs only. Use it when the answer needed is "which articles exist",
+         * not "what are they worth" — `search` costs one 365-day pageview
+         * request per hit on top of this.
+         */
+        searchTitles(domain: Domain, query: string, limit: number): Promise<ArticleSearchHit[]>;
     };
 };
 
@@ -165,6 +172,8 @@ export function createWikimediaClient(options: WikimediaClientOptions = {}): Wik
         http, retryCount, averageDays, maxFallbackDays, resolveArticleViews,
     );
 
+    const searchTitles = createSearchTitles(http, setTtl(cache, 7*DAY), retryCount);
+
     return {
         pageviews: {
             getTopReadList: createGetTopReadList(
@@ -176,7 +185,10 @@ export function createWikimediaClient(options: WikimediaClientOptions = {}): Wik
         article: {
             getSummary: createGetSummary( http, setTtl(cache,7*DAY), retryCount ),
             getLinkedArticles: createGetLinks(http, setTtl(cache, 7*DAY), retryCount),
-            search: createSearchArticles(http, setTtl(cache, 7*DAY), retryCount, resolveArticleViews),
+            search: createSearchArticles(
+                http, setTtl(cache, 7*DAY), retryCount, resolveArticleViews, searchTitles,
+            ),
+            searchTitles,
         },
     };
 }

--- a/external-apis/wikimedia/client/searchArticles.ts
+++ b/external-apis/wikimedia/client/searchArticles.ts
@@ -1,5 +1,10 @@
 import type { Domain } from "../../../dto/enums";
-import { TopReadEntry, isContentArticleTitle, toDisplayTitle } from "../wikimedia";
+import {
+    ArticleSearchHit,
+    TopReadEntry,
+    isContentArticleTitle,
+    toDisplayTitle,
+} from "../wikimedia";
 import {
     MAX_CONCURRENT_REQUESTS,
     fetchJsonWithRetry,
@@ -27,11 +32,58 @@ function buildArticleUrl(domain: Domain, title: string): string {
     return `https://${domain}.wikipedia.org/wiki/${encodeURIComponent(title).replace(/%20/g, "_")}`;
 }
 
+/**
+ * Searches for article titles without touching the pageviews API.
+ *
+ * This is the search call on its own: one request, no per-article fan-out.
+ * `searchArticles` below is this plus a view series per hit, which is what the
+ * market listing needs — but a caller that only wants to know *which articles
+ * exist* (the Article Genie seeding its candidate set, ADR 0006) would pay one
+ * 365-day pageview request per hit for data it discards. At the Genie's ~40
+ * candidates that is ~40 wasted requests before it can ask its first question,
+ * so the two are separated rather than one being layered over the other.
+ *
+ * Cached under its own key: the two searches return different shapes, and a
+ * shared key would let whichever ran first decide what the other got back.
+ */
+export function createSearchTitles(
+    http: WikimediaHttp,
+    cache: CacheLike | null,
+    retryCount: number,
+) {
+    return async function searchTitles(
+        domain: Domain,
+        query: string,
+        limit: number,
+    ): Promise<ArticleSearchHit[]> {
+        const trimmed = query.trim();
+        if (!trimmed) return [];
+
+        const cacheKey = `wikimedia:searchtitles:${domain}.wikipedia:${encodeURIComponent(trimmed)}:limit:${limit}`;
+        const cacheWithTtl = cache ? { ...cache, ttlMs: DEFAULT_SEARCH_CACHE_TTL } : null;
+
+        return withCache(cacheWithTtl, cacheKey, async () => {
+            const url = `https://api.wikimedia.org/core/v1/wikipedia/${domain}/search/page?q=${encodeURIComponent(trimmed)}&limit=${limit}`;
+
+            const response = await fetchJsonWithRetry<SearchResponse>(http, url, retryCount);
+
+            return (response.pages ?? [])
+                .filter((page) => isContentArticleTitle(page.key))
+                .map((page) => ({
+                    canonicalTitle: page.key,
+                    displayTitle: page.title || toDisplayTitle(page.key),
+                    description: page.description,
+                }));
+        });
+    };
+}
+
 export function createSearchArticles(
     http: WikimediaHttp,
     cache: CacheLike | null,
     retryCount: number,
     resolveArticleViews: (domain: Domain, title: string, snapshotDate: Date) => Promise<ArticleViews>,
+    searchTitles = createSearchTitles(http, cache, retryCount),
 ) {
     return async function searchArticles(
         domain: Domain,
@@ -45,27 +97,24 @@ export function createSearchArticles(
         const cacheWithTtl = cache ? { ...cache, ttlMs: DEFAULT_SEARCH_CACHE_TTL } : null;
 
         return withCache(cacheWithTtl, cacheKey, async () => {
-            const url = `https://api.wikimedia.org/core/v1/wikipedia/${domain}/search/page?q=${encodeURIComponent(trimmed)}&limit=${limit}`;
-
-            const response = await fetchJsonWithRetry<SearchResponse>(http, url, retryCount);
-            const pages = (response.pages ?? []).filter((p) => isContentArticleTitle(p.key));
-
+            const hits = await searchTitles(domain, trimmed, limit);
             const snapshotDate = shiftUtcDays(new Date(), -1);
 
             // One per-article request per hit — capped like every other
             // fan-out in this client.
             const entries = await mapWithLimit(
-                pages.map((page, idx) => ({ page, idx })),
+                hits.map((hit, idx) => ({ hit, idx })),
                 MAX_CONCURRENT_REQUESTS,
-                async ({ page, idx }): Promise<TopReadEntry> => {
-                    const views = await resolveArticleViews(domain, page.key, snapshotDate);
+                async ({ hit, idx }): Promise<TopReadEntry> => {
+                    const views = await resolveArticleViews(domain, hit.canonicalTitle, snapshotDate);
                     return {
-                        canonicalTitle: page.key,
-                        displayTitle: page.title || toDisplayTitle(page.key),
+                        canonicalTitle: hit.canonicalTitle,
+                        displayTitle: hit.displayTitle,
+                        description: hit.description,
                         sourceRank: idx + 1,
                         filteredRank: idx + 1,
                         dailyViews: views.latestDayViews ?? 0,
-                        articleUrl: buildArticleUrl(domain, page.key),
+                        articleUrl: buildArticleUrl(domain, hit.canonicalTitle),
                         averageViews30d: views.averageViews30d,
                         weekViews: views.weekViews,
                         monthViews: views.monthViews,

--- a/external-apis/wikimedia/wikimedia.ts
+++ b/external-apis/wikimedia/wikimedia.ts
@@ -6,6 +6,22 @@ export type WikimediaTopReadArticle = {
   rank: number;
 };
 
+/**
+ * A search hit before any pageview work is done: what the search endpoint
+ * itself returns, and nothing more.
+ *
+ * `description` is the one-line blurb the search API supplies (the same text
+ * shown under a title in Wikipedia's own search box). It is what lets a
+ * consumer classify an article that postdates its own knowledge — see
+ * [ADR 0006](../../docs/adr/0006-article-genie.md) — so it is carried here
+ * rather than dropped. It is optional because not every page has one.
+ */
+export type ArticleSearchHit = {
+  canonicalTitle: string;
+  displayTitle: string;
+  description?: string;
+};
+
 export type TopReadEntry = {
   canonicalTitle: string;
   displayTitle: string;
@@ -13,6 +29,8 @@ export type TopReadEntry = {
   filteredRank: number;
   dailyViews: number;
   articleUrl: string;
+  /** Present on search-derived entries; the top-read payload carries no blurb. */
+  description?: string;
   averageViews30d?: number;
   weekViews?: number;
   monthViews?: number;

--- a/frontend/src/assets/genie/asking.svg
+++ b/frontend/src/assets/genie/asking.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M80 132 C70 144 74 158 86 162" stroke="#171f1b" stroke-width="25"/>
+    <path d="M80 132 C70 144 74 158 86 162" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M80 132 C70 144 74 158 86 162" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="89" cy="165" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M120 130 C138 124 146 106 142 90" stroke="#171f1b" stroke-width="25"/>
+    <path d="M120 130 C138 124 146 106 142 90" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M120 130 C138 124 146 106 142 90" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <path d="M136 62 L136 84" stroke="#171f1b" stroke-width="11" stroke-linecap="round"/>
+  <path d="M136 63 L136 84" stroke="#f4f1ea" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="141" cy="86" r="10" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <circle cx="90" cy="99" r="4.5" fill="#171f1b"/>
+  <circle cx="111" cy="99" r="4.5" fill="#171f1b"/>
+  <path d="M81 84 L95 83" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M105 83 L119 84" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <ellipse cx="100" cy="114" rx="5" ry="4" fill="#171f1b"/>
+</svg>

--- a/frontend/src/assets/genie/asleep.svg
+++ b/frontend/src/assets/genie/asleep.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="lamp-lid">
+      <path d="M84 214 C84 199 124 199 124 214" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M84 214 C84 199 124 199 124 214" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="99" y="192" width="10" height="14" rx="5" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M92 214 C94 204 114 204 116 214 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+    </g>
+  </defs>
+  <use href="#lamp"/>
+  <use href="#lamp-lid"/>
+  <path d="M66 210 C78 202 58 194 70 184 C78 178 76 172 72 168" fill="none" stroke="#737f73" stroke-width="4" stroke-linecap="round" opacity="0.45"/>
+  <text x="96" y="176" font-family="Georgia, serif" font-weight="700" font-size="20" fill="#1e7e50" opacity="0.7">z</text>
+  <text x="112" y="150" font-family="Georgia, serif" font-weight="700" font-size="30" fill="#1e7e50" opacity="0.85">z</text>
+  <text x="134" y="112" font-family="Georgia, serif" font-weight="700" font-size="42" fill="#1e7e50">z</text>
+</svg>

--- a/frontend/src/assets/genie/celebrating.svg
+++ b/frontend/src/assets/genie/celebrating.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M80 130 C64 122 58 104 62 90" stroke="#171f1b" stroke-width="25"/>
+    <path d="M80 130 C64 122 58 104 62 90" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M80 130 C64 122 58 104 62 90" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="61" cy="84" r="10" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M120 130 C136 122 142 104 138 90" stroke="#171f1b" stroke-width="25"/>
+    <path d="M120 130 C136 122 142 104 138 90" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M120 130 C136 122 142 104 138 90" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="139" cy="84" r="10" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <path d="M84 101 C87 95 93 95 96 101" stroke="#171f1b" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+  <path d="M104 101 C107 95 113 95 116 101" stroke="#171f1b" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+  <path d="M81 83 L95 81" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M105 81 L119 83" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M90 110 C95 122 105 122 110 110 Z" fill="#171f1b"/>
+  <path d="M46 118 L49 126 L57 129 L49 132 L46 140 L43 132 L35 129 L43 126 Z" fill="#f5c842"/>
+  <path d="M156 112 L158 118 L164 120 L158 122 L156 128 L154 122 L148 120 L154 118 Z" fill="#f5c842"/>
+  <path d="M150 168 L152 174 L158 176 L152 178 L150 184 L148 178 L142 176 L148 174 Z" fill="#f5c842"/>
+</svg>

--- a/frontend/src/assets/genie/defeated.svg
+++ b/frontend/src/assets/genie/defeated.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M78 134 C70 152 70 168 76 180" stroke="#171f1b" stroke-width="25"/>
+    <path d="M78 134 C70 152 70 168 76 180" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M78 134 C70 152 70 168 76 180" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="78" cy="186" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M122 134 C130 152 130 168 124 180" stroke="#171f1b" stroke-width="25"/>
+    <path d="M122 134 C130 152 130 168 124 180" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M122 134 C130 152 130 168 124 180" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="122" cy="186" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <path d="M85 98 C88 103 93 103 96 98" stroke="#171f1b" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+  <path d="M104 98 C107 103 112 103 115 98" stroke="#171f1b" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+  <path d="M82 86 L95 90" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M105 90 L118 86" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M92 117 C96 112 104 112 108 117" stroke="#171f1b" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M128 82 C132 89 135 92 135 96 C135 100 131 102 128 100 C125 98 125 94 126 90 Z" fill="#c2e8d9" stroke="#171f1b" stroke-width="2"/>
+</svg>

--- a/frontend/src/assets/genie/greeting.svg
+++ b/frontend/src/assets/genie/greeting.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M80 132 C66 144 60 160 64 172" stroke="#171f1b" stroke-width="25"/>
+    <path d="M80 132 C66 144 60 160 64 172" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M80 132 C66 144 60 160 64 172" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="65" cy="178" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M120 132 C140 130 150 114 148 96" stroke="#171f1b" stroke-width="25"/>
+    <path d="M120 132 C140 130 150 114 148 96" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M120 132 C140 130 150 114 148 96" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="148" cy="90" r="10" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <circle cx="90" cy="99" r="4" fill="#171f1b"/>
+  <circle cx="111" cy="99" r="4" fill="#171f1b"/>
+  <path d="M82 88 L95 86" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M105 86 L118 88" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M91 111 C96 117 105 117 109 111" stroke="#171f1b" stroke-width="3" fill="none" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/genie/reading.svg
+++ b/frontend/src/assets/genie/reading.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M78 134 C68 146 68 158 76 164" stroke="#171f1b" stroke-width="25"/>
+    <path d="M78 134 C68 146 68 158 76 164" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M78 134 C68 146 68 158 76 164" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <g stroke-linecap="round" fill="none">
+    <path d="M122 134 C132 146 132 158 124 164" stroke="#171f1b" stroke-width="25"/>
+    <path d="M122 134 C132 146 132 158 124 164" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M122 134 C132 146 132 158 124 164" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <g transform="rotate(-4 100 166)">
+    <rect x="70" y="146" width="60" height="42" rx="4" fill="#fbfbf7" stroke="#171f1b" stroke-width="3"/>
+    <path d="M100 146 L100 188" stroke="#171f1b" stroke-width="2.5"/>
+    <path d="M78 158 L93 158" stroke="#737f73" stroke-width="3" stroke-linecap="round"/>
+    <path d="M78 168 L93 168" stroke="#737f73" stroke-width="3" stroke-linecap="round"/>
+    <path d="M78 178 L88 178" stroke="#737f73" stroke-width="3" stroke-linecap="round"/>
+    <path d="M107 158 L122 158" stroke="#737f73" stroke-width="3" stroke-linecap="round"/>
+    <path d="M107 168 L122 168" stroke="#737f73" stroke-width="3" stroke-linecap="round"/>
+  </g>
+  <circle cx="74" cy="167" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <circle cx="126" cy="167" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <circle cx="90" cy="103" r="4" fill="#171f1b"/>
+  <circle cx="111" cy="103" r="4" fill="#171f1b"/>
+  <path d="M82 88 L95 88" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M105 88 L118 88" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M94 114 L107 113" stroke="#171f1b" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/genie/sly.svg
+++ b/frontend/src/assets/genie/sly.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M120 136 C112 150 98 156 84 152" stroke="#171f1b" stroke-width="25"/>
+    <path d="M120 136 C112 150 98 156 84 152" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M120 136 C112 150 98 156 84 152" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="80" cy="150" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M80 136 C90 152 104 156 118 149" stroke="#171f1b" stroke-width="25"/>
+    <path d="M80 136 C90 152 104 156 118 149" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M80 136 C90 152 104 156 118 149" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="122" cy="146" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <path d="M85 100 L96 101" stroke="#171f1b" stroke-width="4" stroke-linecap="round"/>
+  <path d="M105 101 L116 100" stroke="#171f1b" stroke-width="4" stroke-linecap="round"/>
+  <path d="M82 84 L95 87" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M105 90 L118 86" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M91 113 C97 118 106 116 110 110" stroke="#171f1b" stroke-width="3" fill="none" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/genie/stumped.svg
+++ b/frontend/src/assets/genie/stumped.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M80 134 C64 142 58 156 62 168" stroke="#171f1b" stroke-width="25"/>
+    <path d="M80 134 C64 142 58 156 62 168" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M80 134 C64 142 58 156 62 168" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="63" cy="174" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M120 134 C136 142 142 156 138 168" stroke="#171f1b" stroke-width="25"/>
+    <path d="M120 134 C136 142 142 156 138 168" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M120 134 C136 142 142 156 138 168" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="137" cy="174" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <circle cx="90" cy="99" r="4" fill="#171f1b"/>
+  <circle cx="111" cy="100" r="4" fill="#171f1b"/>
+  <path d="M82 82 L95 87" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M105 89 L118 89" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M91 113 C95 109 100 117 109 112" stroke="#171f1b" stroke-width="3" fill="none" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/genie/surprised.svg
+++ b/frontend/src/assets/genie/surprised.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M80 132 C66 128 60 114 64 102" stroke="#171f1b" stroke-width="25"/>
+    <path d="M80 132 C66 128 60 114 64 102" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M80 132 C66 128 60 114 64 102" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="65" cy="96" r="10" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M120 132 C134 128 140 114 136 102" stroke="#171f1b" stroke-width="25"/>
+    <path d="M120 132 C134 128 140 114 136 102" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M120 132 C134 128 140 114 136 102" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="135" cy="96" r="10" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <circle cx="90" cy="100" r="6" fill="#fbfbf7" stroke="#171f1b" stroke-width="2.5"/>
+  <circle cx="90" cy="100" r="2.8" fill="#171f1b"/>
+  <circle cx="111" cy="100" r="6" fill="#fbfbf7" stroke="#171f1b" stroke-width="2.5"/>
+  <circle cx="111" cy="100" r="2.8" fill="#171f1b"/>
+  <path d="M81 84 C86 79 92 80 95 83" stroke="#171f1b" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+  <path d="M105 83 C108 80 114 79 119 84" stroke="#171f1b" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+  <ellipse cx="100" cy="115" rx="4.5" ry="5.5" fill="#171f1b"/>
+</svg>

--- a/frontend/src/assets/genie/thinking.svg
+++ b/frontend/src/assets/genie/thinking.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260" fill="none">
+  <defs>
+    <g id="lamp">
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#171f1b" stroke-width="10" stroke-linecap="round"/>
+      <path d="M152 226 C169 223 178 234 171 243 C165 250 156 252 149 249" fill="none" stroke="#f5c842" stroke-width="5" stroke-linecap="round"/>
+      <rect x="80" y="248" width="60" height="8" rx="4" fill="#d8b03a" stroke="#171f1b" stroke-width="3"/>
+      <path d="M103 238 L117 238 C113 242 113 244 120 249 L100 249 C107 244 107 242 103 238 Z" fill="#d8b03a" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M67 227 L149 227 L124 248 L93 248 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M78 240 L138 240 L124 248 L93 248 Z" fill="rgba(23,31,27,0.2)"/>
+      <path d="M62 220 C66 217 72 215 78 215 L150 215 C154 215 157 217 157 221 C157 225 154 227 150 227 L76 227 C70 226 65 224 62 220 Z" fill="#f5c842" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M86 220 L118 220" stroke="rgba(251,251,247,0.6)" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <g id="base">
+      <path d="M78 120 C60 134 52 154 54 174 C56 192 68 204 88 206 C96 214 88 223 72 224 C96 225 126 215 148 197 C151 184 138 172 124 176 C130 158 130 136 122 120 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M88 206 C96 214 88 223 72 224 C94 222 122 213 135 202 C124 205 104 210 88 206 Z" fill="rgba(23,31,27,0.17)"/>
+      <path d="M56 176 C60 192 72 202 90 205 C74 205 60 197 56 186 Z" fill="rgba(23,31,27,0.12)"/>
+      <use href="#lamp"/>
+      <g fill="none" stroke-linecap="round">
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#171f1b" stroke-width="14"/>
+        <path d="M58 150 C80 161 104 161 128 147" stroke="#f5c842" stroke-width="8"/>
+      </g>
+      <path d="M100 52 C127 52 143 71 141 98 C140 112 133 124 125 131 L75 131 C67 124 60 112 59 98 C57 71 73 52 100 52 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M92 57 C95 40 106 34 111 44 C114 53 109 59 104 61 Z" fill="#1e7e50" stroke="#171f1b" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M80 122 C86 136 114 136 120 122 C114 129 86 129 80 122 Z" fill="rgba(23,31,27,0.45)"/>
+      <circle cx="100" cy="99" r="27" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+      <path d="M73 91 C75 74 86 65 100 65 C114 65 125 74 127 91 C121 79 112 74 100 74 C88 74 79 79 73 91 Z" fill="#f5c842" stroke="#171f1b" stroke-width="2.5" stroke-linejoin="round"/>
+      <path d="M95 119 C97 125 103 125 105 119 C105 129 95 129 95 119 Z" fill="#171f1b"/>
+    </g>
+  </defs>
+  <use href="#base"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M79 134 C70 148 74 162 86 166" stroke="#171f1b" stroke-width="25"/>
+    <path d="M79 134 C70 148 74 162 86 166" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M79 134 C70 148 74 162 86 166" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="89" cy="169" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <g stroke-linecap="round" fill="none">
+    <path d="M121 134 C138 143 137 123 116 118" stroke="#171f1b" stroke-width="25"/>
+    <path d="M121 134 C138 143 137 123 116 118" stroke="#1e7e50" stroke-width="18"/>
+    <path d="M121 134 C138 143 137 123 116 118" stroke="rgba(23,31,27,0.15)" stroke-width="18"/>
+  </g>
+  <circle cx="111" cy="117" r="9.5" fill="#f4f1ea" stroke="#171f1b" stroke-width="3"/>
+  <path d="M85 100 C88 96 93 96 96 100" stroke="#171f1b" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <circle cx="111" cy="99" r="4" fill="#171f1b"/>
+  <path d="M82 84 L95 86" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M105 88 L118 87" stroke="#171f1b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M89 114 L99 113" stroke="#171f1b" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/components/ArticleGenie.vue
+++ b/frontend/src/components/ArticleGenie.vue
@@ -1,0 +1,411 @@
+<template>
+  <!-- A full modal rather than the popover/sheet pair this started as. The
+       Genie takes the player's whole attention for a minute at a time, so it
+       gets the screen — and an auto-height sheet with no `ion-content` collapsed
+       its own hit area, which left the answer buttons visible but unclickable. -->
+  <ion-modal
+    :is-open="isOpen"
+    :initial-breakpoint="1"
+    :breakpoints="[0, 1]"
+    handle-behavior="cycle"
+    class="genie-modal"
+    @did-dismiss="onDismiss"
+  >
+    <ion-header class="ion-no-border">
+      <ion-toolbar>
+        <!-- Abandoning a hunt is a normal thing to want, mid-question as much
+             as at the end — a wrong answer three questions back is otherwise
+             only escapable by closing the panel. Kept in the toolbar so it sits
+             in one place across both states instead of crowding the answers. -->
+        <ion-buttons slot="start">
+          <ion-button
+            v-if="canStartOver"
+            fill="clear"
+            size="small"
+            class="genie-restart"
+            @click="reset()"
+          >
+            <ion-icon slot="start" :icon="refreshOutline" />
+            {{ t("market.genie.newGuess") }}
+          </ion-button>
+        </ion-buttons>
+        <!-- The `k` is struck rather than dropped, so the joke reads as a
+             knock-off oracle. It is hidden from assistive tech, which would
+             otherwise spell out a name nobody says out loud. -->
+        <ion-title class="genie-title">
+          <span class="genie-wordmark"
+            >A<span aria-hidden="true">k</span>Inator</span
+          >
+        </ion-title>
+        <ion-buttons slot="end">
+          <ion-button fill="clear" @click="emit('close')">
+            <ion-icon :icon="closeOutline" slot="icon-only" />
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding genie-content">
+      <div class="genie">
+        <!-- One figure for every state, above whatever the state needs. The
+             asleep frame is the lamp on its own — the only one he is absent
+             from, which is the point of it. -->
+        <img
+          class="genie-figure"
+          :class="{ 'genie-figure--adrift': isBusy }"
+          :src="POSE_ART[pose]"
+          :alt="t('market.genie.imageAlt')"
+        />
+
+        <!-- Opening: the one and only free-text field in the session. -->
+        <template v-if="status === 'idle'">
+          <p class="genie-line">{{ t("market.genie.prompt") }}</p>
+          <ion-item lines="none" class="genie-field">
+            <ion-input
+              :value="draft"
+              :placeholder="t('market.genie.placeholder')"
+              :maxlength="GENIE_MAX_QUERY_CHARS"
+              :aria-label="t('market.genie.prompt')"
+              @ion-input="draft = String($event.detail.value ?? '')"
+              @keyup.enter="submit"
+            />
+          </ion-item>
+          <ion-button
+            expand="block"
+            class="genie-action"
+            :disabled="!draft.trim()"
+            @click="submit"
+          >
+            {{ t("market.genie.ask") }}
+          </ion-button>
+        </template>
+
+        <!-- Working. The wording never mentions how many are left. -->
+        <template v-else-if="status === 'seeding' || status === 'thinking'">
+          <div class="genie-busy">
+            <ion-spinner name="dots" color="primary" />
+            <span class="genie-line">{{
+              status === "seeding"
+                ? t("market.genie.seeking")
+                : t("market.genie.thinking")
+            }}</span>
+          </div>
+        </template>
+
+        <!-- The question. Answers are taps, so the keyboard stays away. -->
+        <template v-else-if="status === 'asking'">
+          <p class="genie-utterance">{{ utterance }}</p>
+          <div class="genie-options">
+            <ion-button
+              v-for="option in options"
+              :key="option"
+              expand="block"
+              fill="outline"
+              class="genie-action"
+              @click="answer(option)"
+            >
+              {{ option }}
+            </ion-button>
+            <!-- Always offered, and never narrows anything: a question the
+                 player cannot answer must not be the reason their article
+                 disappears. -->
+            <ion-button
+              expand="block"
+              fill="clear"
+              color="medium"
+              class="genie-action"
+              @click="answerUnsure()"
+            >
+              {{ t("market.genie.unsure") }}
+            </ion-button>
+          </div>
+        </template>
+
+        <!-- The hunt is over. The Genie says so and stands aside on a tap,
+             rather than the panel vanishing on its own — the rows appear in the
+             table behind it, and a modal that closes itself gives no clue that
+             is where to look. -->
+        <template v-else-if="status === 'results'">
+          <p class="genie-utterance">{{ t("market.genie.found") }}</p>
+          <ion-button
+            expand="block"
+            class="genie-action"
+            @click="emit('close')"
+          >
+            {{ t("market.genie.ok") }}
+          </ion-button>
+          <ion-button
+            v-if="canExtend"
+            expand="block"
+            fill="clear"
+            color="medium"
+            class="genie-action"
+            @click="keepGuessing()"
+          >
+            {{ t("market.genie.keepGuessing") }}
+          </ion-button>
+        </template>
+
+        <!-- Asleep. The panel dismisses to the ordinary search bar; buying an
+             article never depended on the Genie in the first place. -->
+        <template v-else-if="status === 'asleep'">
+          <span class="genie-line">{{ t("market.genie.asleep") }}</span>
+        </template>
+      </div>
+    </ion-content>
+  </ion-modal>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from "vue";
+import {
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonModal,
+  IonSpinner,
+  IonTitle,
+  IonToolbar,
+} from "@ionic/vue";
+import { closeOutline, refreshOutline } from "ionicons/icons";
+import { useI18n } from "vue-i18n";
+import { useGenie, type GeniePose } from "@/composables/useGenie";
+import { GENIE_MAX_QUERY_CHARS } from "../../../dto/genieDTO";
+import type { MarketArticle } from "@/types/market";
+import asking from "@/assets/genie/asking.svg";
+import asleep from "@/assets/genie/asleep.svg";
+import celebrating from "@/assets/genie/celebrating.svg";
+import defeated from "@/assets/genie/defeated.svg";
+import greeting from "@/assets/genie/greeting.svg";
+import reading from "@/assets/genie/reading.svg";
+import sly from "@/assets/genie/sly.svg";
+import stumped from "@/assets/genie/stumped.svg";
+import surprised from "@/assets/genie/surprised.svg";
+import thinking from "@/assets/genie/thinking.svg";
+
+/**
+ * Which pose is shown when is the composable's business — it has the history
+ * the rotation is derived from. This only turns the name into a file.
+ */
+const POSE_ART: Record<GeniePose, string> = {
+  asking,
+  asleep,
+  celebrating,
+  defeated,
+  greeting,
+  reading,
+  sly,
+  stumped,
+  surprised,
+  thinking,
+};
+
+const { t } = useI18n();
+
+/** Long enough to read the line, short enough not to feel like a dead end. */
+const ASLEEP_DISMISS_MS = 2200;
+
+const props = defineProps<{ isOpen: boolean }>();
+
+const emit = defineEmits<{
+  close: [];
+  results: [articles: MarketArticle[]];
+}>();
+
+const {
+  status,
+  pose,
+  utterance,
+  options,
+  results,
+  canExtend,
+  draft,
+  start,
+  answer,
+  answerUnsure,
+  keepGuessing,
+  resumeOrReset,
+  reset,
+} = useGenie();
+
+/**
+ * Only offered once there is a hunt to abandon, and never mid-request: a reset
+ * while a turn is in flight would be undone the moment that turn came back.
+ */
+const canStartOver = computed(
+  () => status.value === "asking" || status.value === "results"
+);
+
+/** Drives the drift on the figure, so a wait never looks like a frozen frame. */
+const isBusy = computed(
+  () => status.value === "seeding" || status.value === "thinking"
+);
+
+function submit() {
+  if (!draft.value.trim()) return;
+  start(draft.value);
+}
+
+// Reopening picks the session back up where it was left, unless it has gone
+// stale — so a mistaken tap on the backdrop costs nothing.
+watch(
+  () => props.isOpen,
+  (open) => {
+    if (open) resumeOrReset();
+  },
+  { immediate: true }
+);
+
+/**
+ * The rows are the answer, so they go to the market table rather than being
+ * listed again here — same price, ownership badge and buy flow as every other
+ * row, which is the whole point of the Genie being additive.
+ *
+ * Handing them over on dismissal, not on arrival, is what makes the reveal
+ * legible: the table changes as the panel gets out of the way, so the player
+ * sees where to look. It runs on `did-dismiss` rather than on the OK button so
+ * that dismissing by the backdrop cannot lose a hunt the player just finished.
+ */
+function onDismiss() {
+  if (results.value.length > 0) {
+    emit("results", results.value);
+  }
+  emit("close");
+}
+
+// Asleep is a brief popup, not a state to sit in: it says its line and hands
+// the player back to the search bar.
+watch(status, (value) => {
+  if (value === "asleep") {
+    window.setTimeout(() => emit("close"), ASLEEP_DISMISS_MS);
+  }
+});
+</script>
+
+<style scoped>
+/* Nearly the whole screen: this is a task you give your attention to, and the
+   market table behind it is not something you cross-reference mid-question. */
+.genie-modal {
+  --width: min(600px, 94vw);
+  --height: min(760px, 90vh);
+  --border-radius: 1rem;
+}
+
+@media (max-width: 767px) {
+  .genie-modal {
+    --width: 100%;
+    --height: 100%;
+    --border-radius: 1rem 1rem 0 0;
+  }
+}
+
+.genie-title {
+  font-size: 1rem;
+}
+
+.genie-wordmark {
+  font-family: var(--font-family-headings);
+  font-weight: 700;
+}
+
+.genie-wordmark span {
+  text-decoration: line-through;
+  text-decoration-thickness: 2px;
+  text-decoration-color: var(--ion-color-danger);
+}
+
+.genie-content {
+  --padding-bottom: calc(var(--ion-safe-area-bottom, 0px) + 1rem);
+}
+
+/* Centred vertically: for most of the session this holds one sentence and a
+   few buttons, and pinning that to the top of a tall modal looks abandoned. */
+/* Centred vertically, but `safe`: on a short screen the tallest state — a
+   two-line question over four options and the "no idea" out — is taller than
+   the modal, and plain `center` would push its top edge out of the scroll
+   container's reach rather than letting it scroll. */
+.genie {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: safe center;
+  gap: 1rem;
+}
+
+/* Sized off the viewport, not the source box: the figure is the first thing
+   that should give way when the question is long and the options are many,
+   because the answer buttons are the only part the player has to reach. */
+.genie-figure {
+  align-self: center;
+  height: clamp(88px, 24vh, 180px);
+  width: auto;
+  flex: none;
+}
+
+@keyframes genie-adrift {
+  from {
+    transform: translateY(3px);
+  }
+  to {
+    transform: translateY(-5px);
+  }
+}
+
+.genie-figure--adrift {
+  animation: genie-adrift 2.4s ease-in-out infinite alternate;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .genie-figure--adrift {
+    animation: none;
+  }
+}
+
+.genie-line {
+  font-size: 1rem;
+  margin: 0;
+  color: var(--ion-color-medium);
+  text-align: center;
+}
+
+.genie-utterance {
+  font-size: 1.25rem;
+  line-height: 1.4;
+  margin: 0 0 0.5rem;
+  text-align: center;
+  color: var(--ion-text-color);
+  font-family: var(--font-family-headings);
+}
+
+.genie-field {
+  --min-height: 52px;
+  --padding-start: 0.75rem;
+  border: 1.5px solid var(--ion-color-primary);
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+.genie-action {
+  margin: 0;
+  --border-radius: 8px;
+  text-transform: none;
+  font-size: 1rem;
+}
+
+.genie-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.genie-busy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+</style>

--- a/frontend/src/composables/useGenie.ts
+++ b/frontend/src/composables/useGenie.ts
@@ -1,0 +1,376 @@
+import { computed, ref } from "vue";
+import { api } from "@/services/api";
+import {
+  hydrateCandidates,
+  seedCandidates,
+  type GenieCandidate,
+} from "@/services/genieService";
+import { useLeagueStore } from "@/stores/league";
+import type { MarketArticle } from "@/types/market";
+import {
+  GENIE_MAX_QUERY_CHARS,
+  GENIE_RESULT_THRESHOLD,
+  GENIE_UNSURE_ANSWER,
+  type GenieBucket,
+  type GenieExchangeDTO,
+} from "../../../dto/genieDTO";
+
+/** Soft cap on questions, and the one extension the player can ask for. */
+const SOFT_TURN_CAP = 10;
+const TURN_EXTENSION = 5;
+
+/**
+ * How long a dismissed session stays warm. Long enough that a mistaken tap on
+ * the backdrop, or a look at the table behind, costs the player nothing; short
+ * enough that coming back much later starts a hunt for whatever they want *now*.
+ */
+const SESSION_TTL_MS = 10 * 60 * 1000;
+
+export type GenieStatus =
+  "idle" | "seeding" | "asking" | "thinking" | "results" | "asleep";
+
+/**
+ * The faces the Genie wears while questioning, cycled so no two consecutive
+ * questions are delivered by the same drawing.
+ *
+ * `thinking` is deliberately not among them: it flashes between every pair of
+ * questions, so reusing it here would put the same pose on screen either side
+ * of the transition — the back-to-back repetition the utterances already avoid.
+ */
+const QUESTION_POSES = [
+  "asking",
+  "sly",
+  "reading",
+  "surprised",
+  "stumped",
+  "defeated",
+] as const;
+
+type GenieQuestionPose = (typeof QUESTION_POSES)[number];
+
+export type GeniePose =
+  GenieQuestionPose | "greeting" | "thinking" | "celebrating" | "asleep";
+
+function shuffled(poses: readonly GenieQuestionPose[]): GenieQuestionPose[] {
+  const out = [...poses];
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/**
+ * The order the question poses come out in, drawn fresh for each hunt so the
+ * third question is not forever asked by the same face.
+ *
+ * Built as whole shuffled passes rather than an independent draw per question:
+ * an independent draw can spend a long hunt alternating between two poses, and
+ * the point of the set is that the player sees it. Every pose appears once per
+ * pass, in an order that changes.
+ *
+ * A pass opening on the pose the previous one closed with is rotated by one
+ * rather than reshuffled — the poses within a pass are all distinct, so moving
+ * the head to the tail fixes the join in a single step, where reshuffling could
+ * in principle keep colliding.
+ *
+ * Long enough to outrun the cap and its extension, so the run never wraps onto
+ * its own start.
+ */
+function buildPoseCycle(): GenieQuestionPose[] {
+  const cycle: GenieQuestionPose[] = [];
+  while (cycle.length <= SOFT_TURN_CAP + TURN_EXTENSION) {
+    const pass = shuffled(QUESTION_POSES);
+    if (pass[0] === cycle[cycle.length - 1]) {
+      cycle.push(...pass.slice(1), pass[0]);
+    } else {
+      cycle.push(...pass);
+    }
+  }
+  return cycle;
+}
+
+/**
+ * Session state lives at module scope, not inside the composable, so it
+ * outlives the panel being closed. Dismissing the modal unmounts the component
+ * — with the state inside it, a stray tap on the backdrop would throw away an
+ * interrogation the player was ten questions into.
+ *
+ * There is exactly one Genie on screen at a time, so a single shared session is
+ * the whole truth rather than a cache of one.
+ */
+const status = ref<GenieStatus>("idle");
+const utterance = ref("");
+const options = ref<string[]>([]);
+const results = ref<MarketArticle[]>([]);
+const candidates = ref<GenieCandidate[]>([]);
+const history = ref<GenieExchangeDTO[]>([]);
+const query = ref("");
+const turnCap = ref(SOFT_TURN_CAP);
+const draft = ref("");
+/** The current question, kept apart from the flavour wrapped around it. */
+const pendingQuestion = ref("");
+/** When the session last did anything, for `resumeOrReset`. */
+const lastTouchedAt = ref(0);
+/** This hunt's running order of question poses, redrawn by `reset`. */
+const poseCycle = ref<GenieQuestionPose[]>(buildPoseCycle());
+
+/**
+ * Maps a candidate count to the word the player hears. The count itself never
+ * leaves this function: shown as a number it reads as debug output and breaks
+ * character, and a Genie that says "31 articles left" is not a Genie.
+ */
+export function bucketFor(count: number): GenieBucket {
+  if (count > 30) return "vast";
+  if (count > 15) return "many";
+  if (count > 8) return "a dozen or so";
+  if (count > GENIE_RESULT_THRESHOLD) return "a handful";
+  return "almost there";
+}
+
+export function useGenie() {
+  const leagueStore = useLeagueStore();
+
+  const askedCount = computed(() => history.value.length);
+
+  /**
+   * The extension is offered only when stopping now would be the cap's doing
+   * rather than the Genie's — if it already has few enough candidates to show,
+   * more questions buy nothing.
+   */
+  const canExtend = computed(
+    () =>
+      status.value === "results" &&
+      turnCap.value === SOFT_TURN_CAP &&
+      askedCount.value >= SOFT_TURN_CAP &&
+      candidates.value.length > GENIE_RESULT_THRESHOLD
+  );
+
+  /**
+   * Which drawing is on screen. Derived from the history rather than kept in a
+   * counter of its own: the panel unmounts when it is dismissed, so a counter
+   * would restart at the first pose whenever the player tapped the backdrop and
+   * came back mid-interview. Deriving it also means `reset` and `keepGuessing`
+   * need no upkeep to stay correct.
+   *
+   * Finishing always looks the same — the Genie has one way of being pleased
+   * with itself, and a fixed pose is what makes the end of the hunt legible.
+   */
+  const pose = computed<GeniePose>(() => {
+    switch (status.value) {
+      case "results":
+        return "celebrating";
+      case "asleep":
+        return "asleep";
+      case "seeding":
+      case "thinking":
+        return "thinking";
+      case "asking":
+        // Clamped rather than wrapped: the cycle is built past the turn cap, so
+        // this only guards a cap raised without the cycle following it.
+        return poseCycle.value[
+          Math.min(history.value.length, poseCycle.value.length - 1)
+        ];
+      default:
+        return "greeting";
+    }
+  });
+
+  function reset() {
+    status.value = "idle";
+    utterance.value = "";
+    options.value = [];
+    results.value = [];
+    candidates.value = [];
+    history.value = [];
+    query.value = "";
+    turnCap.value = SOFT_TURN_CAP;
+    pendingQuestion.value = "";
+    draft.value = "";
+    lastTouchedAt.value = 0;
+    // A fresh hunt gets a fresh running order, so the same round is not always
+    // asked by the same face.
+    poseCycle.value = buildPoseCycle();
+  }
+
+  /** Marks the session as alive, so it survives the next dismissal. */
+  function touch() {
+    lastTouchedAt.value = Date.now();
+  }
+
+  /**
+   * Called when the panel opens. Picks a warm session back up exactly where it
+   * was — same question, same survivors — so a stray tap on the backdrop costs
+   * nothing.
+   *
+   * Only a session the player can still act on is worth resuming: one that is
+   * mid-question, in flight, or holding an unspent "+5". Resuming a finished or
+   * asleep one would reopen onto a screen with nothing to do, which is worse
+   * than starting over.
+   */
+  function resumeOrReset() {
+    const isLive =
+      status.value === "asking" ||
+      status.value === "seeding" ||
+      status.value === "thinking" ||
+      (status.value === "results" && canExtend.value);
+
+    if (!isLive || Date.now() - lastTouchedAt.value > SESSION_TTL_MS) {
+      reset();
+    }
+  }
+
+  /**
+   * Every failure lands in the same place. Quota exhaustion, a transport
+   * problem and an unparseable model reply mean one thing to the player: the
+   * genie is asleep, and the ordinary search bar is right there. The feature is
+   * additive, so nothing about buying an article depends on it.
+   */
+  function fallAsleep() {
+    status.value = "asleep";
+    options.value = [];
+  }
+
+  async function start(rawQuery: string) {
+    const domain = leagueStore.currentLeague?.domain;
+    const trimmed = rawQuery.trim().slice(0, GENIE_MAX_QUERY_CHARS);
+    if (!domain || !trimmed) return;
+
+    reset();
+    query.value = trimmed;
+    draft.value = trimmed;
+    status.value = "seeding";
+    touch();
+
+    try {
+      const seed = await api.genie.seed(trimmed);
+      const seeded = await seedCandidates(domain, seed);
+
+      if (seeded.length === 0) {
+        // Nothing to narrow is not a model failure, but it reaches the player
+        // the same way: there is no session to run.
+        fallAsleep();
+        return;
+      }
+
+      candidates.value = seeded;
+      await ask();
+    } catch {
+      fallAsleep();
+    }
+  }
+
+  /** Sends the current set and history, and takes back the next question. */
+  async function ask() {
+    status.value = "thinking";
+    touch();
+
+    try {
+      const response = await api.genie.takeTurn({
+        query: query.value,
+        history: history.value,
+        candidates: candidates.value.map((candidate) => ({
+          id: candidate.id,
+          title: candidate.title,
+          description: candidate.description,
+        })),
+        bucket: bucketFor(candidates.value.length),
+      });
+
+      const surviving = new Set(response.keep);
+      const kept = candidates.value.filter((candidate) =>
+        surviving.has(candidate.id)
+      );
+      // The backend already refuses to empty the set, so this only guards
+      // against a response that somehow kept nothing recognisable.
+      candidates.value = kept.length > 0 ? kept : candidates.value;
+
+      utterance.value = response.utterance;
+      options.value = response.options;
+      // The bare question, never the flavour wrapped around it: flavour is
+      // display-only, and feeding it back would grow the prompt every turn with
+      // narration that says nothing about the article.
+      pendingQuestion.value = response.question || response.utterance;
+
+      const exhausted = history.value.length >= turnCap.value;
+      if (
+        response.done ||
+        candidates.value.length <= GENIE_RESULT_THRESHOLD ||
+        exhausted
+      ) {
+        await finish();
+        return;
+      }
+
+      status.value = "asking";
+      touch();
+    } catch {
+      fallAsleep();
+    }
+  }
+
+  /**
+   * Records the tap and takes another turn. Only the question is written into
+   * the history — never the flavour around it, which is display-only and would
+   * otherwise re-enter the prompt on every later turn.
+   */
+  async function answer(option: string) {
+    if (status.value !== "asking") return;
+
+    history.value = [
+      ...history.value,
+      { question: pendingQuestion.value, answer: option },
+    ];
+    await ask();
+  }
+
+  /** The tap that must never cost the player their article. */
+  async function answerUnsure() {
+    await answer(GENIE_UNSURE_ANSWER);
+  }
+
+  /** Grants the one "+5" extension and puts the Genie back to work. */
+  async function keepGuessing() {
+    if (!canExtend.value) return;
+    turnCap.value = SOFT_TURN_CAP + TURN_EXTENSION;
+    await ask();
+  }
+
+  /** Prices what is left and hands it to the market table. */
+  async function finish() {
+    const domain = leagueStore.currentLeague?.domain;
+    if (!domain) {
+      fallAsleep();
+      return;
+    }
+
+    status.value = "thinking";
+    try {
+      results.value = await hydrateCandidates(
+        domain,
+        candidates.value.slice(0, GENIE_RESULT_THRESHOLD)
+      );
+      status.value = "results";
+      touch();
+    } catch {
+      fallAsleep();
+    }
+  }
+
+  return {
+    status,
+    pose,
+    utterance,
+    options,
+    results,
+    canExtend,
+    draft,
+    bucket: computed(() => bucketFor(candidates.value.length)),
+    start,
+    resumeOrReset,
+    answer,
+    answerUnsure,
+    keepGuessing,
+    reset,
+  };
+}

--- a/frontend/src/composables/useMarket.ts
+++ b/frontend/src/composables/useMarket.ts
@@ -117,6 +117,28 @@ export function useMarket() {
   const sortDir = ref<SortDir>("desc");
   const currentPage = ref(1);
 
+  /**
+   * The Genie's findings, when it has any. Held apart from the search fallback
+   * because they are not a query result: the ordering is the answer (mutual
+   * links first, price second), and re-sorting them by the table's default
+   * would throw away the part that took the whole interrogation to work out.
+   */
+  const genieResults = ref<MarketArticle[] | null>(null);
+  const isGenieOrderPristine = ref(false);
+
+  function setGenieResults(articles: MarketArticle[]) {
+    genieResults.value = articles;
+    isGenieOrderPristine.value = true;
+    currentPage.value = 1;
+  }
+
+  function clearGenieResults() {
+    genieResults.value = null;
+    isGenieOrderPristine.value = false;
+  }
+
+  const isGenieMode = computed(() => genieResults.value !== null);
+
   function toggleSort(key: SortKey) {
     if (sortKey.value === key) {
       sortDir.value = sortDir.value === "asc" ? "desc" : "asc";
@@ -124,11 +146,17 @@ export function useMarket() {
       sortKey.value = key;
       sortDir.value = "desc";
     }
+    // Sorting is the player overriding the Genie's ranking, which is theirs to
+    // do — but only once they ask for it.
+    isGenieOrderPristine.value = false;
     currentPage.value = 1;
   }
 
   function setSearch(q: string) {
     searchQuery.value = q;
+    // Typing a search is the player going back to looking for themselves, so
+    // the Genie's findings step aside rather than being filtered by it.
+    clearGenieResults();
     currentPage.value = 1;
   }
 
@@ -137,14 +165,18 @@ export function useMarket() {
     currentPage.value = 1;
   }
 
-  function applyStatusAndSort(articles: MarketArticle[]): MarketArticle[] {
-    let filtered = [...articles];
-
+  function applyStatusFilter(articles: MarketArticle[]): MarketArticle[] {
     if (statusFilter.value === "free") {
-      filtered = filtered.filter((a) => !a.owner);
-    } else if (statusFilter.value === "owned") {
-      filtered = filtered.filter((a) => !!a.owner);
+      return articles.filter((a) => !a.owner);
     }
+    if (statusFilter.value === "owned") {
+      return articles.filter((a) => !!a.owner);
+    }
+    return [...articles];
+  }
+
+  function applySort(articles: MarketArticle[]): MarketArticle[] {
+    const filtered = [...articles];
 
     filtered.sort((a, b) => {
       let cmp = 0;
@@ -175,6 +207,10 @@ export function useMarket() {
     });
 
     return filtered;
+  }
+
+  function applyStatusAndSort(articles: MarketArticle[]): MarketArticle[] {
+    return applySort(applyStatusFilter(articles));
   }
 
   function applyLocalSearch(articles: MarketArticle[]): MarketArticle[] {
@@ -270,6 +306,10 @@ export function useMarket() {
   });
 
   const filteredArticles = computed<MarketArticle[]>(() => {
+    if (genieResults.value) {
+      const rows = applyStatusFilter(mergeOwnership(genieResults.value));
+      return isGenieOrderPristine.value ? rows : applySort(rows);
+    }
     if (isOwnedMode.value) {
       return applyStatusAndSort(applyLocalSearch(ownedArticles.value));
     }
@@ -340,6 +380,9 @@ export function useMarket() {
     isListLoading,
     isOwnershipLoading,
     isOwnershipError,
+    isGenieMode,
+    setGenieResults,
+    clearGenieResults,
     ITEMS_PER_PAGE,
   };
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -424,7 +424,22 @@
     "renewSuccess": "Renewal elected",
     "renewError": "Couldn't renew this contract",
     "cancelRenewalSuccess": "Renewal cancelled",
-    "cancelRenewalError": "Couldn't cancel this renewal"
+    "cancelRenewalError": "Couldn't cancel this renewal",
+    "genie": {
+      "trigger": "Ask the genie",
+      "prompt": "Describe what you're after — I'll do the rest.",
+      "placeholder": "a relation between OpenAI and Portugal…",
+      "ask": "Ask",
+      "seeking": "Rummaging through the archives…",
+      "thinking": "Mhh, let me think…",
+      "unsure": "No idea",
+      "found": "There — my hunt is done. Take a look at what I turned up.",
+      "keepGuessing": "Keep guessing",
+      "ok": "Show me",
+      "newGuess": "New guess",
+      "asleep": "The genie is asleep. Try the search bar.",
+      "imageAlt": "The A(k)Inator genie"
+    }
   },
   "league": {
     "back": "Back to dashboard",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -424,7 +424,22 @@
     "renewSuccess": "Rinnovo scelto",
     "renewError": "Impossibile rinnovare questo contratto",
     "cancelRenewalSuccess": "Rinnovo annullato",
-    "cancelRenewalError": "Impossibile annullare il rinnovo"
+    "cancelRenewalError": "Impossibile annullare il rinnovo",
+    "genie": {
+      "trigger": "Chiedi al genio",
+      "prompt": "Descrivi cosa cerchi — al resto penso io.",
+      "placeholder": "una relazione tra OpenAI e il Portogallo…",
+      "ask": "Chiedi",
+      "seeking": "Fruga fruga negli archivi…",
+      "thinking": "Mhh, fammi pensare…",
+      "unsure": "Non saprei",
+      "found": "Ecco — la mia ricerca è finita. Guarda cosa ho trovato.",
+      "keepGuessing": "Continua a indovinare",
+      "ok": "Mostrami",
+      "newGuess": "Nuova ricerca",
+      "asleep": "Il genio dorme. Prova con la barra di ricerca.",
+      "imageAlt": "Il genio A(k)Inator"
+    }
   },
   "league": {
     "back": "Torna alla dashboard",

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -30,6 +30,14 @@ function teamResponseKey(leagueId: string): string {
   return `${leagueId}`;
 }
 
+/** Stands in for an anchor article's outbound link list. */
+const mockOutboundLinks = [
+  "Bitcoin",
+  "Blockchain",
+  "Cryptocurrency",
+  "Artificial intelligence arms race",
+];
+
 const mockTeamResponses: Record<string, TeamLineUp> = {
   [teamResponseKey("italy")]: mockTeamResponse,
   [teamResponseKey("global")]: mockTeamResponse,
@@ -513,6 +521,46 @@ export const handlers = [
     if (!myTeam) return HttpResponse.json([]);
     const all = performancesByLeague[leagueId] ?? [];
     return HttpResponse.json(all.filter((p) => p.teamId === myTeam.id));
+  }),
+
+  // MediaWiki Action API — the outbound links of an article, which the Article
+  // Genie intersects across the anchors a query names.
+  http.get("https://*.wikipedia.org/w/api.php", ({ request }) => {
+    const title = new URL(request.url).searchParams.get("titles") ?? "";
+    return HttpResponse.json({
+      query: {
+        pages: [
+          {
+            pageid: 1,
+            ns: 0,
+            title,
+            links: mockOutboundLinks.map((t) => ({ ns: 0, title: t })),
+          },
+        ],
+      },
+    });
+  }),
+
+  // The Article Genie's two model calls. No model runs in mock mode: the seed
+  // reads as a chemistry query and the turn narrows to a single survivor, which
+  // is enough to drive the panel through to its results.
+  http.post("*/api/me/genie-seeds", async ({ request }) => {
+    const { query } = (await request.json()) as { query: string };
+    return HttpResponse.json({ keywords: query, anchors: [] });
+  }),
+
+  http.post("*/api/me/genie-turns", async ({ request }) => {
+    const { candidates } = (await request.json()) as {
+      candidates: { id: number }[];
+    };
+    return HttpResponse.json({
+      utterance: "Mhh, curious — is it a person?",
+      question: "Is it a person?",
+      keep: candidates.slice(0, 3).map((c) => c.id),
+      options: ["Yes", "No"],
+      kind: "filter",
+      done: candidates.length <= 3,
+    });
   }),
 
   // Problem reports. Nothing is really filed on GitHub in mock mode — the mock

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -15,6 +15,12 @@ import type {
   CreateProblemReportRequest,
   ProblemReportCreatedDTO,
 } from "../../../dto/problemReportDTO";
+import type {
+  GenieSeedRequest,
+  GenieSeedResponse,
+  GenieTurnRequest,
+  GenieTurnResponse,
+} from "../../../dto/genieDTO";
 import { Temporal } from "@js-temporal/polyfill";
 import {
   TIER_DAYS,
@@ -306,6 +312,28 @@ export const reportsApi = {
     }),
 };
 
+// ── Article Genie ─────────────────────────────────────────────────────────────
+
+/**
+ * The Genie's two model calls. Everything else it does — searching Wikipedia,
+ * fetching link sets, pricing — happens in the browser against the Wikimedia
+ * client's own cache, where neither the Worker's subrequest nor its CPU limit
+ * applies (ADR 0006).
+ */
+export const genieApi = {
+  /** Reads the opening text into the searches that seed the candidate set. */
+  seed: (query: string) =>
+    apiRequest<GenieSeedResponse>("/me/genie-seeds", {
+      method: "POST",
+      body: JSON.stringify({ query } satisfies GenieSeedRequest),
+    }),
+  takeTurn: (request: GenieTurnRequest) =>
+    apiRequest<GenieTurnResponse>("/me/genie-turns", {
+      method: "POST",
+      body: JSON.stringify(request),
+    }),
+};
+
 // ── Unified export ────────────────────────────────────────────────────────────
 
 export const api = {
@@ -318,6 +346,7 @@ export const api = {
   dashboard: dashboardApi,
   session: sessionApi,
   reports: reportsApi,
+  genie: genieApi,
 };
 
 export default api;

--- a/frontend/src/services/genieService.ts
+++ b/frontend/src/services/genieService.ts
@@ -1,0 +1,255 @@
+import { createWikimediaClient } from "@/services/wikimediaClient";
+import { fetchMarketArticlesByTitle } from "@/services/marketService";
+import type { MarketArticle } from "@/types/market";
+import type { Domain } from "../../../dto/enums";
+import {
+  GENIE_MAX_CANDIDATES,
+  type GenieSeedResponse,
+} from "../../../dto/genieDTO";
+import { toDisplayTitle } from "../../../external-apis/wikimedia/wikimedia";
+
+const client = createWikimediaClient();
+
+/**
+ * A real Wikipedia article in the Genie's candidate set, with everything known
+ * about how it relates to the anchors — but deliberately *not* its price.
+ *
+ * Pricing a candidate costs one 365-day pageview request, and the client caches
+ * those only as part of a whole search result, not per article. Pricing all ~40
+ * up front would mean ~40 requests before the Genie can say its first word, for
+ * figures that all but five of them will never show. So the seed ranks on link
+ * structure alone and price is resolved at the end, for the survivors only —
+ * see `hydrateCandidates`. ADR 0006 ranks by `(mutual links desc, price asc)`;
+ * that ordering is applied there, where price exists.
+ */
+export interface GenieCandidate {
+  /** Small integer, assigned here. What the model answers in. */
+  id: number;
+  canonicalTitle: string;
+  title: string;
+  description?: string;
+  /**
+   * How many anchors this article links *and* is linked back by — a mutual
+   * link is an EXCELLENT Chemistry Link, one direction alone is GOOD.
+   */
+  mutualAnchors: number;
+  /** How many anchors it has any link relation with, in either direction. */
+  connectedAnchors: number;
+}
+
+/**
+ * `linksto:Formula One` silently parses as `linksto:Formula` plus the free text
+ * "One" and returns unrelated articles. Underscoring is enforced here as well as
+ * in the prompt: a prompt is a request, and this failure is silent.
+ */
+function anchorTerm(anchor: string): string {
+  return anchor.trim().replace(/\s+/g, "_");
+}
+
+/** Mirrors `normKey`/`chemistryKey`: the same fold used everywhere titles meet. */
+function foldTitle(title: string): string {
+  return title.trim().toLowerCase().replace(/[ _]+/g, "_");
+}
+
+interface SeedHit {
+  canonicalTitle: string;
+  title: string;
+  description?: string;
+  rank: number;
+  /** Links *to* every anchor — it came from the `linksto:` search. */
+  linksToAnchors: boolean;
+}
+
+async function searchHits(
+  domain: Domain,
+  query: string,
+  linksToAnchors: boolean
+): Promise<SeedHit[]> {
+  if (!query.trim()) return [];
+  try {
+    const hits = await client.article.searchTitles(
+      domain,
+      query,
+      GENIE_MAX_CANDIDATES
+    );
+    return hits.map((hit, index) => ({
+      canonicalTitle: hit.canonicalTitle,
+      title: hit.displayTitle,
+      description: hit.description,
+      rank: index,
+      linksToAnchors,
+    }));
+  } catch {
+    // One search failing must not end the session: the other seeds still run,
+    // and a thin candidate set is a worse Genie, not a broken one.
+    return [];
+  }
+}
+
+/**
+ * Titles each anchor links *out* to. Fetched per anchor and cached for 7 days
+ * by the client, so a repeat hunt over the same anchors costs nothing.
+ *
+ * Keyed by the fold so it can be intersected and matched against search hits,
+ * but the *original* title is the value — the fold lowercases, and a lowercased
+ * title is not an article. Pageview lookups on `vasco_da_gama` 404, which
+ * `getArticleViews` swallows into undefined views, which prices the row at zero
+ * with blank stats and no error anywhere. That would hit exactly the cheap,
+ * well-connected finds this seed exists to surface.
+ */
+async function outboundSets(
+  domain: Domain,
+  anchors: string[]
+): Promise<Map<string, string>[]> {
+  return Promise.all(
+    anchors.map(async (anchor) => {
+      try {
+        const result = await client.article.getLinkedArticles(domain, anchor);
+        return new Map(
+          result.linkedArticles.map((title) => [foldTitle(title), title])
+        );
+      } catch {
+        return new Map<string, string>();
+      }
+    })
+  );
+}
+
+/**
+ * Builds the candidate set from a parsed query.
+ *
+ * Both seeds always run and are merged — there is no routing decision to get
+ * wrong. Reading *"the Portuguese explorer who reached India"* as an anchor
+ * query would, under routing, drop Vasco da Gama entirely and leave the player
+ * looking at a Genie that simply failed; merged, a misparse can only add
+ * surplus candidates, which is exactly what the narrowing loop is for.
+ *
+ * Nothing here is written for a pair of anchors: the `linksto:` terms are
+ * conjoined and the outbound sets are intersected over however many there are.
+ */
+export async function seedCandidates(
+  domain: Domain,
+  seed: GenieSeedResponse
+): Promise<GenieCandidate[]> {
+  const anchors = seed.anchors.filter((anchor) => anchor.trim().length > 0);
+
+  const anchorQuery = anchors.map((a) => `linksto:${anchorTerm(a)}`).join(" ");
+
+  const [keywordHits, anchorHits, outbound] = await Promise.all([
+    searchHits(domain, seed.keywords, false),
+    anchors.length ? searchHits(domain, anchorQuery, true) : [],
+    outboundSets(domain, anchors),
+  ]);
+
+  // Articles every anchor links out to. Mostly citation-identifier redirects
+  // and other boilerplate, and deliberately kept anyway: they are cheap, they
+  // still carry chemistry, and discarding them as noise would remove the most
+  // efficient plays in the game. The narrowing loop strips what is truly
+  // useless.
+  const intersection = outbound.length
+    ? [...outbound[0].entries()].filter(([key]) =>
+        outbound.every((set) => set.has(key))
+      )
+    : [];
+
+  const merged = new Map<string, SeedHit>();
+  for (const hit of [...anchorHits, ...keywordHits]) {
+    const key = foldTitle(hit.canonicalTitle);
+    const existing = merged.get(key);
+    if (existing) {
+      // A candidate found by both seeds keeps the stronger fact about itself.
+      existing.linksToAnchors ||= hit.linksToAnchors;
+      existing.description ??= hit.description;
+    } else {
+      merged.set(key, { ...hit });
+    }
+  }
+
+  for (const [key, originalTitle] of intersection) {
+    if (merged.has(key)) continue;
+    merged.set(key, {
+      // The link list gives the title as written — correctly cased. Underscore
+      // it into a canonical title rather than reusing the lowercased fold.
+      canonicalTitle: originalTitle.trim().replace(/\s+/g, "_"),
+      title: toDisplayTitle(originalTitle),
+      // The link list carries no blurb. The model is told to judge from title
+      // and description, so these are weaker candidates on purpose — they earn
+      // their place through chemistry, which is ranked below.
+      description: undefined,
+      rank: Number.MAX_SAFE_INTEGER,
+      linksToAnchors: false,
+    });
+  }
+
+  const scored = [...merged.entries()].map(([key, hit]) => {
+    const linkedBy = outbound.filter((set) => set.has(key)).length;
+    return {
+      hit,
+      // Mutual means both directions: the article links to the anchors *and*
+      // the anchor links back. ADR 0006 measured that no candidate manages this
+      // with two unrelated anchors, so in practice this separates the rare
+      // strong find from the merely connected.
+      mutualAnchors: hit.linksToAnchors ? linkedBy : 0,
+      connectedAnchors: hit.linksToAnchors
+        ? Math.max(anchors.length, linkedBy)
+        : linkedBy,
+    };
+  });
+
+  scored.sort(
+    (a, b) =>
+      b.mutualAnchors - a.mutualAnchors ||
+      b.connectedAnchors - a.connectedAnchors ||
+      a.hit.rank - b.hit.rank
+  );
+
+  return scored
+    .slice(0, GENIE_MAX_CANDIDATES)
+    .map(({ hit, mutualAnchors, connectedAnchors }, index) => ({
+      id: index,
+      canonicalTitle: hit.canonicalTitle,
+      title: hit.title,
+      description: hit.description,
+      mutualAnchors,
+      connectedAnchors,
+    }));
+}
+
+/**
+ * Turns the survivors into ordinary market rows: real prices, real ownership,
+ * the normal buy flow. This is the only point at which the Genie costs a
+ * pageview request per article, and by then there are at most a handful.
+ *
+ * Ordered as ADR 0006 specifies — mutual links first, price second — so the
+ * cheap, well-connected find sits above the expensive obvious one. *Artificial
+ * intelligence arms race* carries the same chemistry as *Google* at 1/200th the
+ * traffic, and this is what surfaces it.
+ */
+export async function hydrateCandidates(
+  domain: Domain,
+  candidates: GenieCandidate[]
+): Promise<MarketArticle[]> {
+  const articles = await fetchMarketArticlesByTitle(
+    domain,
+    candidates.map((candidate) => ({
+      title: candidate.canonicalTitle,
+      // ContractPrice genuinely floors at 0 below ~2,000 views (ADR 0003/0005),
+      // so an article with no view series is free rather than unpriced — there
+      // is no stale figure to fall back to here, and none is needed.
+      fallbackPrice: 0,
+    }))
+  );
+
+  const chemistryByKey = new Map(
+    candidates.map((candidate) => [
+      foldTitle(candidate.canonicalTitle),
+      candidate,
+    ])
+  );
+
+  return [...articles].sort((a, b) => {
+    const aChem = chemistryByKey.get(foldTitle(a.title))?.mutualAnchors ?? 0;
+    const bChem = chemistryByKey.get(foldTitle(b.title))?.mutualAnchors ?? 0;
+    return bChem - aChem || a.price - b.price;
+  });
+}

--- a/frontend/src/tests/services/genieService.spec.ts
+++ b/frontend/src/tests/services/genieService.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/mocks/server";
+import { seedCandidates } from "@/services/genieService";
+
+/** Records the search queries the seed actually issued. */
+let searchQueries: string[] = [];
+
+beforeEach(() => {
+  searchQueries = [];
+  // The client caches searches and link sets in localStorage; without this one
+  // test's seed answers the next one's.
+  localStorage.clear();
+});
+
+/**
+ * Answers the keyword search and the `linksto:` search differently, so a test
+ * can tell which candidates came from which seed.
+ */
+function interceptSearch(
+  byQuery: Record<
+    string,
+    { key: string; title: string; description?: string }[]
+  >
+) {
+  server.use(
+    http.get(
+      "https://api.wikimedia.org/core/v1/wikipedia/*/search/page*",
+      ({ request }) => {
+        const query = new URL(request.url).searchParams.get("q") ?? "";
+        searchQueries.push(query);
+        const pages = byQuery[query] ?? [];
+        return HttpResponse.json({ pages });
+      }
+    )
+  );
+}
+
+function interceptLinks(linksByTitle: Record<string, string[]>) {
+  server.use(
+    http.get("https://*.wikipedia.org/w/api.php", ({ request }) => {
+      const title = new URL(request.url).searchParams.get("titles") ?? "";
+      return HttpResponse.json({
+        query: {
+          pages: [
+            {
+              pageid: 1,
+              ns: 0,
+              title,
+              links: (linksByTitle[title] ?? []).map((t) => ({
+                ns: 0,
+                title: t,
+              })),
+            },
+          ],
+        },
+      });
+    })
+  );
+}
+
+describe("seedCandidates", () => {
+  it("runs both seeds and merges them, so a misparse cannot lose the answer", async () => {
+    interceptSearch({
+      "portuguese explorer india": [
+        {
+          key: "Vasco_da_Gama",
+          title: "Vasco da Gama",
+          description: "Explorer",
+        },
+      ],
+      "linksto:Portugal linksto:India": [
+        { key: "Goa", title: "Goa", description: "State in India" },
+      ],
+    });
+    interceptLinks({ Portugal: [], India: [] });
+
+    const candidates = await seedCandidates("en", {
+      keywords: "portuguese explorer india",
+      anchors: ["Portugal", "India"],
+    });
+
+    const titles = candidates.map((c) => c.title);
+    // Routing to the anchor seed alone would have dropped Vasco da Gama and
+    // left the player looking at a Genie that simply failed.
+    expect(titles).toContain("Vasco da Gama");
+    expect(titles).toContain("Goa");
+  });
+
+  it("underscores multi-word anchors, which `linksto:` silently mis-parses", async () => {
+    interceptSearch({});
+    interceptLinks({ "Formula One": [] });
+
+    await seedCandidates("en", {
+      keywords: "races",
+      anchors: ["Formula One"],
+    });
+
+    // `linksto:Formula One` parses as `linksto:Formula` plus the free text
+    // "One" and returns unrelated articles.
+    expect(searchQueries).toContain("linksto:Formula_One");
+    expect(searchQueries).not.toContain("linksto:Formula One");
+  });
+
+  it("ranks a mutual link above a one-way one", async () => {
+    interceptSearch({
+      relation: [],
+      "linksto:OpenAI linksto:Portugal": [
+        { key: "Google", title: "Google", description: "Tech company" },
+        {
+          key: "Artificial_intelligence_arms_race",
+          title: "Artificial intelligence arms race",
+          description: "Competition over AI",
+        },
+      ],
+    });
+    // Only the arms-race article is linked back by both anchors, so only it
+    // holds a mutual link with them.
+    interceptLinks({
+      OpenAI: ["Artificial intelligence arms race"],
+      Portugal: ["Artificial intelligence arms race"],
+    });
+
+    const candidates = await seedCandidates("en", {
+      keywords: "relation",
+      anchors: ["OpenAI", "Portugal"],
+    });
+
+    expect(candidates[0].title).toBe("Artificial intelligence arms race");
+    expect(candidates[0].mutualAnchors).toBe(2);
+    expect(candidates[1].mutualAnchors).toBe(0);
+  });
+
+  it("keeps the cheap boilerplate the anchors both link out to", async () => {
+    interceptSearch({ relation: [] });
+    interceptLinks({
+      OpenAI: ["ArXiv (identifier)", "Microsoft"],
+      Portugal: ["ArXiv (identifier)", "Spain"],
+    });
+
+    const candidates = await seedCandidates("en", {
+      keywords: "relation",
+      anchors: ["OpenAI", "Portugal"],
+    });
+
+    // Low-traffic articles are not noise: they cost almost nothing and still
+    // carry chemistry, so they are ranked rather than filtered out.
+    //
+    // Cased as Wikipedia has it, not folded: the fold is a match key, and a
+    // lowercased title is not an article — pageviews would 404, which is
+    // swallowed into a zero price and blank stats with no error anywhere.
+    expect(candidates.map((c) => c.canonicalTitle)).toContain(
+      "ArXiv_(identifier)"
+    );
+    const arxiv = candidates.find((c) => c.title === "ArXiv (identifier)");
+    expect(arxiv).toBeDefined();
+  });
+
+  it("assigns the small integer ids the model answers in", async () => {
+    interceptSearch({
+      bitcoin: [
+        { key: "Bitcoin", title: "Bitcoin", description: "Cryptocurrency" },
+        { key: "Blockchain", title: "Blockchain", description: "Ledger" },
+      ],
+    });
+
+    const candidates = await seedCandidates("en", {
+      keywords: "bitcoin",
+      anchors: [],
+    });
+
+    expect(candidates.map((c) => c.id)).toEqual([0, 1]);
+  });
+});

--- a/frontend/src/tests/useGenie.spec.ts
+++ b/frontend/src/tests/useGenie.spec.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { createPinia, setActivePinia } from "pinia";
+import { Temporal } from "@js-temporal/polyfill";
+import { server } from "@/mocks/server";
+import { bucketFor, useGenie } from "@/composables/useGenie";
+import { useLeagueStore } from "@/stores/league";
+import type { LeagueDTO } from "../../../dto/leagueDTO";
+
+const league = {
+  id: "global",
+  title: "Global",
+  icon: "🌍",
+  domain: "en",
+  startDate: Temporal.Instant.from("2026-01-01T00:00:00Z"),
+  endDate: Temporal.Instant.from("2026-12-31T00:00:00Z"),
+} as unknown as LeagueDTO;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  useLeagueStore().currentLeague = league;
+  // The Wikimedia client caches searches and link sets in localStorage, so one
+  // test's seed would otherwise answer the next one's.
+  localStorage.clear();
+  // The session deliberately lives at module scope so it survives the panel
+  // closing — which means it also survives from one test to the next.
+  useGenie().reset();
+});
+
+/** Never narrows and never says done, so only the turn cap can end the hunt. */
+function neverNarrows() {
+  return [
+    http.get("https://api.wikimedia.org/core/v1/wikipedia/*/search/page*", () =>
+      HttpResponse.json({
+        pages: Array.from({ length: 12 }, (_, i) => ({
+          key: `Article_${i}`,
+          title: `Article ${i}`,
+          description: "Something",
+        })),
+      })
+    ),
+    http.post("*/api/me/genie-turns", async ({ request }) => {
+      const { candidates } = (await request.json()) as {
+        candidates: { id: number }[];
+      };
+      return HttpResponse.json({
+        utterance: "Mhh — is it a person?",
+        question: "Is it a person?",
+        keep: candidates.map((c) => c.id),
+        options: ["Yes", "No"],
+        kind: "filter",
+        done: false,
+      });
+    }),
+  ];
+}
+
+/**
+ * A replayable stand-in for `Math.random`. A constant would do for determinism
+ * but risks wedging anything that draws until a value differs; this varies and
+ * still repeats exactly for a given seed.
+ */
+function seededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) % 2147483648;
+    return state / 2147483648;
+  };
+}
+
+/** Waits for the loop to settle on a state that is not mid-flight. */
+async function settle(status: { value: string }) {
+  await vi.waitFor(
+    () => {
+      expect(["asking", "results", "asleep", "idle"]).toContain(status.value);
+    },
+    { timeout: 3000 }
+  );
+}
+
+describe("bucketFor", () => {
+  it("describes the set in words, never in numbers", () => {
+    // A Genie that says "31 articles left" is not a Genie — the count reads as
+    // debug output and breaks character.
+    expect(bucketFor(40)).toBe("vast");
+    expect(bucketFor(20)).toBe("many");
+    expect(bucketFor(12)).toBe("a dozen or so");
+    expect(bucketFor(7)).toBe("a handful");
+    expect(bucketFor(2)).toBe("almost there");
+
+    for (const count of [0, 1, 5, 9, 16, 31, 100]) {
+      expect(bucketFor(count)).not.toMatch(/\d/);
+    }
+  });
+});
+
+describe("useGenie", () => {
+  it("seeds, asks a question and offers taps to answer it", async () => {
+    // Enough candidates that the loop has something to narrow: with only a
+    // handful seeded it is right to skip straight to results.
+    server.use(
+      http.get(
+        "https://api.wikimedia.org/core/v1/wikipedia/*/search/page*",
+        () =>
+          HttpResponse.json({
+            pages: Array.from({ length: 12 }, (_, i) => ({
+              key: `Mathematician_${i}`,
+              title: `Mathematician ${i}`,
+              description: "American mathematician",
+            })),
+          })
+      ),
+      // …and a turn that narrows gently, so the loop stays in the question
+      // phase instead of dropping straight to five.
+      http.post("*/api/me/genie-turns", async ({ request }) => {
+        const { candidates } = (await request.json()) as {
+          candidates: { id: number }[];
+        };
+        return HttpResponse.json({
+          utterance: "Mhh — was she a mathematician?",
+          question: "Was she a mathematician?",
+          keep: candidates.map((c) => c.id),
+          options: ["Yes", "No"],
+          kind: "filter",
+          done: false,
+        });
+      })
+    );
+
+    const genie = useGenie();
+    await genie.start("the female mathematician who worked at NASA");
+    await settle(genie.status);
+
+    expect(genie.status.value).toBe("asking");
+    expect(genie.utterance.value).toBeTruthy();
+    expect(genie.options.value.length).toBeGreaterThan(0);
+  });
+
+  it("reaches priced results the market table can render", async () => {
+    const genie = useGenie();
+    await genie.start("bitcoin");
+    await settle(genie.status);
+
+    // The mock narrows to three and then sets done, so a couple of taps get
+    // there regardless of which branch ends the loop.
+    for (let i = 0; i < 3 && genie.status.value === "asking"; i += 1) {
+      await genie.answer(genie.options.value[0]);
+      await settle(genie.status);
+    }
+
+    expect(genie.status.value).toBe("results");
+    expect(genie.results.value.length).toBeGreaterThan(0);
+    for (const article of genie.results.value) {
+      expect(article.title).toBeTruthy();
+      expect(typeof article.price).toBe("number");
+    }
+  });
+
+  it("writes only the bare question into history, never the flavour", async () => {
+    let lastHistory: { question: string; answer: string }[] = [];
+    server.use(
+      http.get(
+        "https://api.wikimedia.org/core/v1/wikipedia/*/search/page*",
+        () =>
+          HttpResponse.json({
+            pages: Array.from({ length: 12 }, (_, i) => ({
+              key: `Article_${i}`,
+              title: `Article ${i}`,
+              description: "Something",
+            })),
+          })
+      ),
+      http.post("*/api/me/genie-turns", async ({ request }) => {
+        const body = (await request.json()) as {
+          candidates: { id: number }[];
+          history: { question: string; answer: string }[];
+        };
+        lastHistory = body.history;
+        return HttpResponse.json({
+          utterance: "Mhh, how curious — is it a person?",
+          question: "Is it a person?",
+          keep: body.candidates.map((c) => c.id),
+          options: ["Yes", "No"],
+          kind: "filter",
+          done: false,
+        });
+      })
+    );
+
+    const genie = useGenie();
+    await genie.start("something");
+    await settle(genie.status);
+    await genie.answer("Yes");
+    await settle(genie.status);
+
+    expect(lastHistory).toEqual([
+      { question: "Is it a person?", answer: "Yes" },
+    ]);
+  });
+
+  it("keeps the panel up to offer another five when the cap is what stopped it", async () => {
+    server.use(...neverNarrows());
+
+    const genie = useGenie();
+    await genie.start("something");
+    await settle(genie.status);
+
+    for (let i = 0; i < 12 && genie.status.value === "asking"; i += 1) {
+      await genie.answer("Yes");
+      await settle(genie.status);
+    }
+
+    expect(genie.status.value).toBe("results");
+    // Stopping here was the cap's doing rather than the Genie's, so the finish
+    // screen offers another five questions alongside its OK.
+    expect(genie.canExtend.value).toBe(true);
+  });
+
+  it("survives being dismissed, so a stray tap costs nothing", async () => {
+    server.use(
+      http.get(
+        "https://api.wikimedia.org/core/v1/wikipedia/*/search/page*",
+        () =>
+          HttpResponse.json({
+            pages: Array.from({ length: 12 }, (_, i) => ({
+              key: `Article_${i}`,
+              title: `Article ${i}`,
+              description: "Something",
+            })),
+          })
+      ),
+      http.post("*/api/me/genie-turns", async ({ request }) => {
+        const { candidates } = (await request.json()) as {
+          candidates: { id: number }[];
+        };
+        return HttpResponse.json({
+          utterance: "Mhh — is it a person?",
+          question: "Is it a person?",
+          keep: candidates.map((c) => c.id),
+          options: ["Yes", "No"],
+          kind: "filter",
+          done: false,
+        });
+      })
+    );
+
+    const genie = useGenie();
+    await genie.start("something");
+    await settle(genie.status);
+    expect(genie.status.value).toBe("asking");
+
+    // The panel is dismissed and opened again — a fresh composable call, and on
+    // a fresh mount the component would get fresh local state.
+    const reopened = useGenie();
+    reopened.resumeOrReset();
+
+    expect(reopened.status.value).toBe("asking");
+    expect(reopened.utterance.value).toBe("Mhh — is it a person?");
+    expect(reopened.options.value).toEqual(["Yes", "No"]);
+  });
+
+  it("starts over once the session has gone cold", async () => {
+    const genie = useGenie();
+    await genie.start("bitcoin");
+    await settle(genie.status);
+    expect(genie.status.value).not.toBe("idle");
+
+    // Eleven minutes later: they are looking for something else by now.
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 11 * 60 * 1000);
+    genie.resumeOrReset();
+
+    expect(genie.status.value).toBe("idle");
+    vi.restoreAllMocks();
+  });
+
+  it("does not resume an asleep session onto a screen with nothing to do", async () => {
+    server.use(
+      http.post("*/api/me/genie-seeds", () =>
+        HttpResponse.json({ error: "GENIE_ASLEEP" }, { status: 503 })
+      )
+    );
+
+    const genie = useGenie();
+    await genie.start("anything");
+    await settle(genie.status);
+    expect(genie.status.value).toBe("asleep");
+
+    genie.resumeOrReset();
+
+    // Reopening onto the asleep line, with no way forward, is worse than
+    // starting over.
+    expect(genie.status.value).toBe("idle");
+  });
+
+  it("changes pose every question and never twice in a row", async () => {
+    // Runs to the turn cap, so every pose in the rotation gets on screen.
+    server.use(...neverNarrows());
+
+    const genie = useGenie();
+    await genie.start("something");
+    await settle(genie.status);
+
+    const seen: string[] = [];
+    for (let i = 0; i < 12 && genie.status.value === "asking"; i += 1) {
+      seen.push(genie.pose.value);
+      await genie.answer("Yes");
+      await settle(genie.status);
+    }
+
+    expect(seen.length).toBeGreaterThan(6);
+    for (let i = 1; i < seen.length; i += 1) {
+      expect(seen[i]).not.toBe(seen[i - 1]);
+    }
+    // The whole set is used rather than a couple of poses alternating: the
+    // rotation is dealt in passes, each spending every pose once.
+    expect(new Set(seen).size).toBe(6);
+    // …and the busy pose is never one of them, or the figure would not change
+    // across the flash between one question and the next.
+    expect(seen).not.toContain("thinking");
+
+    // Finishing always looks the same, whichever question ended the hunt.
+    expect(genie.status.value).toBe("results");
+    expect(genie.pose.value).toBe("celebrating");
+  });
+
+  it("deals a fresh running order to each hunt", async () => {
+    server.use(...neverNarrows());
+
+    const genie = useGenie();
+    const runs: string[][] = [];
+
+    // The order is drawn inside `start`, so the seed has to be in place for it.
+    for (const seed of [1, 7]) {
+      vi.spyOn(Math, "random").mockImplementation(seededRandom(seed));
+
+      await genie.start("something");
+      await settle(genie.status);
+
+      const seen: string[] = [];
+      for (let i = 0; i < 12 && genie.status.value === "asking"; i += 1) {
+        seen.push(genie.pose.value);
+        await genie.answer("Yes");
+        await settle(genie.status);
+      }
+      runs.push(seen);
+      vi.restoreAllMocks();
+    }
+
+    // Two hunts, same questions, different faces asking them — the third
+    // question is not forever the reading pose.
+    expect(runs[0]).not.toEqual(runs[1]);
+    // …and each hunt still holds the guarantee that matters on screen.
+    for (const run of runs) {
+      for (let i = 1; i < run.length; i += 1) {
+        expect(run[i]).not.toBe(run[i - 1]);
+      }
+    }
+  });
+
+  it("falls asleep when the model is unavailable", async () => {
+    server.use(
+      http.post("*/api/me/genie-seeds", () =>
+        HttpResponse.json({ error: "GENIE_ASLEEP" }, { status: 503 })
+      )
+    );
+
+    const genie = useGenie();
+    await genie.start("anything at all");
+    await settle(genie.status);
+
+    // Quota, transport and an unparseable reply all land here: the panel
+    // dismisses to the ordinary search bar, and buying is unaffected.
+    expect(genie.status.value).toBe("asleep");
+    expect(genie.options.value).toEqual([]);
+  });
+
+  it("falls asleep rather than showing an empty hunt", async () => {
+    server.use(
+      http.get(
+        "https://api.wikimedia.org/core/v1/wikipedia/*/search/page*",
+        () => HttpResponse.json({ pages: [] })
+      )
+    );
+
+    const genie = useGenie();
+    await genie.start("a query that finds nothing");
+    await settle(genie.status);
+
+    expect(genie.status.value).toBe("asleep");
+  });
+});

--- a/frontend/src/views/MarketPage.vue
+++ b/frontend/src/views/MarketPage.vue
@@ -69,15 +69,26 @@
 
         <!-- Search + Status filter -->
         <div class="controls-row">
-          <ion-searchbar
-            class="search-bar"
-            :placeholder="t('market.searchPlaceholder')"
-            :value="searchQuery"
-            @ionInput="
-              setSearch(($event.target as HTMLIonSearchbarElement).value ?? '')
-            "
-            :debounce="200"
-          />
+          <!-- The Genie sits *beside* the search bar, sharing its line and its
+               height: it is additive, and the search bar is both the thing it
+               supplements and where a failed session hands the player back to. -->
+          <div class="search-row">
+            <ion-searchbar
+              class="search-bar"
+              :placeholder="t('market.searchPlaceholder')"
+              :value="searchQuery"
+              @ionInput="
+                setSearch(
+                  ($event.target as HTMLIonSearchbarElement).value ?? ''
+                )
+              "
+              :debounce="200"
+            />
+            <ion-button fill="outline" class="genie-trigger" @click="openGenie">
+              <ion-icon slot="start" :icon="sparklesOutline" />
+              {{ t("market.genie.trigger") }}
+            </ion-button>
+          </div>
           <ion-segment
             class="status-segment"
             :value="statusFilter"
@@ -384,6 +395,12 @@
     </div>
     <!-- /page-container -->
 
+    <article-genie
+      :is-open="isGenieOpen"
+      @results="onGenieResults"
+      @close="closeGenie"
+    />
+
     <ArticleDetail
       v-if="selectedArticle"
       :article="selectedArticle"
@@ -423,6 +440,7 @@ import {
   openOutline,
   refreshOutline,
   searchOutline,
+  sparklesOutline,
   swapVerticalOutline,
 } from "ionicons/icons";
 import { useI18n } from "vue-i18n";
@@ -431,6 +449,7 @@ import { useRouter } from "vue-router";
 import NavBar from "@/layout/NavBar.vue";
 import PageReveal from "@/components/PageReveal.vue";
 import ArticleDetail from "@/components/ArticleDetail.vue";
+import ArticleGenie from "@/components/ArticleGenie.vue";
 import { useLeagueStore } from "@/stores/league";
 import {
   useMarket,
@@ -481,8 +500,31 @@ const {
   hasSearchQuery,
   isListLoading,
   isOwnershipLoading,
+  setGenieResults,
   ITEMS_PER_PAGE,
 } = useMarket();
+
+// A full modal, owned by the component itself (as ArticleDetail does). The
+// session behind it survives being dismissed, so this is only visibility.
+const isGenieOpen = ref(false);
+
+function openGenie() {
+  isGenieOpen.value = true;
+}
+
+function closeGenie() {
+  isGenieOpen.value = false;
+}
+
+/**
+ * The findings become ordinary market rows — same price, ownership badge and
+ * buy flow as everything else. Emitted as the panel dismisses, so the table
+ * changes into view rather than behind a modal the player still has open.
+ */
+function onGenieResults(articles: MarketArticle[]) {
+  setGenieResults(articles);
+  closeGenie();
+}
 
 function statusChipColor(article: MarketArticle): string {
   if (!article.owner && isOwnershipLoading.value) return "medium";
@@ -700,6 +742,15 @@ async function handleRefresh(event: CustomEvent) {
   margin-bottom: 16px;
 }
 
+/* One line, one height. The searchbar takes what is left after the trigger,
+   which keeps its own width instead of being squeezed to its label. */
+.search-row {
+  --control-height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .search-bar {
   --border-radius: 8px;
   --color: var(--ion-text-color);
@@ -708,15 +759,53 @@ async function handleRefresh(event: CustomEvent) {
   --icon-color: var(--ion-color-medium);
   --box-shadow: none;
   padding: 0;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
+/* `border-box` is load-bearing: the outline lives on this element, so without it
+   the 1.5px border sits outside the fixed height and the bottom edge is clipped
+   away. The input then fills the container rather than being sized to the same
+   number, which would overflow it by exactly those borders. */
 .search-bar :deep(.searchbar-input-container) {
   border: 1.5px solid var(--ion-color-primary);
   border-radius: 8px;
+  height: var(--control-height);
+  box-sizing: border-box;
+}
+
+.search-bar :deep(.searchbar-input) {
+  height: 100%;
+  box-sizing: border-box;
 }
 
 .status-segment {
   width: 100%;
+}
+
+/* Sized like the balance pill it echoes across the page: a settled block of
+   chrome rather than a button shrink-wrapped to its label. */
+.genie-trigger {
+  flex: 0 0 auto;
+  min-width: 150px;
+  height: var(--control-height);
+  margin: 0;
+  --border-radius: 8px;
+  font-size: 0.8125rem;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+/* Below this the two share the line only if the label goes, and a searchbar
+   squeezed to a few characters is worse than a stacked pair. */
+@media (max-width: 480px) {
+  .search-row {
+    flex-wrap: wrap;
+  }
+
+  .genie-trigger {
+    flex: 1 0 100%;
+  }
 }
 
 /* Desktop table */


### PR DESCRIPTION
 Adds the LLM-assisted discovery panel on the market page (ADR 0006): a
  single input that both scouts chemistry between named articles and
  recovers a half-remembered one, by narrowing a bounded list of real
  Wikipedia titles instead of generating guesses.

  The model never names an article, so hallucination is impossible by
  construction and misclassification is the failure mode the backend
  defends against: ids outside the candidate list are discarded, a
  preference question or an unsure answer keeps the whole set, a turn that
  would empty it restores it, and a question already asked earns a retry
  before the turn is forced to finish. All are enforced server-side rather
  than asked for in the prompt.

  Seeding runs the keyword and linksto: searches together and merges them,
  so a misparsed query can only add candidates, never lose the right one.
  Ranking uses link structure during the loop and applies price only to the
  survivors — pricing all 40 candidates up front would cost ~40 pageview
  requests before the Genie's first word.

  The panel is a full modal that keeps its session across dismissal for ten
  minutes, so a stray tap on the backdrop does not throw away an
  interrogation, and hands its findings to the market table as it closes.

  The AI binding is omitted from the test environment on purpose: Workers
  AI has no local simulator, so its presence makes the vitest pool require
  Cloudflare credentials that CI does not have, which would stop the whole
  backend suite from starting.

  Closes #252