### PR TITLE
Drop expired contracts from lineup formation and bench

### DIFF
--- a/backend/src/services/lineup.ts
+++ b/backend/src/services/lineup.ts
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { Contract, Team } from "../../../model";
 import {
   Domain,
@@ -173,11 +174,21 @@ export class LineupService {
     if (!contractsResult.ok) {
       return contractsResult;
     }
-    // Settled contracts (e.g. sold early) are no longer owned inventory: the
-    // article has returned to Free Agent, so it must drop out of both the
-    // formation and the bench even though the row is retained for its FK.
+    // A contract is only live inventory while its term is still running. It
+    // drops out of both the formation and the bench when it is either settled
+    // (e.g. sold early, or resolved at expiry by the settlement sweep — the row
+    // is retained for its FK) or past its expireDate. Expiry is derived from
+    // the date here, using the same boundary as the settlement sweep
+    // (`expireDate <= today` is due, so active means `expireDate > today`),
+    // rather than waiting for the daily sweep to flip `settled`. That way a
+    // contract whose term has ended — including one already renewed and now
+    // past its new expireDate — never lingers in the lineup between expiry and
+    // the next sweep.
+    const today = Temporal.Now.plainDateISO();
     const activeContracts = contractsResult.value.filter(
-      (contract) => !contract.settled,
+      (contract) =>
+        !contract.settled &&
+        Temporal.PlainDate.compare(contract.expireDate, today) > 0,
     );
     const contractsById = new Map(
       activeContracts.map((contract) => [contract.id, contract]),

--- a/backend/src/tests/integration/lineup.integration.test.ts
+++ b/backend/src/tests/integration/lineup.integration.test.ts
@@ -1,4 +1,5 @@
 import { env } from "cloudflare:workers";
+import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   LineupService,
@@ -9,6 +10,14 @@ import {
 import { PlayerService } from "../../services/player";
 import { GLOBAL_LEAGUE_ID } from "../../services/league";
 import { insertTeam } from "../utils/d1TestUtils";
+
+// The lineup drops contracts once they are past their expireDate, so fixtures
+// that must show up in the lineup need a term that is still running relative to
+// the test run.
+const ACTIVE_PURCHASE_DATE = Temporal.Now.plainDateISO().toString();
+const ACTIVE_EXPIRE_DATE = Temporal.Now.plainDateISO()
+  .add({ days: 7 })
+  .toString();
 
 describe("LineupService Integration Tests", () => {
   let lineupService: LineupService;
@@ -64,14 +73,28 @@ describe("LineupService Integration Tests", () => {
         .prepare(
           "INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .bind(contractId1, teamId, "Cat", "2026-01-01", "2026-01-08", 50)
+        .bind(
+          contractId1,
+          teamId,
+          "Cat",
+          ACTIVE_PURCHASE_DATE,
+          ACTIVE_EXPIRE_DATE,
+          50,
+        )
         .run();
 
       await env.db
         .prepare(
           "INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .bind(contractId2, teamId, "Dog", "2026-01-01", "2026-01-08", 30)
+        .bind(
+          contractId2,
+          teamId,
+          "Dog",
+          ACTIVE_PURCHASE_DATE,
+          ACTIVE_EXPIRE_DATE,
+          30,
+        )
         .run();
 
       // Build a payload putting only contract1 in the formation; contract2 should end up on bench
@@ -127,6 +150,85 @@ describe("LineupService Integration Tests", () => {
       const benchIds = lineup.bench.map((c) => c.id);
       expect(benchIds).toContain(contractId2);
       expect(benchIds).not.toContain(contractId1);
+    });
+
+    it("drops an expired, unsettled contract from the formation and bench", async () => {
+      // One contract still running, one already past its expireDate but not yet
+      // settled by the daily sweep. Expiry is derived from the date, so the
+      // expired one must not appear even though `settled` is still 0 — this is
+      // the case a renewed contract hits once its rolled-forward term ends.
+      const activeId = "contract-active";
+      const expiredId = "contract-expired";
+      const pastExpire = Temporal.Now.plainDateISO()
+        .subtract({ days: 1 })
+        .toString();
+
+      await env.db
+        .prepare(
+          "INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(
+          activeId,
+          teamId,
+          "Cat",
+          ACTIVE_PURCHASE_DATE,
+          ACTIVE_EXPIRE_DATE,
+          50,
+        )
+        .run();
+      await env.db
+        .prepare(
+          "INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(expiredId, teamId, "Dog", "2026-01-01", pastExpire, 30)
+        .run();
+
+      const minimalContract = (id: string, articleId: string) => ({
+        id,
+        team: {
+          id: teamId,
+          name: "Lineup FC",
+          credits: 1000,
+          player: { id: playerId, name: "lineuptester" },
+        },
+        article: { id: articleId, title: articleId, domain: "en" as const },
+        startDate: "2026-01-01T00:00:00Z",
+        duration: "P7D",
+        purchasePrice: 50,
+      });
+
+      // Both are placed in the formation at save time (saveLineup only checks
+      // ownership, not expiry).
+      const saveResult = await lineupService.saveLineup(
+        playerId,
+        GLOBAL_LEAGUE_ID,
+        {
+          formation: {
+            date: new Date().toISOString(),
+            schema: "4-3-3",
+            formation: {
+              GK: minimalContract(activeId, "Cat"),
+              ST: minimalContract(expiredId, "Dog"),
+            },
+          },
+          bench: [],
+        },
+      );
+      expect(saveResult.ok).toBe(true);
+
+      const getResult = await lineupService.getLineup(
+        playerId,
+        GLOBAL_LEAGUE_ID,
+      );
+      expect(getResult.ok).toBe(true);
+      if (!getResult.ok) return;
+      const lineup = getResult.value;
+
+      // Active one keeps its slot; expired one is gone from formation...
+      expect(lineup.formation.formation["GK"]?.id).toBe(activeId);
+      expect(lineup.formation.formation["ST"]).toBeUndefined();
+      // ...and never reappears on the bench.
+      expect(lineup.bench.map((c) => c.id)).not.toContain(expiredId);
     });
 
     it("should return a failure when the player has no team in the league", async () => {
@@ -237,7 +339,14 @@ describe("LineupService Integration Tests", () => {
         .prepare(
           "INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice) VALUES (?, ?, ?, ?, ?, ?)",
         )
-        .bind(contractId, teamId, "Cat", "2026-01-01", "2026-01-08", 50)
+        .bind(
+          contractId,
+          teamId,
+          "Cat",
+          ACTIVE_PURCHASE_DATE,
+          ACTIVE_EXPIRE_DATE,
+          50,
+        )
         .run();
 
       const payload: RawTeamLineUp = {

--- a/backend/src/tests/lineup.spec.ts
+++ b/backend/src/tests/lineup.spec.ts
@@ -43,13 +43,20 @@ const league: League = {
   icon: "🌍",
 };
 
-function makeContract(id: string, articleId: string): Contract {
+// Active by default: `expireDate` sits a week in the future relative to the
+// test run, so the lineup's expiry filter keeps it. Pass an explicit
+// `expireDate` (e.g. a past date) to exercise the expired case.
+function makeContract(
+  id: string,
+  articleId: string,
+  expireDate: Temporal.PlainDate = Temporal.Now.plainDateISO().add({ days: 7 }),
+): Contract {
   return {
     id,
     teamId: TEAM_ID,
     articleId,
-    purchaseDate: Temporal.PlainDate.from("2026-01-01"),
-    expireDate: Temporal.PlainDate.from("2026-01-08"),
+    purchaseDate: Temporal.Now.plainDateISO().subtract({ days: 1 }),
+    expireDate,
     purchasePrice: 50,
     settled: false,
     renewalCount: 0,
@@ -164,6 +171,64 @@ describe("LineupService (unit)", () => {
       const benchIds = value.bench.map((c) => c.id);
       expect(benchIds).toContain("c-2");
       expect(benchIds).not.toContain("c-1");
+    });
+
+    it("drops a contract whose expireDate has passed from formation and bench", async () => {
+      // active in the formation, expired on the bench (settled is still false —
+      // the daily settlement sweep has not run yet, so expiry must be derived
+      // from the date, not the `settled` flag).
+      const active = makeContract("c-active", "Cat");
+      const expired = makeContract(
+        "c-expired",
+        "Dog",
+        Temporal.Now.plainDateISO().subtract({ days: 1 }),
+      );
+      const lineup = makeLineup({ GK: "c-active", ST: "c-expired" });
+
+      const service = new LineupService(
+        makeDeps({
+          lineupRepository: makeLineupRepo(lineup),
+          contractRepository: makeContractRepo([active, expired]),
+        }),
+      );
+
+      const result = await service.getLineup(PLAYER_ID, LEAGUE_ID);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const value = result.value;
+      // The expired contract must not hold its formation slot...
+      expect(value.formation.formation["GK"]?.id).toBe("c-active");
+      expect(value.formation.formation["ST"]).toBeUndefined();
+      // ...nor fall through to the bench.
+      const benchIds = value.bench.map((c) => c.id);
+      expect(benchIds).not.toContain("c-expired");
+    });
+
+    it("treats a contract expiring today (expireDate === today) as expired", async () => {
+      // The settlement sweep counts `expireDate <= today` as due, so the lineup
+      // uses the same boundary: a contract whose term ends today is no longer
+      // live inventory.
+      const expiringToday = makeContract(
+        "c-today",
+        "Cat",
+        Temporal.Now.plainDateISO(),
+      );
+      const lineup = makeLineup({ GK: "c-today" });
+
+      const service = new LineupService(
+        makeDeps({
+          lineupRepository: makeLineupRepo(lineup),
+          contractRepository: makeContractRepo([expiringToday]),
+        }),
+      );
+
+      const result = await service.getLineup(PLAYER_ID, LEAGUE_ID);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.formation.formation["GK"]).toBeUndefined();
+      expect(result.value.bench).toHaveLength(0);
     });
 
     it("silently omits stale formation slots (contract deleted after save)", async () => {


### PR DESCRIPTION
## Summary

Contracts are now filtered from the lineup based on their expiration date, not just their settlement status. A contract is considered "live inventory" only while its term is still running (`expireDate > today`). This ensures expired contracts — including renewed contracts past their rolled-forward term — never linger in the lineup between expiry and the daily settlement sweep.

## Changes

- **LineupService**: Updated the active contract filter to check both `!settled` and `expireDate > today`, using the same boundary as the settlement sweep (`expireDate <= today` is due). This prevents expired unsettled contracts from appearing in formation or bench.

- **Unit tests** (`lineup.spec.ts`):
  - Updated `makeContract()` helper to use dynamic dates relative to test run time (active by default: `expireDate` is 7 days in future; `purchaseDate` is 1 day in past)
  - Added test: "drops a contract whose expireDate has passed from formation and bench" — verifies expired contracts are filtered even when `settled` is false
  - Added test: "treats a contract expiring today as expired" — confirms the boundary condition (`expireDate === today` is expired)

- **Integration tests** (`lineup.integration.test.ts`):
  - Added module-level constants `ACTIVE_PURCHASE_DATE` and `ACTIVE_EXPIRE_DATE` (7 days in future) to ensure test fixtures remain active relative to test execution time
  - Updated all contract inserts to use these dynamic dates instead of hardcoded 2026 dates
  - Added integration test: "drops an expired, unsettled contract from the formation and bench" — verifies the behavior end-to-end with D1

## Implementation Details

- Uses `Temporal.Now.plainDateISO()` to get the current date at test/runtime, ensuring tests remain valid as time passes
- Expiry check uses `Temporal.PlainDate.compare(contract.expireDate, today) > 0` to match the settlement sweep's boundary logic
- The filter applies to both formation slots and bench, so expired contracts are completely removed from the lineup response

https://claude.ai/code/session_01MHJM6Crz4dDEfiG1Q9pvsR