### PR TITLE
refactor: state the derived-credits rule once (#503)

### DIFF
--- a/backend/migrations/0006_team_credits_view.sql
+++ b/backend/migrations/0006_team_credits_view.sql
@@ -1,0 +1,31 @@
+-- Migration: State the derived-credits rule once, as a view
+-- Date: 2026-08-01
+
+-- Team credits are derived from the contracts ledger, never stored (migration
+-- 0005 dropped teams.credits). Until now that derivation was hand-copied into
+-- four repositories, so the aggregate's core invariant lived in four places at
+-- once. This view is its single canonical statement in SQL:
+--
+--   credits = STARTING_CREDITS - sum(purchasePrice) + sum(salePayout where settled)
+--
+-- Driven from teams (not from contracts) so that every team gets exactly one
+-- row: a team with no contracts yields STARTING_CREDITS rather than no row at
+-- all. That is what lets every caller plain-JOIN the view, and lets the
+-- guarded contract INSERT read it as a scalar subquery without a COALESCE
+-- fallback re-stating the starting budget.
+--
+-- The starting budget is inlined because SQLite views cannot take parameters.
+-- It MUST stay equal to STARTING_CREDITS in model/team.ts -- an integration
+-- test asserts the two agree, so drift fails the build rather than silently
+-- mispricing every balance.
+--
+-- Rationale and the race this shape protects:
+-- docs/adr/0007-team-credits-derived-and-enforced-at-write.md
+CREATE VIEW IF NOT EXISTS team_credits AS
+SELECT t.id AS teamId,
+       1000
+         - COALESCE(SUM(c.purchasePrice), 0)
+         + COALESCE(SUM(CASE WHEN c.settled = 1 THEN c.salePayout ELSE 0 END), 0) AS credits
+FROM teams t
+LEFT JOIN contracts c ON c.teamId = t.id
+GROUP BY t.id;

--- a/backend/migrations/0006_team_credits_view.sql
+++ b/backend/migrations/0006_team_credits_view.sql
@@ -14,6 +14,16 @@
 -- guarded contract INSERT read it as a scalar subquery without a COALESCE
 -- fallback re-stating the starting budget.
 --
+-- playerId and leagueId are exposed, and named in the GROUP BY, so that
+-- callers can filter the view on its own columns. A view is not a cache -- it
+-- is inlined into the referencing statement and recomputed every time -- so
+-- what matters for cost is whether SQLite can push the caller's WHERE clause
+-- down into the aggregate. It only does that for constraints on the view's
+-- own GROUP BY columns, so `WHERE tc.leagueId = ?` narrows the aggregate to
+-- one league while an equivalent `WHERE t.leagueId = ?` on a joined table
+-- would build it for every team in the database first. Callers must filter on
+-- the view's columns, not on the joined teams row.
+--
 -- The starting budget is inlined because SQLite views cannot take parameters.
 -- It MUST stay equal to STARTING_CREDITS in model/team.ts -- an integration
 -- test asserts the two agree, so drift fails the build rather than silently
@@ -23,9 +33,11 @@
 -- docs/adr/0007-team-credits-derived-and-enforced-at-write.md
 CREATE VIEW IF NOT EXISTS team_credits AS
 SELECT t.id AS teamId,
+       t.playerId AS playerId,
+       t.leagueId AS leagueId,
        1000
          - COALESCE(SUM(c.purchasePrice), 0)
          + COALESCE(SUM(CASE WHEN c.settled = 1 THEN c.salePayout ELSE 0 END), 0) AS credits
 FROM teams t
 LEFT JOIN contracts c ON c.teamId = t.id
-GROUP BY t.id;
+GROUP BY t.id, t.playerId, t.leagueId;

--- a/backend/src/repositories/d1/contractRepositoryD1.ts
+++ b/backend/src/repositories/d1/contractRepositoryD1.ts
@@ -107,7 +107,9 @@ export class ContractRepositoryD1 implements ContractRepository {
     try {
       // teamCredits comes from the team_credits view — the single SQL
       // statement of the derivation (migration 0006, ADR 0007) — never from a
-      // stored column and never re-derived here.
+      // stored column and never re-derived here. The league filter is applied
+      // to the view's own leagueId so SQLite narrows the aggregate to this
+      // league instead of building it for every team in the database.
       const result = await this.db
         .prepare(
           `SELECT c.*, t.name AS teamName, tc.credits AS teamCredits,
@@ -116,7 +118,7 @@ export class ContractRepositoryD1 implements ContractRepository {
            JOIN teams t ON c.teamId = t.id
            JOIN players p ON t.playerId = p.id
            JOIN team_credits tc ON tc.teamId = t.id
-           WHERE t.leagueId = ? AND c.settled = 0`,
+           WHERE tc.leagueId = ? AND c.settled = 0`,
         )
         .bind(leagueId)
         .all<LeagueContractQueryRow>();

--- a/backend/src/repositories/d1/contractRepositoryD1.ts
+++ b/backend/src/repositories/d1/contractRepositoryD1.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@js-temporal/polyfill";
 import { Contract } from "../../../../model";
-import { MAX_TEAM_CONTRACTS, STARTING_CREDITS } from "../../../../model/team";
+import { MAX_TEAM_CONTRACTS } from "../../../../model/team";
 import {
   ContractRepository,
   CONTRACT_WRITE_ERRORS,
@@ -105,19 +105,12 @@ export class ContractRepositoryD1 implements ContractRepository {
 
   async getByLeagueId(leagueId: string): Promise<Result<LeagueContractRow[]>> {
     try {
-      // teamCredits is derived from the contracts ledger (see
-      // TeamRepositoryD1.getByPlayerAndLeague), computed once per team via a
-      // CTE rather than a stored column.
+      // teamCredits comes from the team_credits view — the single SQL
+      // statement of the derivation (migration 0006, ADR 0007) — never from a
+      // stored column and never re-derived here.
       const result = await this.db
         .prepare(
-          `WITH team_credits AS (
-             SELECT teamId,
-                    ? - COALESCE(SUM(purchasePrice), 0)
-                      + COALESCE(SUM(CASE WHEN settled = 1 THEN salePayout ELSE 0 END), 0) AS credits
-             FROM contracts
-             GROUP BY teamId
-           )
-           SELECT c.*, t.name AS teamName, tc.credits AS teamCredits,
+          `SELECT c.*, t.name AS teamName, tc.credits AS teamCredits,
                   p.id AS playerId, p.username AS playerName
            FROM contracts c
            JOIN teams t ON c.teamId = t.id
@@ -125,7 +118,7 @@ export class ContractRepositoryD1 implements ContractRepository {
            JOIN team_credits tc ON tc.teamId = t.id
            WHERE t.leagueId = ? AND c.settled = 0`,
         )
-        .bind(STARTING_CREDITS, leagueId)
+        .bind(leagueId)
         .all<LeagueContractQueryRow>();
 
       return success(result.results.map(toLeagueContractRow));
@@ -144,20 +137,19 @@ export class ContractRepositoryD1 implements ContractRepository {
 
       // Single guarded write, no db.batch needed: the INSERT only applies if
       // every purchase condition still holds at write time — derived credits
-      // (STARTING_CREDITS - everything ever spent + everything recovered from
-      // early sales) cover the price, no team in the league holds an active
-      // contract on the article, and the team is under its contract cap.
-      // Naturally atomic — SQLite/D1 guarantee single-statement atomicity
-      // against concurrent writers — so a concurrent purchase can't slip in
-      // between the service's pre-checks and this write.
+      // (read from the team_credits view) cover the price, no team in the
+      // league holds an active contract on the article, and the team is under
+      // its contract cap. Naturally atomic — SQLite/D1 guarantee
+      // single-statement atomicity against concurrent writers — so a
+      // concurrent purchase can't slip in between the service's pre-checks and
+      // this write. The view is evaluated inline as part of this statement, so
+      // reading credits through it costs nothing in atomicity: this is still
+      // one statement, and it is still what enforces the invariant (ADR 0007).
       const result = await this.db
         .prepare(
           `INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice, settled, renewalCount, renewalElected)
            SELECT ?, ?, ?, ?, ?, ?, 0, 0, 0
-           WHERE (
-             ? - COALESCE((SELECT SUM(purchasePrice) FROM contracts WHERE teamId = ?), 0)
-               + COALESCE((SELECT SUM(salePayout) FROM contracts WHERE teamId = ? AND settled = 1), 0)
-           ) >= ?
+           WHERE (SELECT credits FROM team_credits WHERE teamId = ?) >= ?
            AND NOT EXISTS (
              SELECT 1
              FROM contracts c
@@ -175,8 +167,6 @@ export class ContractRepositoryD1 implements ContractRepository {
           purchaseDate,
           expireDate,
           newContract.purchasePrice,
-          STARTING_CREDITS,
-          newContract.teamId,
           newContract.teamId,
           newContract.purchasePrice,
           newContract.articleId,
@@ -241,26 +231,19 @@ export class ContractRepositoryD1 implements ContractRepository {
     today: Temporal.PlainDate,
   ): Promise<Result<DueContract[]>> {
     try {
-      // teamCredits is derived from the same ledger as getByLeagueId; domain
-      // comes from the owning team's league. The WHERE clause rides the
+      // teamCredits comes from the same team_credits view as getByLeagueId;
+      // domain comes from the owning team's league. The WHERE clause rides the
       // idx_contracts_settled_expire (settled, expireDate) index.
       const result = await this.db
         .prepare(
-          `WITH team_credits AS (
-             SELECT teamId,
-                    ? - COALESCE(SUM(purchasePrice), 0)
-                      + COALESCE(SUM(CASE WHEN settled = 1 THEN salePayout ELSE 0 END), 0) AS credits
-             FROM contracts
-             GROUP BY teamId
-           )
-           SELECT c.*, l.domain AS domain, tc.credits AS teamCredits
+          `SELECT c.*, l.domain AS domain, tc.credits AS teamCredits
            FROM contracts c
            JOIN teams t ON c.teamId = t.id
            JOIN leagues l ON t.leagueId = l.id
            JOIN team_credits tc ON tc.teamId = t.id
            WHERE c.settled = 0 AND c.expireDate <= ?`,
         )
-        .bind(STARTING_CREDITS, today.toString())
+        .bind(today.toString())
         .all<DueContractQueryRow>();
 
       return success(result.results.map(toDueContract));

--- a/backend/src/repositories/d1/notificationRepositoryD1.ts
+++ b/backend/src/repositories/d1/notificationRepositoryD1.ts
@@ -4,7 +4,6 @@ import {
   NotificationRow,
   NOTIFICATION_ERRORS,
 } from "../notificationRepository";
-import { STARTING_CREDITS } from "../../../../model/team";
 import { Result, success, failure } from "../result";
 
 interface NotificationJoinRow {
@@ -25,18 +24,10 @@ interface NotificationJoinRow {
   playerName: string;
 }
 
-// credits is derived from the contracts ledger (see
-// TeamRepositoryD1.getByPlayerAndLeague) via a CTE rather than a stored
-// column. Its bind param (STARTING_CREDITS) must be the first `?` supplied by
-// every caller of this fragment, before their own WHERE params.
+// credits comes from the team_credits view (migration 0006, ADR 0007) rather
+// than a stored column. The view takes no parameters, so this fragment binds
+// nothing of its own and callers supply only their own WHERE params.
 const SELECT_NOTIFICATIONS = `
-  WITH team_credits AS (
-    SELECT teamId,
-           ? - COALESCE(SUM(purchasePrice), 0)
-             + COALESCE(SUM(CASE WHEN settled = 1 THEN salePayout ELSE 0 END), 0) AS credits
-    FROM contracts
-    GROUP BY teamId
-  )
   SELECT n.id, n.message, n.date, n.isRead,
          c.id AS contractId, c.articleId, c.purchaseDate, c.expireDate, c.purchasePrice,
          t.id AS teamId, t.name AS teamName, tc.credits, t.leagueId,
@@ -68,7 +59,7 @@ export class NotificationRepositoryD1 implements NotificationRepository {
         .prepare(
           `${SELECT_NOTIFICATIONS} WHERE t.playerId = ? AND t.leagueId = ? ORDER BY n.date DESC`,
         )
-        .bind(STARTING_CREDITS, playerId, leagueId)
+        .bind(playerId, leagueId)
         .all<NotificationJoinRow>();
 
       return success(result.results.map(toNotificationRow));
@@ -85,7 +76,7 @@ export class NotificationRepositoryD1 implements NotificationRepository {
         .prepare(
           `${SELECT_NOTIFICATIONS} WHERE t.playerId = ? ORDER BY n.date DESC`,
         )
-        .bind(STARTING_CREDITS, playerId)
+        .bind(playerId)
         .all<NotificationJoinRow>();
 
       return success(result.results.map(toNotificationRow));

--- a/backend/src/repositories/d1/notificationRepositoryD1.ts
+++ b/backend/src/repositories/d1/notificationRepositoryD1.ts
@@ -27,6 +27,11 @@ interface NotificationJoinRow {
 // credits comes from the team_credits view (migration 0006, ADR 0007) rather
 // than a stored column. The view takes no parameters, so this fragment binds
 // nothing of its own and callers supply only their own WHERE params.
+//
+// Callers must scope by `tc.playerId` / `tc.leagueId` rather than by the
+// joined `t.` row: the view is recomputed per statement, and only a constraint
+// on its own columns gets pushed down into the aggregate. Filtering on `t.`
+// instead would sum every team in the database before discarding all but one.
 const SELECT_NOTIFICATIONS = `
   SELECT n.id, n.message, n.date, n.isRead,
          c.id AS contractId, c.articleId, c.purchaseDate, c.expireDate, c.purchasePrice,
@@ -57,7 +62,7 @@ export class NotificationRepositoryD1 implements NotificationRepository {
     try {
       const result = await this.db
         .prepare(
-          `${SELECT_NOTIFICATIONS} WHERE t.playerId = ? AND t.leagueId = ? ORDER BY n.date DESC`,
+          `${SELECT_NOTIFICATIONS} WHERE tc.playerId = ? AND tc.leagueId = ? ORDER BY n.date DESC`,
         )
         .bind(playerId, leagueId)
         .all<NotificationJoinRow>();
@@ -74,7 +79,7 @@ export class NotificationRepositoryD1 implements NotificationRepository {
     try {
       const result = await this.db
         .prepare(
-          `${SELECT_NOTIFICATIONS} WHERE t.playerId = ? ORDER BY n.date DESC`,
+          `${SELECT_NOTIFICATIONS} WHERE tc.playerId = ? ORDER BY n.date DESC`,
         )
         .bind(playerId)
         .all<NotificationJoinRow>();

--- a/backend/src/repositories/d1/performanceRepositoryD1.ts
+++ b/backend/src/repositories/d1/performanceRepositoryD1.ts
@@ -84,7 +84,9 @@ export class PerformanceRepositoryD1 implements PerformanceRepository {
       // teamCredits comes from the team_credits view (migration 0006, ADR
       // 0007) rather than a stored column. The view has a row for every team,
       // including one that has never bought a contract, so this is a plain
-      // JOIN with no starting-budget fallback restated here.
+      // JOIN with no starting-budget fallback restated here. The league filter
+      // names the view's own leagueId so SQLite narrows the aggregate to this
+      // league rather than building it for every team in the database.
       const latestRows = await this.db
         .prepare(
           `SELECT t.id AS teamId, t.name AS teamName, tc.credits AS teamCredits,
@@ -94,7 +96,7 @@ export class PerformanceRepositoryD1 implements PerformanceRepository {
            JOIN players pl ON pl.id = t.playerId
            JOIN team_credits tc ON tc.teamId = t.id
            LEFT JOIN performances p ON p.teamId = t.id
-           WHERE t.leagueId = ?
+           WHERE tc.leagueId = ?
            GROUP BY t.id, t.name, tc.credits, pl.id, pl.username`,
         )
         .bind(leagueId)

--- a/backend/src/repositories/d1/performanceRepositoryD1.ts
+++ b/backend/src/repositories/d1/performanceRepositoryD1.ts
@@ -1,6 +1,5 @@
 import { Temporal } from "@js-temporal/polyfill";
 import { Performance } from "../../../../model";
-import { STARTING_CREDITS } from "../../../../model/team";
 import { Result, success, failure } from "../result";
 import type {
   PerformanceRepository,
@@ -82,29 +81,23 @@ export class PerformanceRepositoryD1 implements PerformanceRepository {
     leagueId: string,
   ): Promise<Result<TeamCumulative[]>> {
     try {
-      // teamCredits is derived from the contracts ledger (see
-      // TeamRepositoryD1.getByPlayerAndLeague) via a CTE rather than a stored
-      // column.
+      // teamCredits comes from the team_credits view (migration 0006, ADR
+      // 0007) rather than a stored column. The view has a row for every team,
+      // including one that has never bought a contract, so this is a plain
+      // JOIN with no starting-budget fallback restated here.
       const latestRows = await this.db
         .prepare(
-          `WITH team_credits AS (
-             SELECT teamId,
-                    ? - COALESCE(SUM(purchasePrice), 0)
-                      + COALESCE(SUM(CASE WHEN settled = 1 THEN salePayout ELSE 0 END), 0) AS credits
-             FROM contracts
-             GROUP BY teamId
-           )
-           SELECT t.id AS teamId, t.name AS teamName, COALESCE(tc.credits, ?) AS teamCredits,
+          `SELECT t.id AS teamId, t.name AS teamName, tc.credits AS teamCredits,
                   pl.id AS playerId, pl.username AS playerName,
                   COALESCE(SUM(p.points), 0) AS total
            FROM teams t
            JOIN players pl ON pl.id = t.playerId
-           LEFT JOIN team_credits tc ON tc.teamId = t.id
+           JOIN team_credits tc ON tc.teamId = t.id
            LEFT JOIN performances p ON p.teamId = t.id
            WHERE t.leagueId = ?
            GROUP BY t.id, t.name, tc.credits, pl.id, pl.username`,
         )
-        .bind(STARTING_CREDITS, STARTING_CREDITS, leagueId)
+        .bind(leagueId)
         .all<{
           teamId: string;
           teamName: string;

--- a/backend/src/repositories/d1/teamRepositoryD1.ts
+++ b/backend/src/repositories/d1/teamRepositoryD1.ts
@@ -78,12 +78,20 @@ export class TeamRepositoryD1 implements TeamRepository {
       // derivation itself lives in the team_credits view (migration 0006, ADR
       // 0007) — the one place it is written in SQL — and every team has a row
       // there, so this is a plain JOIN with no fallback.
+      //
+      // Filtered on the view's own playerId/leagueId, not on the joined teams
+      // row: the view is inlined and recomputed per statement, and SQLite only
+      // pushes a constraint down into its aggregate when the constraint names
+      // the view's GROUP BY columns. Written this way it seeks one team via
+      // UNIQUE (playerId, leagueId) and sums only that team's contracts;
+      // written as `WHERE t.playerId = ?` it would aggregate every team in the
+      // database on every dashboard load.
       const result = await this.db
         .prepare(
           `SELECT t.id, t.name, t.playerId, t.leagueId, tc.credits
-           FROM teams t
-           JOIN team_credits tc ON tc.teamId = t.id
-           WHERE t.playerId = ? AND t.leagueId = ?`,
+           FROM team_credits tc
+           JOIN teams t ON t.id = tc.teamId
+           WHERE tc.playerId = ? AND tc.leagueId = ?`,
         )
         .bind(playerId, leagueId)
         .first<Team>();

--- a/backend/src/repositories/d1/teamRepositoryD1.ts
+++ b/backend/src/repositories/d1/teamRepositoryD1.ts
@@ -74,19 +74,18 @@ export class TeamRepositoryD1 implements TeamRepository {
     leagueId: string,
   ): Promise<Result<Team | null>> {
     try {
-      // credits is derived from the contracts ledger, not stored: starting
-      // budget minus everything ever spent, plus payouts from early sales.
+      // credits is derived from the contracts ledger, not stored. The
+      // derivation itself lives in the team_credits view (migration 0006, ADR
+      // 0007) — the one place it is written in SQL — and every team has a row
+      // there, so this is a plain JOIN with no fallback.
       const result = await this.db
         .prepare(
-          `SELECT t.id, t.name, t.playerId, t.leagueId,
-                  ? - COALESCE(SUM(c.purchasePrice), 0)
-                    + COALESCE(SUM(CASE WHEN c.settled = 1 THEN c.salePayout ELSE 0 END), 0) AS credits
+          `SELECT t.id, t.name, t.playerId, t.leagueId, tc.credits
            FROM teams t
-           LEFT JOIN contracts c ON c.teamId = t.id
-           WHERE t.playerId = ? AND t.leagueId = ?
-           GROUP BY t.id, t.name, t.playerId, t.leagueId`,
+           JOIN team_credits tc ON tc.teamId = t.id
+           WHERE t.playerId = ? AND t.leagueId = ?`,
         )
-        .bind(STARTING_CREDITS, playerId, leagueId)
+        .bind(playerId, leagueId)
         .first<Team>();
 
       return success(result ?? null);

--- a/backend/src/tests/integration/leaderboard.integration.test.ts
+++ b/backend/src/tests/integration/leaderboard.integration.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { LeaderboardService } from "../../services/leaderboard";
 import { GLOBAL_LEAGUE_ID } from "../../services/league";
 import { resetD1Database, insertTeam } from "../utils/d1TestUtils";
+import { STARTING_CREDITS } from "../../../../model/team";
 
 const TEAMS = [
   { id: "team-lb-1", name: "Alpha FC", playerId: "player-lb-1" },
@@ -68,6 +69,12 @@ describe("LeaderboardService.getLeaderboard", () => {
     expect(result.value.every((e) => e.cumulativePoints === 0)).toBe(true);
     expect(result.value.every((e) => e.rankDelta === null)).toBe(true);
     expect(result.value.map((e) => e.rank)).toEqual([1, 2, 3]);
+    // A team that has never bought a contract still reads its full budget
+    // straight out of the team_credits view (ADR 0007) — the view is driven
+    // from `teams`, so there is no missing row for the query to fall back on.
+    expect(result.value.every((e) => e.team.credits === STARTING_CREDITS)).toBe(
+      true,
+    );
   });
 
   it("keeps an unscored team in the table alongside scored ones", async () => {

--- a/backend/src/tests/integration/team.integration.test.ts
+++ b/backend/src/tests/integration/team.integration.test.ts
@@ -5,7 +5,11 @@ import { PlayerService } from "../../services/player";
 import { TeamRepositoryD1 } from "../../repositories/d1/teamRepositoryD1";
 import type { TeamRepository } from "../../repositories/teamRepository";
 import { success, failure } from "../../repositories/result";
-import { STARTING_CREDITS } from "../../../../model/team";
+import {
+  deriveCreditsFromLedger,
+  STARTING_CREDITS,
+  type CreditLedgerEntry,
+} from "../../../../model/team";
 import type { Team } from "../../../../model";
 
 describe("TeamService Integration Tests", () => {
@@ -258,6 +262,113 @@ describe("TeamService Integration Tests", () => {
           player: { id: playerId, name: "Bob" },
         });
       }
+    });
+  });
+
+  // The team_credits view is the single SQL statement of the Team aggregate's
+  // core invariant (ADR 0007). These assert it against the model's pure
+  // `deriveCreditsFromLedger` — spec and concurrency-safe implementation are
+  // duplicated on purpose, so tests are what keep them equal.
+  describe("team_credits view", () => {
+    const TEAM_ID = "team-credits-view";
+
+    async function creditsFromView(teamId: string): Promise<number | null> {
+      const row = await env.db
+        .prepare("SELECT credits FROM team_credits WHERE teamId = ?")
+        .bind(teamId)
+        .first<{ credits: number }>();
+      return row?.credits ?? null;
+    }
+
+    async function insertContract(
+      opts: Pick<CreditLedgerEntry, "purchasePrice" | "settled" | "salePayout">,
+    ): Promise<void> {
+      await env.db
+        .prepare(
+          `INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice, settled, salePayout)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+          crypto.randomUUID(),
+          TEAM_ID,
+          `article-${crypto.randomUUID()}`,
+          "2026-01-01",
+          "2026-01-08",
+          opts.purchasePrice,
+          opts.settled ? 1 : 0,
+          opts.salePayout,
+        )
+        .run();
+    }
+
+    beforeEach(async () => {
+      await env.db
+        .prepare(
+          "INSERT INTO teams (id, name, playerId, leagueId) VALUES (?, ?, ?, ?)",
+        )
+        .bind(TEAM_ID, "Ledger FC", playerId, leagueId)
+        .run();
+    });
+
+    // The drift guard for the one value the view cannot bind: SQLite views
+    // take no parameters, so the starting budget is inlined in migration 0006
+    // and this is what fails if it stops matching model/team.ts.
+    it("should yield exactly STARTING_CREDITS for a team with no contracts", async () => {
+      expect(await creditsFromView(TEAM_ID)).toBe(STARTING_CREDITS);
+    });
+
+    it("should match the model's derivation for a mixed ledger", async () => {
+      const ledger: CreditLedgerEntry[] = [
+        { purchasePrice: 150, settled: false, salePayout: null },
+        { purchasePrice: 80, settled: false, salePayout: null },
+        { purchasePrice: 200, settled: true, salePayout: 260 },
+        { purchasePrice: 50, settled: true, salePayout: 10 },
+      ];
+      for (const entry of ledger) {
+        await insertContract(entry);
+      }
+
+      expect(await creditsFromView(TEAM_ID)).toBe(
+        deriveCreditsFromLedger(STARTING_CREDITS, ledger),
+      );
+    });
+
+    it("should not credit a payout until the contract is settled", async () => {
+      await insertContract({
+        purchasePrice: 150,
+        settled: false,
+        salePayout: 90,
+      });
+
+      expect(await creditsFromView(TEAM_ID)).toBe(STARTING_CREDITS - 150);
+    });
+
+    it("should treat a settled contract with a null payout as recovering nothing", async () => {
+      await insertContract({
+        purchasePrice: 150,
+        settled: true,
+        salePayout: null,
+      });
+
+      expect(await creditsFromView(TEAM_ID)).toBe(STARTING_CREDITS - 150);
+    });
+
+    it("should scope the derivation to one team", async () => {
+      const otherTeamId = "team-credits-view-other";
+      await env.db
+        .prepare(
+          "INSERT INTO teams (id, name, playerId, leagueId) VALUES (?, ?, ?, ?)",
+        )
+        .bind(otherTeamId, "Bystander FC", "system", leagueId)
+        .run();
+      await insertContract({
+        purchasePrice: 150,
+        settled: false,
+        salePayout: null,
+      });
+
+      expect(await creditsFromView(TEAM_ID)).toBe(STARTING_CREDITS - 150);
+      expect(await creditsFromView(otherTeamId)).toBe(STARTING_CREDITS);
     });
   });
 });

--- a/backend/src/tests/team.spec.ts
+++ b/backend/src/tests/team.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveCredits,
+  deriveCreditsFromLedger,
+  STARTING_CREDITS,
+  type CreditLedgerEntry,
+} from "../../../model/team";
+
+/**
+ * The canonical statement of the Team aggregate's core invariant (ADR 0007).
+ * These assert the *rule*; the equivalent `team_credits` view is asserted
+ * against these same numbers in team.integration.test.ts.
+ */
+describe("deriveCredits", () => {
+  it("returns the starting budget for a team that has bought nothing", () => {
+    expect(deriveCredits(STARTING_CREDITS, [], [])).toBe(STARTING_CREDITS);
+  });
+
+  it("subtracts every purchase price", () => {
+    expect(deriveCredits(1000, [150, 80, 20], [])).toBe(750);
+  });
+
+  it("adds back payouts recovered from settled contracts", () => {
+    expect(deriveCredits(1000, [150, 80], [90])).toBe(860);
+  });
+
+  it("can leave a team richer than it started when payouts beat purchases", () => {
+    expect(deriveCredits(1000, [100], [340])).toBe(1240);
+  });
+
+  it("does not floor at zero — overspending would be visible, not hidden", () => {
+    // Nothing in the derivation clamps: a negative balance means the guarded
+    // INSERT let something through, and the read should show it rather than
+    // silently reporting 0.
+    expect(deriveCredits(1000, [1200], [])).toBe(-200);
+  });
+
+  it("handles fractional prices without rounding", () => {
+    expect(deriveCredits(1000, [10.5, 3.25], [1.75])).toBe(988);
+  });
+});
+
+describe("deriveCreditsFromLedger", () => {
+  const unsettled = (purchasePrice: number): CreditLedgerEntry => ({
+    purchasePrice,
+    settled: false,
+    salePayout: null,
+  });
+  const settled = (
+    purchasePrice: number,
+    salePayout: number,
+  ): CreditLedgerEntry => ({ purchasePrice, settled: true, salePayout });
+
+  it("returns the starting budget for an empty ledger", () => {
+    expect(deriveCreditsFromLedger(STARTING_CREDITS, [])).toBe(
+      STARTING_CREDITS,
+    );
+  });
+
+  it("counts an unsettled contract as spent and recovers nothing", () => {
+    expect(deriveCreditsFromLedger(1000, [unsettled(150)])).toBe(850);
+  });
+
+  it("recovers the payout once a contract is settled", () => {
+    expect(deriveCreditsFromLedger(1000, [settled(150, 90)])).toBe(940);
+  });
+
+  it("ignores a payout written on a contract that is not settled yet", () => {
+    // Mirrors the view's `CASE WHEN settled = 1`: settlement, not the presence
+    // of a payout value, is what releases the credits.
+    const ledger: CreditLedgerEntry[] = [
+      { purchasePrice: 150, settled: false, salePayout: 90 },
+    ];
+    expect(deriveCreditsFromLedger(1000, ledger)).toBe(850);
+  });
+
+  it("treats a settled contract with no payout as recovering nothing", () => {
+    const ledger: CreditLedgerEntry[] = [
+      { purchasePrice: 150, settled: true, salePayout: null },
+    ];
+    expect(deriveCreditsFromLedger(1000, ledger)).toBe(850);
+  });
+
+  it("sums a mixed ledger of held and settled contracts", () => {
+    const ledger = [
+      unsettled(150),
+      unsettled(80),
+      settled(200, 260),
+      settled(50, 10),
+    ];
+    expect(deriveCreditsFromLedger(STARTING_CREDITS, ledger)).toBe(790);
+  });
+
+  it("agrees with deriveCredits on the same ledger", () => {
+    const ledger = [unsettled(150), settled(200, 260)];
+
+    expect(deriveCreditsFromLedger(STARTING_CREDITS, ledger)).toBe(
+      deriveCredits(STARTING_CREDITS, [150, 200], [260]),
+    );
+  });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,7 +66,8 @@ doc disagree, **the ADR wins**.
 [0002 Language Scale Factor](./adr/0002-language-scale-factor.md) ·
 [0003 Closed Trading Economy](./adr/0003-closed-trading-economy.md) ·
 [0004 Scoring Engine Platform](./adr/0004-scoring-engine-platform.md) ·
-[0005 Contract Pricing](./adr/0005-contract-pricing.md)
+[0005 Contract Pricing](./adr/0005-contract-pricing.md) ·
+[0007 Team Credits Derived and Enforced at the Write](./adr/0007-team-credits-derived-and-enforced-at-write.md)
 
 ### `agents/` — machine-read repo metadata
 Issue tracker, triage labels, and domain-context layout. Skills read these at

--- a/docs/adr/0007-team-credits-derived-and-enforced-at-write.md
+++ b/docs/adr/0007-team-credits-derived-and-enforced-at-write.md
@@ -94,19 +94,21 @@ It is now stated once, as the `team_credits` view:
 ```sql
 CREATE VIEW team_credits AS
 SELECT t.id AS teamId,
+       t.playerId AS playerId,
+       t.leagueId AS leagueId,
        1000
          - COALESCE(SUM(c.purchasePrice), 0)
          + COALESCE(SUM(CASE WHEN c.settled = 1 THEN c.salePayout ELSE 0 END), 0) AS credits
 FROM teams t
 LEFT JOIN contracts c ON c.teamId = t.id
-GROUP BY t.id;
+GROUP BY t.id, t.playerId, t.leagueId;
 ```
 
 Every reader joins the view. The guarded `INSERT` reads it as a scalar
 subquery, which changes nothing about its atomicity — a view is inlined into
 the referencing statement, so it is still one statement doing the enforcing.
 
-Two shape choices are load-bearing:
+Three shape choices are load-bearing:
 
 - **Driven from `teams`, not from `contracts`.** Grouping over `contracts`
   alone gives no row at all for a team that has never bought anything, which
@@ -114,6 +116,16 @@ Two shape choices are load-bearing:
   — the duplication we are removing, in a subtler form. Driving from `teams`
   gives every team exactly one row, so a brand-new team reads
   `STARTING_CREDITS` straight out of the view.
+- **`playerId` and `leagueId` are exposed and named in the `GROUP BY`, and
+  callers filter on them.** A view is not a cache: SQLite has no materialised
+  views, so the aggregate is recomputed as part of every statement that
+  references it. What decides the cost is therefore whether SQLite can push the
+  caller's `WHERE` clause down into the aggregate, and it only does that for
+  constraints naming the view's own `GROUP BY` columns. `WHERE tc.leagueId = ?`
+  narrows the aggregate to one league; the equivalent `WHERE t.leagueId = ?` on
+  a joined `teams` row does not, and builds it for every team in the database
+  first. `EXPLAIN QUERY PLAN` is the check: the view's `CO-ROUTINE` block
+  should show a `SEARCH` on an index, not a bare `SCAN t`.
 - **The starting budget is inlined.** SQLite views cannot take parameters, so
   `1000` appears literally in the view instead of being bound from
   `STARTING_CREDITS`. This is the one piece of duplication the change does not
@@ -136,10 +148,13 @@ honest by tests that assert both produce the same number for the same ledger.
 
 ## Consequences
 
-- Reading a balance always costs an aggregate over the team's contracts. If
-  that ever shows up in profiling, the fix is a materialised summary
-  maintained by triggers — not a hand-maintained column, and not moving the
-  check into the service layer.
+- Reading a balance always costs an aggregate over the team's contracts, on
+  every read — nothing is cached. Adding a reader that filters the view on a
+  joined table's columns instead of the view's own silently turns a per-team
+  aggregate into a whole-database one, so new call sites should be checked with
+  `EXPLAIN QUERY PLAN`. If the per-read cost ever shows up in profiling, the
+  fix is a materialised summary maintained by triggers — not a hand-maintained
+  column, and not moving the check into the service layer.
 - The formula lives in a migration, and migrations are immutable history.
   Changing `STARTING_CREDITS` means a new migration redefining the view *and*
   the constant in `model/team.ts`. Note this retroactively restates every

--- a/docs/adr/0007-team-credits-derived-and-enforced-at-write.md
+++ b/docs/adr/0007-team-credits-derived-and-enforced-at-write.md
@@ -1,0 +1,159 @@
+---
+title: "ADR 0007: Team Credits Are Derived, Not Stored, and Enforced at the Write"
+type: adr
+tags: [economy, credits, concurrency, persistence, decision]
+---
+
+# Team credits are derived, not stored, and enforced at the write
+
+> **Status:** accepted, implemented. The derivation lives in the `team_credits`
+> SQL view (`backend/migrations/0006_team_credits_view.sql`) and is mirrored as
+> a pure function in `model/team.ts`.
+
+A team's credit balance is the Team aggregate's core invariant:
+
+```
+credits = STARTING_CREDITS − Σ purchasePrice + Σ salePayout (where settled)
+```
+
+Two decisions are recorded here, and they pull in opposite directions on
+purpose.
+
+## Decision 1 — credits are derived from the contracts ledger, never stored
+
+There is no `teams.credits` column. Migration
+`0005_derive_team_credits.sql` dropped it and added `contracts.salePayout` so
+that every event that moves a balance — a purchase, an early sale, a settlement
+at expiry — is a row in the contracts ledger and nothing else.
+
+A stored balance would be a second source of truth for something the ledger
+already fully determines. Any write that updated one without the other, or
+crashed between the two, leaves a team richer or poorer than its own contract
+history says it should be, permanently and silently. Deriving removes that
+failure mode by construction: there is nothing to drift.
+
+The cost is that every read of a balance is an aggregate over that team's
+contracts. At the scale this game operates (tens of contracts per team, capped
+at `MAX_TEAM_CONTRACTS` active) that is a cheap grouped scan, and it buys an
+invariant that cannot be violated by a partial write.
+
+## Decision 2 — the invariant is enforced at the write, in SQL, not in the aggregate
+
+Classic DDD says an aggregate enforces its own invariants: the service loads
+the Team, asks it whether it can afford the contract, and persists the result.
+We deliberately do **not** do that for credits.
+
+The reason is a race. Read-then-write in the application layer looks like:
+
+1. Request A reads credits = 100, price = 80 → affordable.
+2. Request B reads credits = 100, price = 80 → affordable.
+3. A writes its contract. B writes its contract.
+4. The team has spent 160 of its 100 credits.
+
+Nothing in the application layer prevents step 2, because the check and the
+write are two separate round trips to D1 and another request can interleave
+between them. The same argument applies to `MAX_TEAM_CONTRACTS`: two concurrent
+buys at 21 active contracts both see room and both commit, landing the team on
+23.
+
+So the credit check, the contract-count check and the insert are **one
+statement** — the guarded `INSERT` in
+`ContractRepositoryD1.create`, which inserts only if the conditions still hold
+at write time:
+
+```sql
+INSERT INTO contracts (...)
+SELECT ?, ?, ?, ?, ?, ?, 0, 0, 0
+WHERE (SELECT credits FROM team_credits WHERE teamId = ?) >= ?
+  AND NOT EXISTS (... article already owned in this league ...)
+  AND (SELECT COUNT(*) FROM contracts WHERE teamId = ? AND settled = 0) < ?
+```
+
+SQLite (and therefore D1) guarantees single-statement atomicity against
+concurrent writers, so the interleaving above cannot happen: the loser inserts
+zero rows and the repository returns `PURCHASE_CONFLICT`. The service's
+pre-checks upstream still exist — they produce good error messages — but they
+are not what makes the invariant hold. This statement is.
+
+Settlement writes are guarded the same way and for the same reason:
+`settleSale` and `settleExpiry` flip `settled` and persist the payout in one
+`UPDATE` guarded on `settled = 0`, which is what makes a double-sell and a
+re-run of the nightly sweep both no-ops.
+
+## Decision 3 — the derivation is written exactly once in SQL
+
+The consequence of decision 2 is that the rule has to be expressed in SQL. The
+consequence of decision 1 is that it is needed at every site that reads a
+balance. Before this ADR, that meant the formula was hand-copied into four
+repositories (`contractRepositoryD1`, `teamRepositoryD1`,
+`notificationRepositoryD1`, `performanceRepositoryD1`) — four chances to fix a
+bug in three places.
+
+It is now stated once, as the `team_credits` view:
+
+```sql
+CREATE VIEW team_credits AS
+SELECT t.id AS teamId,
+       1000
+         - COALESCE(SUM(c.purchasePrice), 0)
+         + COALESCE(SUM(CASE WHEN c.settled = 1 THEN c.salePayout ELSE 0 END), 0) AS credits
+FROM teams t
+LEFT JOIN contracts c ON c.teamId = t.id
+GROUP BY t.id;
+```
+
+Every reader joins the view. The guarded `INSERT` reads it as a scalar
+subquery, which changes nothing about its atomicity — a view is inlined into
+the referencing statement, so it is still one statement doing the enforcing.
+
+Two shape choices are load-bearing:
+
+- **Driven from `teams`, not from `contracts`.** Grouping over `contracts`
+  alone gives no row at all for a team that has never bought anything, which
+  forces every caller to re-state the starting budget in a `COALESCE` fallback
+  — the duplication we are removing, in a subtler form. Driving from `teams`
+  gives every team exactly one row, so a brand-new team reads
+  `STARTING_CREDITS` straight out of the view.
+- **The starting budget is inlined.** SQLite views cannot take parameters, so
+  `1000` appears literally in the view instead of being bound from
+  `STARTING_CREDITS`. This is the one piece of duplication the change does not
+  eliminate, and it is guarded by an integration test asserting the view's
+  value for a contract-less team equals `STARTING_CREDITS`. Drift fails CI
+  rather than silently mispricing every balance in the game.
+
+## Decision 4 — the rule is mirrored as a pure function in `model/`
+
+`model/team.ts` exposes `deriveCredits(startingCredits, purchases, payouts)`
+and `deriveCreditsFromLedger`. They do **not** run in the purchase path — they
+would reintroduce the race if they did. They exist so the aggregate's core
+invariant has one readable, testable statement in the domain model instead of
+existing only as SQL the model cannot see, and so a reader of `model/team.ts`
+learns the rule without opening a migration.
+
+The duplication between the pure function and the view is accepted and
+deliberate: it is a specification and its concurrency-safe implementation, kept
+honest by tests that assert both produce the same number for the same ledger.
+
+## Consequences
+
+- Reading a balance always costs an aggregate over the team's contracts. If
+  that ever shows up in profiling, the fix is a materialised summary
+  maintained by triggers — not a hand-maintained column, and not moving the
+  check into the service layer.
+- The formula lives in a migration, and migrations are immutable history.
+  Changing `STARTING_CREDITS` means a new migration redefining the view *and*
+  the constant in `model/team.ts`. Note this retroactively restates every
+  team's balance either way, since nothing is stored.
+- A future migration cannot drop or rename `contracts.purchasePrice`,
+  `contracts.salePayout`, `contracts.settled` or `teams.id` without recreating
+  the view in the same migration — SQLite validates views on schema change.
+- The service layer's affordability pre-checks are now explicitly advisory.
+  Removing one degrades an error message, it does not open a hole; changing the
+  guarded `INSERT` does open one.
+
+## Related
+
+- [ADR 0003: Closed Trading Economy](./0003-closed-trading-economy.md)
+- [ADR 0005: Contract Pricing](./0005-contract-pricing.md)
+- [Scoring & Economy System](../domain/scoring-system.md)
+- [Backend Architecture](../architecture/backend-architecture.md)

--- a/model/team.ts
+++ b/model/team.ts
@@ -10,10 +10,12 @@ export interface Team {
  * ADR 0003/0005: starting budget for every new team — 1,000 credits, no
  * per-language scale factor needed (points-based pricing doesn't reproduce
  * the rounding-to-zero issue the old views^1.5 formula had). Lives in the
- * shared model package rather than backend-only because the repository layer
- * needs it in multiple places to derive a team's current credits from the
- * contracts ledger: `credits = STARTING_CREDITS - sum(purchasePrice) +
- * sum(salePayout where settled)`, computed at read time rather than stored.
+ * shared model package rather than backend-only because both surfaces need
+ * it: the frontend to explain the budget to a new player, and the backend as
+ * the base of the credit derivation below.
+ *
+ * The `team_credits` SQL view inlines this value (SQLite views take no
+ * parameters). The two MUST stay equal — an integration test asserts it.
  */
 export const STARTING_CREDITS = 1000;
 
@@ -23,3 +25,63 @@ export const STARTING_CREDITS = 1000;
  * guarded contract INSERT that checks the derived credits.
  */
 export const MAX_TEAM_CONTRACTS = 22;
+
+/**
+ * The part of a contract the credit derivation reads. Deliberately narrower
+ * than `Contract`: credits depend on the price paid and, once settled, the
+ * payout recovered — nothing else about the contract's lifecycle.
+ */
+export interface CreditLedgerEntry {
+  purchasePrice: number;
+  settled: boolean;
+  /** Proceeds recovered at settlement (early sale or expiry). Null until settled. */
+  salePayout: number | null;
+}
+
+/**
+ * A team's credit balance — the Team aggregate's core invariant:
+ *
+ * ```
+ * credits = startingCredits − Σ purchasePrice + Σ salePayout (where settled)
+ * ```
+ *
+ * Credits are **derived, never stored**: there is no balance column to drift
+ * out of sync with the contracts ledger.
+ *
+ * This function is the canonical, readable statement of the rule, and what the
+ * model tests assert against. It is **not** what runs in production: the
+ * balance is enforced at the write, inside a single guarded `INSERT` that
+ * reads the equivalent `team_credits` SQL view, because splitting the check
+ * from the write would let two concurrent purchases both pass it. See
+ * `docs/adr/0007-team-credits-derived-and-enforced-at-write.md` for the race
+ * that shape prevents and why the duplication between here and SQL is
+ * deliberate.
+ */
+export function deriveCredits(
+  startingCredits: number,
+  purchases: readonly number[],
+  payouts: readonly number[],
+): number {
+  const spent = purchases.reduce((sum, price) => sum + price, 0);
+  const recovered = payouts.reduce((sum, payout) => sum + payout, 0);
+  return startingCredits - spent + recovered;
+}
+
+/**
+ * `deriveCredits` applied to a team's whole contracts ledger, doing the
+ * "where settled" selection the SQL view's `CASE WHEN settled = 1` does.
+ * Unsettled contracts contribute their purchase price only — a contract still
+ * held has cost its price and recovered nothing.
+ */
+export function deriveCreditsFromLedger(
+  startingCredits: number,
+  ledger: readonly CreditLedgerEntry[],
+): number {
+  return deriveCredits(
+    startingCredits,
+    ledger.map((entry) => entry.purchasePrice),
+    ledger
+      .filter((entry) => entry.settled)
+      .map((entry) => entry.salePayout ?? 0),
+  );
+}


### PR DESCRIPTION
A team's credit balance is the Team aggregate's core invariant:

  credits = STARTING_CREDITS - Σ purchasePrice + Σ salePayout (where settled)

It was hand-written as SQL in four D1 repositories — contractRepositoryD1,
teamRepositoryD1, notificationRepositoryD1 and performanceRepositoryD1 — so
the rule lived in four places at once, in a language the domain model could
not see.

State it once, as the `team_credits` view (migration 0006). Every reader now
joins the view instead of re-deriving; the guarded contract INSERT reads it as
a scalar subquery, which changes nothing about its atomicity — a view is
inlined into the referencing statement, so the credit check, the contract-count
check and the write are still one statement, and that statement is still what
enforces the invariant.

The view is driven from `teams` rather than from `contracts`, so every team has
exactly one row and a team that has never bought a contract reads its full
starting budget straight out of the view. That removes the COALESCE fallbacks
that were re-stating the starting budget at the call sites, and the bind-order
hazard where STARTING_CREDITS had to be the first `?` of every query.

Mirror the rule as `deriveCredits` / `deriveCreditsFromLedger` in model/team.ts.
These do not run in the purchase path — they would reintroduce the race if they
did — they give the invariant a readable canonical statement the model tests
assert against.

The starting budget is inlined in the view because SQLite views take no
parameters. An integration test asserts the view's value for a contract-less
team equals STARTING_CREDITS, so drift between SQL and model/team.ts fails CI.

Record the trade-off in ADR 0007: this is where we knowingly trade "invariants
belong to the aggregate" for a concurrency guarantee, and the ADR states the
race that the guarded INSERT prevents.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BbnxPG1x3Ta4XRkHW6y1hw