### PR TITLE
feat: show another team's line-up from the league standings

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -299,16 +299,16 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.20.1.tgz",
-      "integrity": "sha512-eN5jHaX78lY/btWlyWIiNtTIgmXnI0CvwC6CPukgRjHoXs66jqX0AEKUsUJOeybfXEmZUhhy5FP/Xx+6wNwI7A==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.20.3.tgz",
+      "integrity": "sha512-aCMvM5zQ3MTz8SorSZB6ZxjVK2Gof6UhIc2Z1z9zbX/obucSYwDUkx8A0MUOod4I7clfB0QLarKBjRdIczK3vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cjs-module-lexer": "1.2.3",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260730.0-alpha",
-        "wrangler": "4.118.0",
+        "miniflare": "5.20260801.1-alpha",
+        "wrangler": "4.120.0",
         "zod": "4.4.3"
       },
       "peerDependencies": {
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
-      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260801.1.tgz",
+      "integrity": "sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==",
       "cpu": [
         "x64"
       ],
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
-      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260801.1.tgz",
+      "integrity": "sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==",
       "cpu": [
         "arm64"
       ],
@@ -352,9 +352,9 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
-      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260801.1.tgz",
+      "integrity": "sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==",
       "cpu": [
         "x64"
       ],
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
-      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260801.1.tgz",
+      "integrity": "sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==",
       "cpu": [
         "arm64"
       ],
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
-      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260801.1.tgz",
+      "integrity": "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==",
       "cpu": [
         "x64"
       ],
@@ -490,9 +490,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -510,9 +507,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -530,9 +524,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -550,9 +541,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -570,9 +558,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -590,9 +575,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -610,9 +592,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -630,9 +609,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -650,9 +626,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -676,9 +649,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -702,9 +672,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -728,9 +695,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -754,9 +718,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -780,9 +741,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -806,9 +764,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -832,9 +787,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -911,16 +863,16 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare": {
-      "version": "5.20260730.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
-      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
+      "version": "5.20260801.1-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260801.1-alpha.tgz",
+      "integrity": "sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
-        "undici": "7.28.0",
-        "workerd": "1.20260730.1",
+        "undici": "7.29.0",
+        "workerd": "1.20260801.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -986,10 +938,20 @@
         "@img/sharp-win32-x64": "0.35.2"
       }
     },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/workerd": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
-      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260801.1.tgz",
+      "integrity": "sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1000,17 +962,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260730.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
-        "@cloudflare/workerd-linux-64": "1.20260730.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
-        "@cloudflare/workerd-windows-64": "1.20260730.1"
+        "@cloudflare/workerd-darwin-64": "1.20260801.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260801.1",
+        "@cloudflare/workerd-linux-64": "1.20260801.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260801.1",
+        "@cloudflare/workerd-windows-64": "1.20260801.1"
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
-      "version": "4.118.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.118.0.tgz",
-      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
+      "version": "4.120.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.120.0.tgz",
+      "integrity": "sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1018,10 +980,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260730.0-alpha",
+        "miniflare": "5.20260801.1-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260730.1"
+        "workerd": "1.20260801.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1035,7 +997,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260730.1"
+        "@cloudflare/workers-types": "^5.20260801.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -2641,9 +2603,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2661,9 +2620,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2681,9 +2637,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2701,9 +2654,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2721,9 +2671,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2741,9 +2688,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3467,16 +3411,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -4761,9 +4705,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4785,9 +4726,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4809,9 +4747,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4833,9 +4768,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5072,9 +5004,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -5266,9 +5198,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -5286,7 +5218,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/backend/src/repositories/d1/teamRepositoryD1.ts
+++ b/backend/src/repositories/d1/teamRepositoryD1.ts
@@ -73,17 +73,36 @@ export class TeamRepositoryD1 implements TeamRepository {
     playerId: string,
     leagueId: string,
   ): Promise<Result<Team | null>> {
+    return this.getByKeyInLeague("playerId", playerId, leagueId);
+  }
+
+  async getByIdAndLeague(
+    teamId: string,
+    leagueId: string,
+  ): Promise<Result<Team | null>> {
+    return this.getByKeyInLeague("id", teamId, leagueId);
+  }
+
+  /**
+   * The single team-row read, differing only in which column addresses the team
+   * — a closed set of two, so nothing caller-supplied reaches the SQL text.
+   * credits is derived from the contracts ledger, not stored: the rule itself
+   * lives in the team_credits view (ADR 0007), stated once.
+   */
+  private async getByKeyInLeague(
+    key: "id" | "playerId",
+    value: string,
+    leagueId: string,
+  ): Promise<Result<Team | null>> {
     try {
-      // credits is derived from the contracts ledger, not stored — the rule
-      // itself lives in the team_credits view (ADR 0007), stated once.
       const result = await this.db
         .prepare(
           `SELECT t.id, t.name, t.playerId, t.leagueId, tc.credits
            FROM teams t
            JOIN team_credits tc ON tc.teamId = t.id
-           WHERE t.playerId = ? AND t.leagueId = ?`,
+           WHERE t.${key} = ? AND t.leagueId = ?`,
         )
-        .bind(playerId, leagueId)
+        .bind(value, leagueId)
         .first<Team>();
 
       return success(result ?? null);

--- a/backend/src/repositories/d1/teamRepositoryD1.ts
+++ b/backend/src/repositories/d1/teamRepositoryD1.ts
@@ -73,25 +73,29 @@ export class TeamRepositoryD1 implements TeamRepository {
     playerId: string,
     leagueId: string,
   ): Promise<Result<Team | null>> {
-    return this.getByKeyInLeague("playerId", playerId, leagueId);
+    try {
+      // credits is derived from the contracts ledger, not stored — the rule
+      // itself lives in the team_credits view (ADR 0007), stated once.
+      const result = await this.db
+        .prepare(
+          `SELECT t.id, t.name, t.playerId, t.leagueId, tc.credits
+           FROM teams t
+           JOIN team_credits tc ON tc.teamId = t.id
+           WHERE t.playerId = ? AND t.leagueId = ?`,
+        )
+        .bind(playerId, leagueId)
+        .first<Team>();
+
+      return success(result ?? null);
+    } catch (error) {
+      return failure(
+        `Error fetching team: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
   }
 
   async getByIdAndLeague(
     teamId: string,
-    leagueId: string,
-  ): Promise<Result<Team | null>> {
-    return this.getByKeyInLeague("id", teamId, leagueId);
-  }
-
-  /**
-   * The single team-row read, differing only in which column addresses the team
-   * — a closed set of two, so nothing caller-supplied reaches the SQL text.
-   * credits is derived from the contracts ledger, not stored: the rule itself
-   * lives in the team_credits view (ADR 0007), stated once.
-   */
-  private async getByKeyInLeague(
-    key: "id" | "playerId",
-    value: string,
     leagueId: string,
   ): Promise<Result<Team | null>> {
     try {
@@ -100,9 +104,9 @@ export class TeamRepositoryD1 implements TeamRepository {
           `SELECT t.id, t.name, t.playerId, t.leagueId, tc.credits
            FROM teams t
            JOIN team_credits tc ON tc.teamId = t.id
-           WHERE t.${key} = ? AND t.leagueId = ?`,
+           WHERE t.id = ? AND t.leagueId = ?`,
         )
-        .bind(value, leagueId)
+        .bind(teamId, leagueId)
         .first<Team>();
 
       return success(result ?? null);

--- a/backend/src/repositories/teamRepository.ts
+++ b/backend/src/repositories/teamRepository.ts
@@ -27,4 +27,14 @@ export interface TeamRepository {
     playerId: string,
     leagueId: string,
   ): Promise<Result<Team | null>>;
+  /**
+   * The league is part of the key, not a redundant filter: this serves reads
+   * addressed by team id from a league context, so a team belonging to another
+   * league must be indistinguishable from one that does not exist (null), never
+   * a row from outside the league the caller asked about.
+   */
+  getByIdAndLeague(
+    teamId: string,
+    leagueId: string,
+  ): Promise<Result<Team | null>>;
 }

--- a/backend/src/routes/leagues.ts
+++ b/backend/src/routes/leagues.ts
@@ -387,6 +387,27 @@ leagues.get("/:id/lineup", async (c) => {
   return c.json(result.value);
 });
 
+// Another team's line-up, read-only. The team is named in the path because the
+// viewer does not own it — unlike `/:id/lineup`, which is self-scoped from the
+// JWT. Teams on a league's standings are shareably visible (api-naming-rules.md),
+// so the id in the URL is not a security control: the standings this reads from
+// are already served to every member. A team id outside the league resolves to
+// NO_TEAM → 404, so a wrong link is reported as not-found, not as a failure.
+leagues.get("/:id/teams/:teamId/lineup", async (c) => {
+  const leagueId = c.req.param("id");
+  const teamId = c.req.param("teamId");
+
+  const lineupService = LineupService.fromDb(c.env.db);
+  const result = await lineupService.getRivalLineup(leagueId, teamId);
+  if (!result.ok) {
+    return c.json(
+      { error: result.error },
+      result.error === LINEUP_ERRORS.NO_TEAM ? 404 : 500,
+    );
+  }
+  return c.json(result.value);
+});
+
 leagues.put("/:id/lineup", async (c) => {
   const leagueId = c.req.param("id");
   const playerResult = await resolveCurrentPlayer(c);

--- a/backend/src/routes/leagues.ts
+++ b/backend/src/routes/leagues.ts
@@ -390,9 +390,9 @@ leagues.get("/:id/lineup", async (c) => {
 // Another team's line-up, read-only. The team is named in the path because the
 // viewer does not own it — unlike `/:id/lineup`, which is self-scoped from the
 // JWT. Teams on a league's standings are shareably visible (api-naming-rules.md),
-// so the id in the URL is not a security control: the standings this reads from
-// are already served to every member. A team id outside the league resolves to
-// NO_TEAM → 404, so a wrong link is reported as not-found, not as a failure.
+// so the id in the URL is not a security control: the standings already name
+// every team in the league to every member. A team id outside the league
+// resolves to NO_TEAM → 404, so a wrong link is reported as not-found.
 leagues.get("/:id/teams/:teamId/lineup", async (c) => {
   const leagueId = c.req.param("id");
   const teamId = c.req.param("teamId");

--- a/backend/src/services/lineup.ts
+++ b/backend/src/services/lineup.ts
@@ -21,6 +21,7 @@ import { PlayerRepository } from "../repositories/playerRepository";
 import { PlayerRepositoryD1 } from "../repositories/d1/playerRepositoryD1";
 import { Result, success, failure } from "../repositories/result";
 import { toRawContract } from "./rawContract";
+import { TeamService } from "./team";
 
 export const LINEUP_ERRORS = {
   NO_TEAM: TEAM_ERRORS.NO_TEAM_IN_LEAGUE,
@@ -31,6 +32,13 @@ export const LINEUP_ERRORS = {
 export type LineupServiceDeps = {
   lineupRepository: LineupRepository;
   teamRepository: TeamRepository;
+  /**
+   * The door to teams the caller does not own. TeamService, not TeamRepository,
+   * because whatever it comes to decide about who is readable as a rival —
+   * dressing, derived fields, absence — should apply here without this service
+   * learning about it (docs/architecture/backend-architecture.md).
+   */
+  teamService: TeamService;
   contractRepository: ContractRepository;
   leagueRepository: LeagueRepository;
   playerRepository: PlayerRepository;
@@ -105,6 +113,7 @@ export function parseLineupPayload(body: unknown): Result<RawTeamLineUp> {
 export class LineupService {
   private lineupRepository: LineupRepository;
   private teamRepository: TeamRepository;
+  private teamService: TeamService;
   private contractRepository: ContractRepository;
   private leagueRepository: LeagueRepository;
   private playerRepository: PlayerRepository;
@@ -112,6 +121,7 @@ export class LineupService {
   constructor(deps: LineupServiceDeps) {
     this.lineupRepository = deps.lineupRepository;
     this.teamRepository = deps.teamRepository;
+    this.teamService = deps.teamService;
     this.contractRepository = deps.contractRepository;
     this.leagueRepository = deps.leagueRepository;
     this.playerRepository = deps.playerRepository;
@@ -122,6 +132,7 @@ export class LineupService {
     return new LineupService({
       lineupRepository: new LineupRepositoryD1(db),
       teamRepository: new TeamRepositoryD1(db),
+      teamService: new TeamService(db),
       contractRepository: new ContractRepositoryD1(db),
       leagueRepository: new LeagueRepositoryD1(db),
       playerRepository: new PlayerRepositoryD1(db),
@@ -143,16 +154,17 @@ export class LineupService {
    * caller's session. Unlike {@link getLineup} this is not self-scoped: the
    * viewer does not own the team, so the team is named in the path.
    *
-   * The league is half the key the team is looked up by, so a team id from
-   * another league is absent rather than readable, and a wrong id is reported
-   * as not-found instead of as a failed request.
+   * The team comes from TeamService, which owns what a team is to someone who
+   * does not own it. The league is half the key it is looked up by, so a team
+   * id from another league is absent rather than readable, and a wrong id is
+   * reported as not-found instead of as a failed request.
    */
   async getRivalLineup(
     leagueId: string,
     teamId: string,
   ): Promise<Result<RawTeamLineUp>> {
     return this.lineupOfTeam(
-      this.teamRepository.getByIdAndLeague(teamId, leagueId),
+      this.teamService.getTeamInLeague(teamId, leagueId),
       leagueId,
     );
   }

--- a/backend/src/services/lineup.ts
+++ b/backend/src/services/lineup.ts
@@ -11,8 +11,7 @@ import {
 import { RawContract } from "../../../dto/contractDTO";
 import { LineupRepository } from "../repositories/lineupRepository";
 import { LineupRepositoryD1 } from "../repositories/d1/lineupRepositoryD1";
-import { TEAM_ERRORS, TeamRepository } from "../repositories/teamRepository";
-import { TeamRepositoryD1 } from "../repositories/d1/teamRepositoryD1";
+import { TEAM_ERRORS } from "../repositories/teamRepository";
 import { ContractRepository } from "../repositories/contractRepository";
 import { ContractRepositoryD1 } from "../repositories/d1/contractRepositoryD1";
 import { LeagueRepository } from "../repositories/leagueRepository";
@@ -31,12 +30,12 @@ export const LINEUP_ERRORS = {
 
 export type LineupServiceDeps = {
   lineupRepository: LineupRepository;
-  teamRepository: TeamRepository;
   /**
-   * The door to teams the caller does not own. TeamService, not TeamRepository,
-   * because whatever it comes to decide about who is readable as a rival —
-   * dressing, derived fields, absence — should apply here without this service
-   * learning about it (docs/architecture/backend-architecture.md).
+   * The one door to teams, self-scoped and rival alike. TeamService rather than
+   * TeamRepository because whatever it comes to decide about teams — dressing,
+   * derived fields, what counts as absent — should reach the line-up views
+   * without this service learning about it
+   * (docs/architecture/backend-architecture.md).
    */
   teamService: TeamService;
   contractRepository: ContractRepository;
@@ -112,7 +111,6 @@ export function parseLineupPayload(body: unknown): Result<RawTeamLineUp> {
 
 export class LineupService {
   private lineupRepository: LineupRepository;
-  private teamRepository: TeamRepository;
   private teamService: TeamService;
   private contractRepository: ContractRepository;
   private leagueRepository: LeagueRepository;
@@ -120,7 +118,6 @@ export class LineupService {
 
   constructor(deps: LineupServiceDeps) {
     this.lineupRepository = deps.lineupRepository;
-    this.teamRepository = deps.teamRepository;
     this.teamService = deps.teamService;
     this.contractRepository = deps.contractRepository;
     this.leagueRepository = deps.leagueRepository;
@@ -131,7 +128,6 @@ export class LineupService {
   static fromDb(db: D1Database): LineupService {
     return new LineupService({
       lineupRepository: new LineupRepositoryD1(db),
-      teamRepository: new TeamRepositoryD1(db),
       teamService: new TeamService(db),
       contractRepository: new ContractRepositoryD1(db),
       leagueRepository: new LeagueRepositoryD1(db),
@@ -144,7 +140,7 @@ export class LineupService {
     leagueId: string,
   ): Promise<Result<RawTeamLineUp>> {
     return this.lineupOfTeam(
-      this.teamRepository.getByPlayerAndLeague(playerId, leagueId),
+      this.teamService.getPlayerTeamInLeague(playerId, leagueId),
       leagueId,
     );
   }
@@ -268,7 +264,7 @@ export class LineupService {
     leagueId: string,
     payload: RawTeamLineUp,
   ): Promise<Result<void>> {
-    const teamResult = await this.teamRepository.getByPlayerAndLeague(
+    const teamResult = await this.teamService.getPlayerTeamInLeague(
       playerId,
       leagueId,
     );

--- a/backend/src/services/lineup.ts
+++ b/backend/src/services/lineup.ts
@@ -21,7 +21,6 @@ import { PlayerRepository } from "../repositories/playerRepository";
 import { PlayerRepositoryD1 } from "../repositories/d1/playerRepositoryD1";
 import { Result, success, failure } from "../repositories/result";
 import { toRawContract } from "./rawContract";
-import { LeaderboardService } from "./leaderboard";
 
 export const LINEUP_ERRORS = {
   NO_TEAM: TEAM_ERRORS.NO_TEAM_IN_LEAGUE,
@@ -35,11 +34,6 @@ export type LineupServiceDeps = {
   contractRepository: ContractRepository;
   leagueRepository: LeagueRepository;
   playerRepository: PlayerRepository;
-  /**
-   * Only `getRivalLineup` needs it — to name which teams a league contains and
-   * who owns each — so it is optional: the self-scoped reads work without it.
-   */
-  leaderboardService?: LeaderboardService;
 };
 
 export type RawTeamLineUp = {
@@ -114,7 +108,6 @@ export class LineupService {
   private contractRepository: ContractRepository;
   private leagueRepository: LeagueRepository;
   private playerRepository: PlayerRepository;
-  private leaderboardService?: LeaderboardService;
 
   constructor(deps: LineupServiceDeps) {
     this.lineupRepository = deps.lineupRepository;
@@ -122,7 +115,6 @@ export class LineupService {
     this.contractRepository = deps.contractRepository;
     this.leagueRepository = deps.leagueRepository;
     this.playerRepository = deps.playerRepository;
-    this.leaderboardService = deps.leaderboardService;
   }
 
   /** Build a D1-backed instance — the production/route construction path. */
@@ -133,7 +125,6 @@ export class LineupService {
       contractRepository: new ContractRepositoryD1(db),
       leagueRepository: new LeagueRepositoryD1(db),
       playerRepository: new PlayerRepositoryD1(db),
-      leaderboardService: new LeaderboardService(db),
     });
   }
 
@@ -141,10 +132,41 @@ export class LineupService {
     playerId: string,
     leagueId: string,
   ): Promise<Result<RawTeamLineUp>> {
-    const teamResult = await this.teamRepository.getByPlayerAndLeague(
-      playerId,
+    return this.lineupOfTeam(
+      this.teamRepository.getByPlayerAndLeague(playerId, leagueId),
       leagueId,
     );
+  }
+
+  /**
+   * A rival team's line-up, read-only, addressed by team id rather than by the
+   * caller's session. Unlike {@link getLineup} this is not self-scoped: the
+   * viewer does not own the team, so the team is named in the path.
+   *
+   * The league is half the key the team is looked up by, so a team id from
+   * another league is absent rather than readable, and a wrong id is reported
+   * as not-found instead of as a failed request.
+   */
+  async getRivalLineup(
+    leagueId: string,
+    teamId: string,
+  ): Promise<Result<RawTeamLineUp>> {
+    return this.lineupOfTeam(
+      this.teamRepository.getByIdAndLeague(teamId, leagueId),
+      leagueId,
+    );
+  }
+
+  /**
+   * The one line-up read, over whichever team the caller resolved. Both entry
+   * points differ only in how they address the team — everything downstream,
+   * including whose name dresses the contracts, comes from the team row itself.
+   */
+  private async lineupOfTeam(
+    pendingTeam: Promise<Result<Team | null>>,
+    leagueId: string,
+  ): Promise<Result<RawTeamLineUp>> {
+    const teamResult = await pendingTeam;
     if (!teamResult.ok) {
       return teamResult;
     }
@@ -154,7 +176,7 @@ export class LineupService {
     const team = teamResult.value;
 
     const [playerResult, leagueResult] = await Promise.all([
-      this.playerRepository.getById(playerId),
+      this.playerRepository.getById(team.playerId),
       this.leagueRepository.getById(leagueId),
     ]);
     if (!playerResult.ok) return playerResult;
@@ -227,45 +249,6 @@ export class LineupService {
       },
       bench,
     });
-  }
-
-  /**
-   * A rival team's line-up, read-only, addressed by team id rather than by the
-   * caller's session. Unlike {@link getLineup} this is not self-scoped: the
-   * viewer does not own the team, so the team is named in the path.
-   *
-   * Which teams a league contains, and who owns each, is resolved from the
-   * league standings rather than a fresh team lookup — the standings are this
-   * feature's own source of truth for exactly that, and are what the client
-   * already reads the rival's name and rank from. Resolving through them keeps
-   * one definition of "the teams in this league" (every team appears, scored or
-   * not; a team outside the league is simply absent) and lets a wrong team id
-   * be reported as not-found rather than as a failed request. This makes a
-   * service depend on another service, which docs/architecture/backend-architecture.md
-   * frames as a repository's job; the reuse is the deliberate trade for not
-   * restating that membership query here.
-   */
-  async getRivalLineup(
-    leagueId: string,
-    teamId: string,
-  ): Promise<Result<RawTeamLineUp>> {
-    if (!this.leaderboardService) {
-      return failure("Leaderboard service is not configured");
-    }
-
-    const boardResult = await this.leaderboardService.getLeaderboard(leagueId);
-    if (!boardResult.ok) {
-      return boardResult;
-    }
-
-    const entry = boardResult.value.find((e) => e.team.id === teamId);
-    if (!entry) {
-      return failure(LINEUP_ERRORS.NO_TEAM);
-    }
-
-    // The owner resolved above is the team's, so getLineup addresses that same
-    // team — the rival's line-up is built by exactly the self-scoped path.
-    return this.getLineup(entry.team.player.id, leagueId);
   }
 
   async saveLineup(

--- a/backend/src/services/lineup.ts
+++ b/backend/src/services/lineup.ts
@@ -21,6 +21,7 @@ import { PlayerRepository } from "../repositories/playerRepository";
 import { PlayerRepositoryD1 } from "../repositories/d1/playerRepositoryD1";
 import { Result, success, failure } from "../repositories/result";
 import { toRawContract } from "./rawContract";
+import { LeaderboardService } from "./leaderboard";
 
 export const LINEUP_ERRORS = {
   NO_TEAM: TEAM_ERRORS.NO_TEAM_IN_LEAGUE,
@@ -34,6 +35,11 @@ export type LineupServiceDeps = {
   contractRepository: ContractRepository;
   leagueRepository: LeagueRepository;
   playerRepository: PlayerRepository;
+  /**
+   * Only `getRivalLineup` needs it — to name which teams a league contains and
+   * who owns each — so it is optional: the self-scoped reads work without it.
+   */
+  leaderboardService?: LeaderboardService;
 };
 
 export type RawTeamLineUp = {
@@ -108,6 +114,7 @@ export class LineupService {
   private contractRepository: ContractRepository;
   private leagueRepository: LeagueRepository;
   private playerRepository: PlayerRepository;
+  private leaderboardService?: LeaderboardService;
 
   constructor(deps: LineupServiceDeps) {
     this.lineupRepository = deps.lineupRepository;
@@ -115,6 +122,7 @@ export class LineupService {
     this.contractRepository = deps.contractRepository;
     this.leagueRepository = deps.leagueRepository;
     this.playerRepository = deps.playerRepository;
+    this.leaderboardService = deps.leaderboardService;
   }
 
   /** Build a D1-backed instance — the production/route construction path. */
@@ -125,6 +133,7 @@ export class LineupService {
       contractRepository: new ContractRepositoryD1(db),
       leagueRepository: new LeagueRepositoryD1(db),
       playerRepository: new PlayerRepositoryD1(db),
+      leaderboardService: new LeaderboardService(db),
     });
   }
 
@@ -218,6 +227,45 @@ export class LineupService {
       },
       bench,
     });
+  }
+
+  /**
+   * A rival team's line-up, read-only, addressed by team id rather than by the
+   * caller's session. Unlike {@link getLineup} this is not self-scoped: the
+   * viewer does not own the team, so the team is named in the path.
+   *
+   * Which teams a league contains, and who owns each, is resolved from the
+   * league standings rather than a fresh team lookup — the standings are this
+   * feature's own source of truth for exactly that, and are what the client
+   * already reads the rival's name and rank from. Resolving through them keeps
+   * one definition of "the teams in this league" (every team appears, scored or
+   * not; a team outside the league is simply absent) and lets a wrong team id
+   * be reported as not-found rather than as a failed request. This makes a
+   * service depend on another service, which docs/architecture/backend-architecture.md
+   * frames as a repository's job; the reuse is the deliberate trade for not
+   * restating that membership query here.
+   */
+  async getRivalLineup(
+    leagueId: string,
+    teamId: string,
+  ): Promise<Result<RawTeamLineUp>> {
+    if (!this.leaderboardService) {
+      return failure("Leaderboard service is not configured");
+    }
+
+    const boardResult = await this.leaderboardService.getLeaderboard(leagueId);
+    if (!boardResult.ok) {
+      return boardResult;
+    }
+
+    const entry = boardResult.value.find((e) => e.team.id === teamId);
+    if (!entry) {
+      return failure(LINEUP_ERRORS.NO_TEAM);
+    }
+
+    // The owner resolved above is the team's, so getLineup addresses that same
+    // team — the rival's line-up is built by exactly the self-scoped path.
+    return this.getLineup(entry.team.player.id, leagueId);
   }
 
   async saveLineup(

--- a/backend/src/services/team.ts
+++ b/backend/src/services/team.ts
@@ -89,6 +89,19 @@ export class TeamService {
     return teamResult;
   }
 
+  /**
+   * The team a league contains under this id, or null when it contains no such
+   * team. The league is half the key rather than a filter applied to the
+   * answer, so a team belonging to another league is absent here rather than
+   * readable — this serves reads whose team id comes from the client.
+   */
+  async getTeamInLeague(
+    teamId: string,
+    leagueId: string,
+  ): Promise<Result<Team | null>> {
+    return this.teamRepository.getByIdAndLeague(teamId, leagueId);
+  }
+
   async getMyTeam(
     playerId: string,
     leagueId: string,

--- a/backend/src/services/team.ts
+++ b/backend/src/services/team.ts
@@ -102,15 +102,28 @@ export class TeamService {
     return this.teamRepository.getByIdAndLeague(teamId, leagueId);
   }
 
+  /**
+   * The team this player fields in this league, or null when they field none.
+   * The self-scoped counterpart to {@link getTeamInLeague}: the caller holds a
+   * player id from the session rather than a team id from a URL.
+   *
+   * Returns the domain model, so callers that must go on to resolve things the
+   * team only points at — its owner's name, its contracts — have what they need.
+   * {@link getMyTeam} is this read dressed for the wire.
+   */
+  async getPlayerTeamInLeague(
+    playerId: string,
+    leagueId: string,
+  ): Promise<Result<Team | null>> {
+    return this.teamRepository.getByPlayerAndLeague(playerId, leagueId);
+  }
+
   async getMyTeam(
     playerId: string,
     leagueId: string,
     playerName: string,
   ): Promise<Result<TeamDTO | null>> {
-    const result = await this.teamRepository.getByPlayerAndLeague(
-      playerId,
-      leagueId,
-    );
+    const result = await this.getPlayerTeamInLeague(playerId, leagueId);
     if (!result.ok) {
       return result;
     }

--- a/backend/src/tests/contract.spec.ts
+++ b/backend/src/tests/contract.spec.ts
@@ -81,6 +81,7 @@ function makeTeamRepo(
     create: async () => failure("unused"),
     existsByNameInLeague: async () => failure("unused"),
     getByPlayerAndLeague: async () => result,
+    getByIdAndLeague: async () => failure("unused"),
   };
 }
 

--- a/backend/src/tests/integration/lineup.integration.test.ts
+++ b/backend/src/tests/integration/lineup.integration.test.ts
@@ -150,6 +150,80 @@ describe("LineupService Integration Tests", () => {
     });
   });
 
+  describe("getRivalLineup", () => {
+    it("returns another team's lineup addressed by team id", async () => {
+      // A second player fielding a team in the same league, with one contract
+      // placed in the formation. getRivalLineup must surface exactly that team's
+      // line-up, resolved from the team id in the path rather than the session.
+      const rivalPlayerResult = await playerService.createPlayer(
+        "rivalowner",
+        "rival@example.com",
+        "account-rival-1",
+      );
+      expect(rivalPlayerResult.ok).toBe(true);
+      if (!rivalPlayerResult.ok) throw new Error("setup failed: rival player");
+
+      const rivalTeamId = "team-rival-1";
+      await insertTeam(env.db, {
+        id: rivalTeamId,
+        name: "Rival FC",
+        playerId: rivalPlayerResult.value.id,
+        leagueId: GLOBAL_LEAGUE_ID,
+      });
+
+      const rivalContractId = "contract-rival-1";
+      await env.db
+        .prepare(
+          "INSERT INTO contracts (id, teamId, articleId, purchaseDate, expireDate, purchasePrice) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(
+          rivalContractId,
+          rivalTeamId,
+          "Cat",
+          "2026-01-01",
+          "2026-01-08",
+          50,
+        )
+        .run();
+
+      await env.db
+        .prepare(
+          "INSERT INTO lineups (teamId, schema, formation, updatedAt) VALUES (?, ?, ?, ?)",
+        )
+        .bind(
+          rivalTeamId,
+          "4-3-3",
+          JSON.stringify({ GK: rivalContractId }),
+          new Date().toISOString(),
+        )
+        .run();
+
+      const result = await lineupService.getRivalLineup(
+        GLOBAL_LEAGUE_ID,
+        rivalTeamId,
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.formation.schema).toBe("4-3-3");
+      expect(result.value.formation.formation["GK"]?.id).toBe(rivalContractId);
+      // The contract carries the rival's team identity, not the caller's.
+      expect(result.value.formation.formation["GK"]?.team.id).toBe(rivalTeamId);
+    });
+
+    it("reports a team that is not in the league as NO_TEAM, not an error", async () => {
+      const result = await lineupService.getRivalLineup(
+        GLOBAL_LEAGUE_ID,
+        "team-not-in-this-league",
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe(LINEUP_ERRORS.NO_TEAM);
+      }
+    });
+  });
+
   describe("saveLineup", () => {
     it("should return a failure when a contractId in the formation does not belong to the team", async () => {
       // Insert a contract for a different team

--- a/backend/src/tests/integration/lineup.integration.test.ts
+++ b/backend/src/tests/integration/lineup.integration.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../services/lineup";
 import { PlayerService } from "../../services/player";
 import { GLOBAL_LEAGUE_ID } from "../../services/league";
-import { insertTeam } from "../utils/d1TestUtils";
+import { insertLineup, insertTeam } from "../utils/d1TestUtils";
 
 describe("LineupService Integration Tests", () => {
   let lineupService: LineupService;
@@ -215,6 +215,54 @@ describe("LineupService Integration Tests", () => {
       const result = await lineupService.getRivalLineup(
         GLOBAL_LEAGUE_ID,
         "team-not-in-this-league",
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe(LINEUP_ERRORS.NO_TEAM);
+      }
+    });
+
+    // The team id alone would find this row; the league is the other half of
+    // the key, so a line-up from a league the caller did not ask about must be
+    // unreadable through it rather than merely unlikely to be requested.
+    it("does not serve a team that exists in another league", async () => {
+      const otherLeagueId = "league-elsewhere";
+      await env.db
+        .prepare(
+          "INSERT INTO leagues (id, name, adminId, startDate, endDate, domain, icon) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(
+          otherLeagueId,
+          "Elsewhere League",
+          playerId,
+          "2026-01-01T00:00:00Z",
+          "2026-12-31T00:00:00Z",
+          "en",
+          "🌍",
+        )
+        .run();
+
+      const outsiderPlayerResult = await playerService.createPlayer(
+        "outsider",
+        "outsider@example.com",
+        "account-outsider-1",
+      );
+      expect(outsiderPlayerResult.ok).toBe(true);
+      if (!outsiderPlayerResult.ok) throw new Error("setup failed: outsider");
+
+      const outsiderTeamId = "team-outsider-1";
+      await insertTeam(env.db, {
+        id: outsiderTeamId,
+        name: "Outsider FC",
+        playerId: outsiderPlayerResult.value.id,
+        leagueId: otherLeagueId,
+      });
+      await insertLineup(env.db, outsiderTeamId, "4-3-3", {});
+
+      const result = await lineupService.getRivalLineup(
+        GLOBAL_LEAGUE_ID,
+        outsiderTeamId,
       );
 
       expect(result.ok).toBe(false);

--- a/backend/src/tests/integration/team.integration.test.ts
+++ b/backend/src/tests/integration/team.integration.test.ts
@@ -212,6 +212,7 @@ describe("TeamService Integration Tests", () => {
         create: async () => failure("boom"),
         existsByNameInLeague: async () => failure("boom"),
         getByPlayerAndLeague: async () => failure("db error"),
+        getByIdAndLeague: async () => failure("boom"),
       };
       const service = new TeamService({
         teamRepository: failingRepository,
@@ -238,6 +239,7 @@ describe("TeamService Integration Tests", () => {
         create: async () => failure("unused"),
         existsByNameInLeague: async () => failure("unused"),
         getByPlayerAndLeague: async () => success(team),
+        getByIdAndLeague: async () => failure("unused"),
       };
       const service = new TeamService({
         teamRepository: repository,
@@ -296,6 +298,16 @@ describe("TeamRepositoryD1 error handling", () => {
   it("should return a failure from getByPlayerAndLeague when D1 throws", async () => {
     const repository = new TeamRepositoryD1(throwingDb);
     const result = await repository.getByPlayerAndLeague("p1", "l1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("D1 unavailable");
+    }
+  });
+
+  it("should return a failure from getByIdAndLeague when D1 throws", async () => {
+    const repository = new TeamRepositoryD1(throwingDb);
+    const result = await repository.getByIdAndLeague("t1", "l1");
 
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/backend/src/tests/integration/team.integration.test.ts
+++ b/backend/src/tests/integration/team.integration.test.ts
@@ -183,6 +183,59 @@ describe("TeamService Integration Tests", () => {
     });
   });
 
+  describe("getTeamInLeague", () => {
+    it("returns the league's team under that id, credits included", async () => {
+      const created = await teamService.createTeam(
+        playerId,
+        leagueId,
+        "The Wiki Wizards",
+      );
+      expect(created.ok).toBe(true);
+      if (!created.ok) throw new Error("setup failed: team");
+
+      const result = await teamService.getTeamInLeague(
+        created.value.id,
+        leagueId,
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value?.name).toBe("The Wiki Wizards");
+      expect(result.value?.playerId).toBe(playerId);
+      expect(result.value?.credits).toBe(STARTING_CREDITS);
+    });
+
+    it("returns null for an id no team carries", async () => {
+      const result = await teamService.getTeamInLeague(
+        "no-such-team",
+        leagueId,
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value).toBeNull();
+    });
+
+    // The id alone would find the row: the league is the other half of the key,
+    // so a team is unreadable through a league that does not contain it.
+    it("returns null for a team that belongs to another league", async () => {
+      const created = await teamService.createTeam(
+        playerId,
+        leagueId,
+        "The Wiki Wizards",
+      );
+      expect(created.ok).toBe(true);
+      if (!created.ok) throw new Error("setup failed: team");
+
+      const result = await teamService.getTeamInLeague(
+        created.value.id,
+        "some-other-league",
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value).toBeNull();
+    });
+  });
+
   describe("getMyTeam", () => {
     it("should return null when the player has no team in the league", async () => {
       const result = await teamService.getMyTeam(playerId, leagueId, "Alice");

--- a/backend/src/tests/integration/team.integration.test.ts
+++ b/backend/src/tests/integration/team.integration.test.ts
@@ -236,6 +236,45 @@ describe("TeamService Integration Tests", () => {
     });
   });
 
+  describe("getPlayerTeamInLeague", () => {
+    it("returns the domain model, not the wire shape getMyTeam dresses", async () => {
+      const created = await teamService.createTeam(
+        playerId,
+        leagueId,
+        "The Wiki Wizards",
+      );
+      expect(created.ok).toBe(true);
+      if (!created.ok) throw new Error("setup failed: team");
+
+      const result = await teamService.getPlayerTeamInLeague(
+        playerId,
+        leagueId,
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // playerId and leagueId are what callers go on to resolve the owner and
+      // the league by; TeamDTO carries neither.
+      expect(result.value).toEqual({
+        id: created.value.id,
+        name: "The Wiki Wizards",
+        playerId,
+        leagueId,
+        credits: STARTING_CREDITS,
+      });
+    });
+
+    it("returns null when the player fields no team in the league", async () => {
+      const result = await teamService.getPlayerTeamInLeague(
+        playerId,
+        leagueId,
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value).toBeNull();
+    });
+  });
+
   describe("getMyTeam", () => {
     it("should return null when the player has no team in the league", async () => {
       const result = await teamService.getMyTeam(playerId, leagueId, "Alice");

--- a/backend/src/tests/lineup.spec.ts
+++ b/backend/src/tests/lineup.spec.ts
@@ -11,6 +11,11 @@ import { TeamRepository } from "../repositories/teamRepository";
 import { ContractRepository } from "../repositories/contractRepository";
 import { LeagueRepository } from "../repositories/leagueRepository";
 import { PlayerRepository } from "../repositories/playerRepository";
+import {
+  PerformanceRepository,
+  TeamCumulative,
+} from "../repositories/performanceRepository";
+import { LeaderboardService } from "../services/leaderboard";
 import { success, failure } from "../repositories/result";
 import type { Contract, Team, Lineup, League, Player } from "../../../model";
 
@@ -116,6 +121,34 @@ function makeLineupRepo(stored: Lineup | null = null): LineupRepository {
       current = { ...data };
       return success(undefined);
     },
+  };
+}
+
+/**
+ * A LeaderboardService whose standings are exactly `teams`. Only
+ * getLeagueCumulatives is exercised; the other repo methods are unused here.
+ */
+function makeLeaderboardService(
+  cumulatives: TeamCumulative[],
+): LeaderboardService {
+  const repo: PerformanceRepository = {
+    getRecentByTeam: async () => failure("unused"),
+    getLeagueCumulatives: async () => success(cumulatives),
+    upsertDaily: async () => failure("unused"),
+  };
+  return new LeaderboardService(repo);
+}
+
+function cumulative(overrides: Partial<TeamCumulative> = {}): TeamCumulative {
+  return {
+    teamId: TEAM_ID,
+    teamName: "Test FC",
+    teamCredits: 1000,
+    playerId: PLAYER_ID,
+    playerName: "testuser",
+    cumulativeLatest: 0,
+    cumulativePrevious: 0,
+    ...overrides,
   };
 }
 
@@ -296,6 +329,57 @@ describe("LineupService (unit)", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.formation.formation["GK"]?.article.domain).toBe("it");
+    });
+  });
+
+  describe("getRivalLineup", () => {
+    it("resolves the team's owner from the standings and returns its lineup", async () => {
+      const c1 = makeContract("c-1", "Cat");
+      const lineup = makeLineup({ GK: "c-1" });
+
+      const service = new LineupService(
+        makeDeps({
+          lineupRepository: makeLineupRepo(lineup),
+          contractRepository: makeContractRepo([c1]),
+          leaderboardService: makeLeaderboardService([cumulative()]),
+        }),
+      );
+
+      const result = await service.getRivalLineup(LEAGUE_ID, TEAM_ID);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.formation.formation["GK"]?.id).toBe("c-1");
+    });
+
+    it("returns NO_TEAM when the team is not on the standings", async () => {
+      const service = new LineupService(
+        makeDeps({
+          leaderboardService: makeLeaderboardService([
+            cumulative({ teamId: "some-other-team" }),
+          ]),
+        }),
+      );
+
+      const result = await service.getRivalLineup(LEAGUE_ID, TEAM_ID);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe(LINEUP_ERRORS.NO_TEAM);
+    });
+
+    it("propagates a standings failure rather than reporting not-found", async () => {
+      const failingBoard: PerformanceRepository = {
+        getRecentByTeam: async () => failure("unused"),
+        getLeagueCumulatives: async () => failure("db error"),
+        upsertDaily: async () => failure("unused"),
+      };
+      const service = new LineupService(
+        makeDeps({
+          leaderboardService: new LeaderboardService(failingBoard),
+        }),
+      );
+
+      const result = await service.getRivalLineup(LEAGUE_ID, TEAM_ID);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe("db error");
     });
   });
 

--- a/backend/src/tests/lineup.spec.ts
+++ b/backend/src/tests/lineup.spec.ts
@@ -11,6 +11,7 @@ import { TeamRepository } from "../repositories/teamRepository";
 import { ContractRepository } from "../repositories/contractRepository";
 import { LeagueRepository } from "../repositories/leagueRepository";
 import { PlayerRepository } from "../repositories/playerRepository";
+import { TeamService } from "../services/team";
 import { success, failure } from "../repositories/result";
 import type { Contract, Team, Lineup, League, Player } from "../../../model";
 
@@ -128,12 +129,25 @@ function makeLineupRepo(stored: Lineup | null = null): LineupRepository {
   };
 }
 
+/**
+ * A real TeamService over a stub repository — the seam under test is which
+ * door LineupService knocks on, so faking the service itself would assert
+ * nothing about the team read actually reaching the repository behind it.
+ */
+function makeTeamService(teamRepository = makeTeamRepo()): TeamService {
+  return new TeamService({
+    teamRepository,
+    lineupRepository: makeLineupRepo(),
+  });
+}
+
 function makeDeps(
   overrides: Partial<LineupServiceDeps> = {},
 ): LineupServiceDeps {
   return {
     lineupRepository: makeLineupRepo(),
     teamRepository: makeTeamRepo(),
+    teamService: makeTeamService(),
     contractRepository: makeContractRepo([]),
     leagueRepository: makeLeagueRepo(),
     playerRepository: makePlayerRepo(),
@@ -361,13 +375,13 @@ describe("LineupService (unit)", () => {
       if (!result.ok) expect(result.error).toBe(LINEUP_ERRORS.NO_TEAM);
     });
 
-    it("propagates a repository failure rather than reporting not-found", async () => {
+    it("propagates a team-read failure rather than reporting not-found", async () => {
       const failingTeams: TeamRepository = {
         ...makeTeamRepo(),
         getByIdAndLeague: async () => failure("db error"),
       };
       const service = new LineupService(
-        makeDeps({ teamRepository: failingTeams }),
+        makeDeps({ teamService: makeTeamService(failingTeams) }),
       );
 
       const result = await service.getRivalLineup(LEAGUE_ID, TEAM_ID);

--- a/backend/src/tests/lineup.spec.ts
+++ b/backend/src/tests/lineup.spec.ts
@@ -146,7 +146,6 @@ function makeDeps(
 ): LineupServiceDeps {
   return {
     lineupRepository: makeLineupRepo(),
-    teamRepository: makeTeamRepo(),
     teamService: makeTeamService(),
     contractRepository: makeContractRepo([]),
     leagueRepository: makeLeagueRepo(),
@@ -211,13 +210,13 @@ describe("LineupService (unit)", () => {
       expect(value.bench).toHaveLength(0);
     });
 
-    it("returns a failure when the team repo returns an error", async () => {
+    it("returns a failure when the team read returns an error", async () => {
       const service = new LineupService(
         makeDeps({
-          teamRepository: {
+          teamService: makeTeamService({
             ...makeTeamRepo(),
             getByPlayerAndLeague: async () => failure("db error"),
-          },
+          }),
         }),
       );
 
@@ -228,7 +227,7 @@ describe("LineupService (unit)", () => {
 
     it("returns failure when the player has no team in the league", async () => {
       const service = new LineupService(
-        makeDeps({ teamRepository: makeTeamRepo(null) }),
+        makeDeps({ teamService: makeTeamService(makeTeamRepo(null)) }),
       );
 
       const result = await service.getLineup(PLAYER_ID, LEAGUE_ID);
@@ -482,7 +481,7 @@ describe("LineupService (unit)", () => {
 
     it("returns a failure when the team is not found", async () => {
       const service = new LineupService(
-        makeDeps({ teamRepository: makeTeamRepo(null) }),
+        makeDeps({ teamService: makeTeamService(makeTeamRepo(null)) }),
       );
 
       const result = await service.saveLineup(PLAYER_ID, LEAGUE_ID, {

--- a/backend/src/tests/lineup.spec.ts
+++ b/backend/src/tests/lineup.spec.ts
@@ -11,11 +11,6 @@ import { TeamRepository } from "../repositories/teamRepository";
 import { ContractRepository } from "../repositories/contractRepository";
 import { LeagueRepository } from "../repositories/leagueRepository";
 import { PlayerRepository } from "../repositories/playerRepository";
-import {
-  PerformanceRepository,
-  TeamCumulative,
-} from "../repositories/performanceRepository";
-import { LeaderboardService } from "../services/leaderboard";
 import { success, failure } from "../repositories/result";
 import type { Contract, Team, Lineup, League, Player } from "../../../model";
 
@@ -78,6 +73,15 @@ function makeTeamRepo(result: Team | null = team): TeamRepository {
     create: async () => failure("unused"),
     existsByNameInLeague: async () => failure("unused"),
     getByPlayerAndLeague: async () => success(result),
+    // Addressed by id, so unlike the self-scoped read this stub cannot ignore
+    // its arguments: it answers with the fixture only when both halves of the
+    // key match, which is what makes "team from another league" absent.
+    getByIdAndLeague: async (teamId, leagueId) =>
+      success(
+        result !== null && teamId === result.id && leagueId === result.leagueId
+          ? result
+          : null,
+      ),
   };
 }
 
@@ -121,34 +125,6 @@ function makeLineupRepo(stored: Lineup | null = null): LineupRepository {
       current = { ...data };
       return success(undefined);
     },
-  };
-}
-
-/**
- * A LeaderboardService whose standings are exactly `teams`. Only
- * getLeagueCumulatives is exercised; the other repo methods are unused here.
- */
-function makeLeaderboardService(
-  cumulatives: TeamCumulative[],
-): LeaderboardService {
-  const repo: PerformanceRepository = {
-    getRecentByTeam: async () => failure("unused"),
-    getLeagueCumulatives: async () => success(cumulatives),
-    upsertDaily: async () => failure("unused"),
-  };
-  return new LeaderboardService(repo);
-}
-
-function cumulative(overrides: Partial<TeamCumulative> = {}): TeamCumulative {
-  return {
-    teamId: TEAM_ID,
-    teamName: "Test FC",
-    teamCredits: 1000,
-    playerId: PLAYER_ID,
-    playerName: "testuser",
-    cumulativeLatest: 0,
-    cumulativePrevious: 0,
-    ...overrides,
   };
 }
 
@@ -225,8 +201,7 @@ describe("LineupService (unit)", () => {
       const service = new LineupService(
         makeDeps({
           teamRepository: {
-            create: async () => failure("unused"),
-            existsByNameInLeague: async () => failure("unused"),
+            ...makeTeamRepo(),
             getByPlayerAndLeague: async () => failure("db error"),
           },
         }),
@@ -333,7 +308,7 @@ describe("LineupService (unit)", () => {
   });
 
   describe("getRivalLineup", () => {
-    it("resolves the team's owner from the standings and returns its lineup", async () => {
+    it("returns the line-up of the team named in the path", async () => {
       const c1 = makeContract("c-1", "Cat");
       const lineup = makeLineup({ GK: "c-1" });
 
@@ -341,7 +316,6 @@ describe("LineupService (unit)", () => {
         makeDeps({
           lineupRepository: makeLineupRepo(lineup),
           contractRepository: makeContractRepo([c1]),
-          leaderboardService: makeLeaderboardService([cumulative()]),
         }),
       );
 
@@ -351,30 +325,49 @@ describe("LineupService (unit)", () => {
       expect(result.value.formation.formation["GK"]?.id).toBe("c-1");
     });
 
-    it("returns NO_TEAM when the team is not on the standings", async () => {
+    it("dresses the contracts with the team's own owner, not the viewer", async () => {
+      const c1 = makeContract("c-1", "Cat");
       const service = new LineupService(
         makeDeps({
-          leaderboardService: makeLeaderboardService([
-            cumulative({ teamId: "some-other-team" }),
-          ]),
+          lineupRepository: makeLineupRepo(makeLineup({ GK: "c-1" })),
+          contractRepository: makeContractRepo([c1]),
         }),
       );
 
       const result = await service.getRivalLineup(LEAGUE_ID, TEAM_ID);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.formation.formation["GK"]?.team).toEqual({
+        id: TEAM_ID,
+        name: "Test FC",
+        credits: 1000,
+        player: { id: PLAYER_ID, name: "testuser" },
+      });
+    });
+
+    it("returns NO_TEAM for a team id the league does not contain", async () => {
+      const service = new LineupService(makeDeps());
+
+      const result = await service.getRivalLineup(LEAGUE_ID, "some-other-team");
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error).toBe(LINEUP_ERRORS.NO_TEAM);
     });
 
-    it("propagates a standings failure rather than reporting not-found", async () => {
-      const failingBoard: PerformanceRepository = {
-        getRecentByTeam: async () => failure("unused"),
-        getLeagueCumulatives: async () => failure("db error"),
-        upsertDaily: async () => failure("unused"),
+    it("returns NO_TEAM for a team that exists in another league", async () => {
+      const service = new LineupService(makeDeps());
+
+      const result = await service.getRivalLineup("other-league", TEAM_ID);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe(LINEUP_ERRORS.NO_TEAM);
+    });
+
+    it("propagates a repository failure rather than reporting not-found", async () => {
+      const failingTeams: TeamRepository = {
+        ...makeTeamRepo(),
+        getByIdAndLeague: async () => failure("db error"),
       };
       const service = new LineupService(
-        makeDeps({
-          leaderboardService: new LeaderboardService(failingBoard),
-        }),
+        makeDeps({ teamRepository: failingTeams }),
       );
 
       const result = await service.getRivalLineup(LEAGUE_ID, TEAM_ID);

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -6,6 +6,12 @@ import {
 } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
+// Every pool worker re-reads wrangler.jsonc, so each one repeats the same two
+// wrangler notices — that `.dev.vars` was loaded, and that the rate limiters in
+// `env.test` are `unsafe` bindings. Both are expected and neither says anything
+// about the run, so keep wrangler quiet unless it has an actual error.
+process.env.WRANGLER_LOG ??= "error";
+
 const migrationsPath = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "migrations",

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -53,7 +53,30 @@ FantasyWiki/
 ### Services (`backend/src/services`)
 - Implement business logic and orchestration
 - Depend on repository interfaces (`PlayerRepository`) rather than route concerns
+- Depend on other services whose functionality they need
 - Return typed `Result` values consumed by routes
+
+#### Composing services
+
+A service may — and is encouraged to — call another service when that service
+already provides something useful. Reuse beats restating: a rule implemented
+twice is a rule that will eventually be two different rules. Take the
+dependency through the constructor like any repository, so tests can substitute
+it, and let the caller's `Result` carry the callee's failure outward rather
+than re-wording it.
+
+The rule is one of preference, and it holds even when all you want is the data:
+when what service A needs is offered both by service B and by repository C,
+reach for B. Go to C only when there is no such B. A service's read is rarely
+only a read — it dresses rows into DTOs, fills in derived fields, applies the
+rules that decide what counts as absent — and calling it means you inherit
+those, including the ones added after you wrote the call. Reaching past it to
+the repository buys one fewer hop and gives up all of that.
+
+One limit keeps this from becoming a tangle: **keep the dependencies acyclic**.
+If A calls B, B must not call back into A. A cycle usually means the shared
+part wants to be its own service (or to move down into a repository) rather
+than to be reached for in both directions.
 
 ### Repositories (`backend/src/repositories`)
 - Define repository contracts (`playerRepository.ts`)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6966,9 +6966,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2417,9 +2417,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4731,9 +4731,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5378,9 +5378,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6250,9 +6250,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9114,9 +9114,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7443,9 +7443,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/frontend/src/components/league/LeagueStandings.vue
+++ b/frontend/src/components/league/LeagueStandings.vue
@@ -43,11 +43,21 @@
           <span class="col-trend">{{ t("league.colTrend") }}</span>
         </div>
 
-        <div
+        <!-- Every row but the viewer's own opens that team's line-up, and does
+             it as a real button so the board stays keyboard-reachable. Your own
+             row stays inert: your team page is where you edit the line-up, and
+             routing you to the read-only copy of it would be a dead end. -->
+        <component
+          :is="isMine(entry) ? 'div' : 'button'"
           v-for="entry in visible"
           :key="entry.team.id"
+          :type="isMine(entry) ? undefined : 'button'"
           class="standings-row"
-          :class="{ 'standings-row--me': isMine(entry) }"
+          :class="{
+            'standings-row--me': isMine(entry),
+            'standings-row--link': !isMine(entry),
+          }"
+          @click="isMine(entry) || emit('openTeam', entry.team.id)"
         >
           <div class="col-rank">
             <span
@@ -76,7 +86,7 @@
             <ion-icon :icon="trend(entry).icon" class="trend-icon" />
             <span class="trend-label">{{ trend(entry).label }}</span>
           </div>
-        </div>
+        </component>
 
         <!-- A failed fetch is not an empty league. Saying "no teams" for a
              network error would be a claim about the league that nothing
@@ -140,6 +150,11 @@ const props = defineProps<{
   errored?: boolean;
   /** Where the league sits in its calendar; only the pre-scoring note reads it. */
   phase?: LeaguePhase | null;
+}>();
+
+const emit = defineEmits<{
+  /** A row other than the viewer's own was activated. */
+  openTeam: [teamId: string];
 }>();
 
 const { t, locale } = useI18n();
@@ -289,6 +304,29 @@ function trend(entry: LeaderboardEntryDTO): {
 
 .standings-row--me {
   background: rgba(var(--ion-color-primary-rgb), 0.08);
+}
+
+/* Rows that navigate are <button>: strip the UA chrome so they stay visually
+   identical to the inert one, and keep the grid the row layout depends on. */
+.standings-row--link {
+  width: 100%;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.standings-row--link:hover {
+  background: var(--ion-background-color-step-50);
+}
+
+.standings-row--link:focus-visible {
+  outline: 2px solid var(--ion-color-primary);
+  outline-offset: -2px;
 }
 
 .col-points,

--- a/frontend/src/composables/queryKeys.ts
+++ b/frontend/src/composables/queryKeys.ts
@@ -36,4 +36,11 @@ export const queryKeys = {
   globalLeague: () => ["global-league"] as const,
   /** A single league by id — including ones the player has not joined yet. */
   league: (leagueId: string) => ["league", leagueId] as const,
+  /**
+   * Another team's line-up, read-only. Deliberately not under `teamLineup`:
+   * that key is the viewer's own and every lineup mutation invalidates it,
+   * which would evict rivals the player is only looking at.
+   */
+  rivalLineup: (leagueId: string | null, teamId: string | null) =>
+    ["rival-lineup", leagueId, teamId] as const,
 };

--- a/frontend/src/composables/useRivalLineup.ts
+++ b/frontend/src/composables/useRivalLineup.ts
@@ -1,0 +1,98 @@
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+import { useQuery } from "@tanstack/vue-query";
+import { queryKeys } from "@/composables/queryKeys";
+import { useLeaderboard } from "@/composables/useLeaderboard";
+import { useMyTeam } from "@/composables/useMyTeam";
+import { fetchRivalLineup } from "@/services/teamService";
+import type { TeamLineUp } from "@/types/team";
+import type { LeaderboardEntryDTO } from "../../../dto/leaderboardDTO";
+
+/**
+ * Everything the rival team page renders: one other team's line-up, plus the
+ * standings row that gives it a name, a rank and a points total.
+ *
+ * Identity comes from the leaderboard rather than a team endpoint because the
+ * standings already carry every field the header shows, and the page is only
+ * ever reached from that same board — so the query is usually a cache hit and
+ * the header paints with the pitch instead of after it.
+ */
+export function useRivalLineup(
+  leagueId: MaybeRefOrGetter<string | undefined>,
+  teamId: MaybeRefOrGetter<string | undefined>
+) {
+  const league = computed(() => toValue(leagueId) ?? null);
+  const team = computed(() => toValue(teamId) ?? null);
+
+  const {
+    leaderboard,
+    isLoading: isLeaderboardLoading,
+    isError: isLeaderboardError,
+    refetch: refetchLeaderboard,
+  } = useLeaderboard(league);
+
+  const { myTeam } = useMyTeam(league);
+
+  const {
+    data: lineup,
+    isLoading: isLineupLoading,
+    isError: isLineupError,
+    error,
+    refetch: refetchLineup,
+  } = useQuery<TeamLineUp>({
+    queryKey: computed(() => queryKeys.rivalLineup(league.value, team.value)),
+    queryFn: () => fetchRivalLineup(league.value!, team.value!),
+    enabled: computed(() => !!league.value && !!team.value),
+  });
+
+  const entry = computed<LeaderboardEntryDTO | null>(
+    () => leaderboard.value.find((e) => e.team.id === team.value) ?? null
+  );
+
+  /**
+   * The viewer's own standings row, for the head-to-head strip. Null when they
+   * only spectate this league — the strip is then simply not shown, which is
+   * honest, where a zero would read as "you are on nothing".
+   */
+  const mine = computed<LeaderboardEntryDTO | null>(() => {
+    const id = myTeam.value?.id;
+    if (!id) return null;
+    return leaderboard.value.find((e) => e.team.id === id) ?? null;
+  });
+
+  /**
+   * Points the rival is ahead by; negative when the viewer leads. Null unless
+   * both rows are known, so the strip never compares against a missing half.
+   */
+  const pointsGap = computed<number | null>(() => {
+    if (!entry.value || !mine.value) return null;
+    return entry.value.cumulativePoints - mine.value.cumulativePoints;
+  });
+
+  /**
+   * The team is in this league but its row has not arrived yet vs. it is not in
+   * this league at all. Only the settled second case is a 404 for the page.
+   */
+  const isUnknownTeam = computed(
+    () => !isLeaderboardLoading.value && !!team.value && entry.value === null
+  );
+
+  const isOwnTeam = computed(
+    () => !!myTeam.value?.id && myTeam.value.id === team.value
+  );
+
+  return {
+    entry,
+    mine,
+    pointsGap,
+    lineup,
+    isOwnTeam,
+    isUnknownTeam,
+    isLeaderboardLoading,
+    isLineupLoading,
+    isError: computed(() => isLineupError.value || isLeaderboardError.value),
+    error,
+    async refetch() {
+      await Promise.all([refetchLeaderboard(), refetchLineup()]);
+    },
+  };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -389,6 +389,24 @@
       "saveSuccess": "Lineup saved!",
       "saveFailed": "Couldn't save your lineup. Please try again.",
       "retry": "Retry"
+    },
+    "rivalTeamPage": {
+      "back": "Back to the league",
+      "backToStandings": "Back to the standings",
+      "loadingTitle": "Loading team…",
+      "failedToLoad": "Failed to load this team",
+      "notFoundTitle": "Team not found",
+      "notFoundDetail": "This team is not playing in this league.",
+      "retry": "Retry",
+      "rank": "#{rank}",
+      "points": "Points",
+      "trend": "Trend",
+      "schema": "Formation",
+      "bench": "Bench",
+      "gapAhead": "Ahead of you by {points} points",
+      "gapBehind": "Behind you by {points} points",
+      "gapLevel": "Level with you on points",
+      "viewMyTeam": "My team"
     }
   },
   "market": {

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -389,6 +389,24 @@
       "saveSuccess": "Formazione salvata!",
       "saveFailed": "Impossibile salvare la formazione. Riprova.",
       "retry": "Riprova"
+    },
+    "rivalTeamPage": {
+      "back": "Torna alla lega",
+      "backToStandings": "Torna alla classifica",
+      "loadingTitle": "Caricamento squadra…",
+      "failedToLoad": "Impossibile caricare questa squadra",
+      "notFoundTitle": "Squadra non trovata",
+      "notFoundDetail": "Questa squadra non partecipa a questa lega.",
+      "retry": "Riprova",
+      "rank": "#{rank}",
+      "points": "Punti",
+      "trend": "Andamento",
+      "schema": "Modulo",
+      "bench": "Panchina",
+      "gapAhead": "Davanti a te di {points} punti",
+      "gapBehind": "Dietro di te di {points} punti",
+      "gapLevel": "A pari punti con te",
+      "viewMyTeam": "La mia squadra"
     }
   },
   "market": {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -188,6 +188,21 @@ export const handlers = [
     return HttpResponse.json(response);
   }),
 
+  // Another team's line-up. The fixture is the same XI for every team id: the
+  // mock exists so the rival page is navigable, and inventing a distinct squad
+  // per team would be fixture data pretending to be a scouting feature.
+  http.get("*/api/leagues/:leagueId/teams/:teamId/lineup", ({ params }) => {
+    const response =
+      mockTeamResponses[teamResponseKey(String(params.leagueId))];
+    if (!response) {
+      return HttpResponse.json(
+        { error: "Team layout not found" },
+        { status: 404 }
+      );
+    }
+    return HttpResponse.json(response);
+  }),
+
   http.put("*/api/leagues/:leagueId/lineup", async ({ params, request }) => {
     const leagueId = String(params.leagueId);
     const key = teamResponseKey(leagueId);

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -9,6 +9,7 @@ import TeamPage from "@/views/TeamPage.vue";
 import TeamCreationPage from "@/views/TeamCreationPage.vue";
 import MarketPage from "@/views/MarketPage.vue";
 import LeaguePage from "@/views/LeaguePage.vue";
+import RivalTeamPage from "@/views/RivalTeamPage.vue";
 import LegalPage from "@/views/LegalPage.vue";
 import GuidePage from "@/views/GuidePage.vue";
 import ReportProblemPage from "@/views/ReportProblemPage.vue";
@@ -80,6 +81,14 @@ const routes: Array<RouteRecordRaw> = [
     path: "/leagues/:leagueId",
     name: "League",
     component: LeaguePage,
+  },
+  {
+    // Another team's line-up, read-only. Nested under the league because a team
+    // is only ever meaningful inside one — the same standings row is what leads
+    // here, and the league in the path is what the page compares against.
+    path: "/leagues/:leagueId/teams/:teamId",
+    name: "RivalTeam",
+    component: RivalTeamPage,
   },
   {
     path: "/community",

--- a/frontend/src/services/teamService.ts
+++ b/frontend/src/services/teamService.ts
@@ -65,6 +65,28 @@ export async function fetchTeam(leagueId: string): Promise<TeamLineUp> {
 }
 
 /**
+ * Fetch another team's line-up in a league.
+ *
+ * Separate from `fetchTeam` because the two resolve their team differently:
+ * that one is self-scoped (the backend reads the player from the session and
+ * the client never names them), while this one addresses a team the viewer
+ * does not own, so the id has to travel in the path. The payload is the same
+ * shape, so the deserializer is shared.
+ */
+export async function fetchRivalLineup(
+  leagueId: string,
+  teamId: string
+): Promise<TeamLineUp> {
+  const res = await fetch(
+    `${BASE}/api/leagues/${leagueId}/teams/${teamId}/lineup`,
+    { credentials: "include" }
+  );
+  if (!res.ok) throw new Error(`Failed to fetch team lineup: ${res.status}`);
+  const raw = (await res.json()) as RawTeamLineUp;
+  return deserializeLineup(raw);
+}
+
+/**
  * Persist the current team layout.
  * Used by both the explicit Save action in the UI and auto-save flows
  * such as saving when leaving the team view.

--- a/frontend/src/tests/RivalTeamPage.spec.ts
+++ b/frontend/src/tests/RivalTeamPage.spec.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, afterEach, beforeAll, beforeEach } from "vitest";
+import { mount, flushPromises, type VueWrapper } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { http, HttpResponse } from "msw";
+import { server } from "@/mocks/server";
+import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
+import router from "@/router/index";
+import RivalTeamPage from "@/views/RivalTeamPage.vue";
+import { useAppStore } from "@/stores/app";
+import { useLeagueStore } from "@/stores/league";
+import { leagues } from "@/mocks/data/leagues";
+import i18n from "@/i18n";
+import type { LeaderboardEntryDTO } from "../../../dto/leaderboardDTO";
+
+// The viewer in the Global League fixture — see src/mocks/data/leagues.ts.
+const MY_TEAM_ID = "team-2";
+const RIVAL_TEAM_ID = "team-4";
+
+function entry(
+  id: string,
+  name: string,
+  rank: number,
+  points: number,
+  rankDelta: number | null = 0
+): LeaderboardEntryDTO {
+  return {
+    team: {
+      id,
+      name,
+      credits: 500,
+      player: { id: `player-${id}`, name: `Player ${id}` },
+    },
+    cumulativePoints: points,
+    rank,
+    rankDelta,
+  };
+}
+
+/** Board where the rival leads the viewer by 40 points. */
+function board(): LeaderboardEntryDTO[] {
+  return [
+    entry(RIVAL_TEAM_ID, "Wiki Masters", 1, 140, 2),
+    entry(MY_TEAM_ID, "Global Warriors", 2, 100),
+  ];
+}
+
+function stubBoard(entries: LeaderboardEntryDTO[]) {
+  server.use(
+    http.get("*/api/leagues/:leagueId/leaderboard", () =>
+      HttpResponse.json(entries)
+    )
+  );
+}
+
+function makePlugins() {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  // The route is auth-gated, so an unauthenticated store bounces the push to
+  // /home and the page mounts with no params at all.
+  useAppStore().setUserFromData({
+    sub: "player-1",
+    email: "player@example.com",
+    name: "Player One",
+    picture: "",
+  });
+
+  const leagueStore = useLeagueStore();
+  leagueStore.availableLeagues = leagues;
+  leagueStore.currentLeague = leagues[0];
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const plugins: any[] = [
+    pinia,
+    [VueQueryPlugin, { queryClient }],
+    router,
+    i18n,
+  ];
+  return plugins;
+}
+
+/**
+ * Torn down between tests for the same reason LeaguePage's spec does it: the
+ * router is a module singleton while each test gets a fresh pinia, so a page
+ * left mounted keeps watching a route it no longer owns.
+ */
+let mounted: VueWrapper | undefined;
+
+async function mountAt(teamId: string) {
+  const path = `/leagues/global/teams/${teamId}`;
+  const plugins = makePlugins();
+  await router.push(path);
+  await router.isReady();
+  mounted = mount(RivalTeamPage, { global: { plugins } });
+  await flushPromises();
+  await flushPromises();
+  return mounted;
+}
+
+describe("RivalTeamPage.vue", () => {
+  beforeAll(() => {
+    // The pitch anchors its chemistry lines off a ResizeObserver, which jsdom
+    // does not ship — same stub the TeamFormation spec installs.
+    if (!window.ResizeObserver) {
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    mounted?.unmount();
+    mounted = undefined;
+  });
+
+  it("names the team and its rank from the standings row", async () => {
+    stubBoard(board());
+    const wrapper = await mountAt(RIVAL_TEAM_ID);
+
+    expect(wrapper.text()).toContain("Wiki Masters");
+    expect(wrapper.text()).toContain("#1");
+  });
+
+  it("states the gap from the viewer's side when they are behind", async () => {
+    stubBoard(board());
+    const wrapper = await mountAt(RIVAL_TEAM_ID);
+
+    expect(wrapper.text()).toContain("Ahead of you by 40 points");
+  });
+
+  it("flips the gap wording when the viewer leads", async () => {
+    stubBoard([
+      entry(RIVAL_TEAM_ID, "Wiki Masters", 2, 60),
+      entry(MY_TEAM_ID, "Global Warriors", 1, 100),
+    ]);
+    const wrapper = await mountAt(RIVAL_TEAM_ID);
+
+    expect(wrapper.text()).toContain("Behind you by 40 points");
+  });
+
+  it("renders the line-up read-only — no save or swap affordance", async () => {
+    stubBoard(board());
+    const wrapper = await mountAt(RIVAL_TEAM_ID);
+
+    // The pitch is present…
+    expect(wrapper.findComponent({ name: "TeamFormation" }).exists()).toBe(
+      true
+    );
+    // …and hosted in its non-editable mode, which is what withholds drag-to-move.
+    expect(
+      wrapper.findComponent({ name: "TeamFormation" }).props("editable")
+    ).toBe(false);
+  });
+
+  /**
+   * A team id that is not in this league is a wrong link, not a failed request:
+   * the page must not offer a retry that cannot succeed.
+   */
+  it("treats a team outside the league as not found, not as an error", async () => {
+    stubBoard(board());
+    const wrapper = await mountAt("team-not-in-this-league");
+
+    expect(wrapper.text()).toContain("Team not found");
+    expect(wrapper.text()).not.toContain("Retry");
+  });
+});

--- a/frontend/src/views/LeaguePage.vue
+++ b/frontend/src/views/LeaguePage.vue
@@ -67,6 +67,7 @@
           :loading="isLeaderboardLoading"
           :errored="isLeaderboardError"
           :phase="phase"
+          @open-team="openTeam"
         />
       </page-reveal>
     </div>
@@ -122,6 +123,17 @@ const {
 // Scoped to the league in the route, not the selected one: this page is
 // reachable for any league, and "You" has to mark the right row.
 const { myTeamId } = useMyTeam(leagueId);
+
+/**
+ * Opens a rival's line-up. Pushed, not replaced: it is a step down from the
+ * standings, and Back has to come straight back to the row it was opened from.
+ */
+function openTeam(teamId: string) {
+  router.push({
+    name: "RivalTeam",
+    params: { leagueId: leagueId.value, teamId },
+  });
+}
 
 /**
  * Keeps the URL and the NavBar's league switcher saying the same thing. Two

--- a/frontend/src/views/RivalTeamPage.vue
+++ b/frontend/src/views/RivalTeamPage.vue
@@ -1,0 +1,412 @@
+<template>
+  <nav-bar>
+    <ion-refresher slot="fixed" @ionRefresh="handleRefresh($event)">
+      <ion-refresher-content />
+    </ion-refresher>
+
+    <!-- Heading first, and outside every branch: the back arrow is the way out
+         of a page that failed to load, so it must not depend on the load. -->
+    <div class="page-heading">
+      <ion-button
+        fill="clear"
+        size="small"
+        class="back-btn"
+        :aria-label="t('views.rivalTeamPage.back')"
+        @click="goBack()"
+      >
+        <ion-icon slot="icon-only" :icon="arrowBackOutline" />
+      </ion-button>
+      <h2 class="page-title">
+        {{ entry?.team.name ?? t("views.rivalTeamPage.loadingTitle") }}
+      </h2>
+      <ion-badge v-if="entry" color="medium" class="rank-badge">
+        {{ rankLabel }}
+      </ion-badge>
+    </div>
+
+    <!-- A team that is not in this league's standings is a wrong link, not a
+         failed request — saying "retry" would invite a retry that cannot work. -->
+    <ion-card v-if="isUnknownTeam" class="state-card">
+      <ion-card-content>
+        <p class="ion-no-margin state-title">
+          {{ t("views.rivalTeamPage.notFoundTitle") }}
+        </p>
+        <p class="state-detail">
+          {{ t("views.rivalTeamPage.notFoundDetail") }}
+        </p>
+        <ion-button fill="outline" size="small" @click="goBack()">
+          {{ t("views.rivalTeamPage.backToStandings") }}
+        </ion-button>
+      </ion-card-content>
+    </ion-card>
+
+    <ion-card v-else-if="isError" color="danger" class="state-card">
+      <ion-card-content>
+        <div class="error-row">
+          <ion-icon :icon="alertCircleOutline" />
+          <div>
+            <p class="ion-no-margin state-title">
+              {{ t("views.rivalTeamPage.failedToLoad") }}
+            </p>
+            <p class="state-detail">{{ error?.message }}</p>
+            <ion-button
+              fill="outline"
+              color="light"
+              size="small"
+              @click="refetch()"
+            >
+              <ion-icon slot="start" :icon="refreshOutline" />
+              {{ t("views.rivalTeamPage.retry") }}
+            </ion-button>
+          </div>
+        </div>
+      </ion-card-content>
+    </ion-card>
+
+    <div v-else-if="isLoading" class="pitch-skeleton" aria-busy="true">
+      <ion-skeleton-text :animated="true" class="skeleton-summary" />
+      <ion-skeleton-text :animated="true" class="skeleton-pitch" />
+      <ion-skeleton-text :animated="true" class="skeleton-bench" />
+    </div>
+
+    <page-reveal v-else>
+      <!-- Head-to-head. Shown only when the viewer fields a team here: for a
+           spectator there is no gap to state, and a zero would claim one. -->
+      <div v-if="pointsGap !== null" class="head-to-head">
+        <ion-icon
+          :icon="pointsGap > 0 ? trendingUpOutline : trendingDownOutline"
+          :class="pointsGap > 0 ? 'gap-icon--behind' : 'gap-icon--ahead'"
+        />
+        <span class="gap-text">{{ gapLabel }}</span>
+        <ion-button
+          fill="clear"
+          size="small"
+          class="my-team-link"
+          @click="router.push({ name: 'Team' })"
+        >
+          {{ t("views.rivalTeamPage.viewMyTeam") }}
+        </ion-button>
+      </div>
+
+      <!-- Summary: the standings facts the pitch itself cannot show. -->
+      <div class="summary-row">
+        <div class="summary-cell">
+          <span class="summary-label">{{
+            t("views.rivalTeamPage.points")
+          }}</span>
+          <span class="summary-value">{{ pointsLabel }}</span>
+        </div>
+        <div class="summary-cell">
+          <span class="summary-label">{{
+            t("views.rivalTeamPage.trend")
+          }}</span>
+          <span class="summary-value" :class="trend.cssClass">{{
+            trend.label
+          }}</span>
+        </div>
+        <div class="summary-cell">
+          <span class="summary-label">{{
+            t("views.rivalTeamPage.schema")
+          }}</span>
+          <span class="summary-value">{{
+            lineup?.formation.schema ?? "—"
+          }}</span>
+        </div>
+        <div class="summary-cell">
+          <span class="summary-label">{{
+            t("views.rivalTeamPage.bench")
+          }}</span>
+          <span class="summary-value">{{ lineup?.bench.length ?? 0 }}</span>
+        </div>
+      </div>
+
+      <!-- The same pitch the player edits on their own team page, in its
+           read-only mode: one component means a rival's formation can never
+           drift from how the viewer's own is drawn. -->
+      <team-formation
+        v-if="lineup"
+        :formation="lineup.formation"
+        :editable="false"
+        @article-click="openDetail"
+      />
+
+      <bench-section
+        v-if="lineup"
+        :articles="lineup.bench"
+        @article-click="openDetail"
+      />
+    </page-reveal>
+
+    <!-- No onSwap and no onRequestTrade: swapping is the owner's action, and
+         those buttons only render when a host supplies the handler. -->
+    <article-detail
+      v-if="selectedContract"
+      :contract="selectedContract"
+      :article="selectedContract.article"
+      :is-open="isDetailOpen"
+      @close="closeDetail"
+    />
+  </nav-bar>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import {
+  IonBadge,
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonIcon,
+  IonRefresher,
+  IonRefresherContent,
+  IonSkeletonText,
+} from "@ionic/vue";
+import {
+  alertCircleOutline,
+  arrowBackOutline,
+  refreshOutline,
+  trendingDownOutline,
+  trendingUpOutline,
+} from "ionicons/icons";
+import { useI18n } from "vue-i18n";
+
+import NavBar from "@/layout/NavBar.vue";
+import PageReveal from "@/components/PageReveal.vue";
+import TeamFormation from "@/components/formation/TeamFormation.vue";
+import BenchSection from "@/components/formation/BenchSection.vue";
+import ArticleDetail from "@/components/ArticleDetail.vue";
+import { useRivalLineup } from "@/composables/useRivalLineup";
+import type { ContractDTO } from "../../../dto/contractDTO";
+
+const route = useRoute();
+const router = useRouter();
+const { t, locale } = useI18n();
+
+const leagueId = computed(() => route.params.leagueId as string | undefined);
+const teamId = computed(() => route.params.teamId as string | undefined);
+
+const {
+  entry,
+  pointsGap,
+  lineup,
+  isUnknownTeam,
+  isLeaderboardLoading,
+  isLineupLoading,
+  isError,
+  error,
+  refetch,
+} = useRivalLineup(leagueId, teamId);
+
+const isLoading = computed(
+  () => isLeaderboardLoading.value || isLineupLoading.value
+);
+
+const rankLabel = computed(() =>
+  entry.value ? t("views.rivalTeamPage.rank", { rank: entry.value.rank }) : ""
+);
+
+const pointsLabel = computed(() =>
+  entry.value
+    ? entry.value.cumulativePoints.toLocaleString(locale.value, {
+        maximumFractionDigits: 1,
+      })
+    : "—"
+);
+
+/**
+ * Whose favour the points gap is in. Phrased from the viewer's side ("ahead of
+ * you" / "behind you") because the reader is comparing themselves to this team,
+ * not reading a neutral fixture.
+ */
+const gapLabel = computed(() => {
+  const gap = pointsGap.value;
+  if (gap === null) return "";
+  const points = Math.abs(gap).toLocaleString(locale.value, {
+    maximumFractionDigits: 1,
+  });
+  if (gap === 0) return t("views.rivalTeamPage.gapLevel");
+  return gap > 0
+    ? t("views.rivalTeamPage.gapAhead", { points })
+    : t("views.rivalTeamPage.gapBehind", { points });
+});
+
+/** Same three-way reading as the standings: a dash is "never compared". */
+const trend = computed(() => {
+  const delta = entry.value?.rankDelta;
+  if (delta == null) return { cssClass: "trend--new", label: "—" };
+  if (delta === 0) return { cssClass: "trend--stable", label: "=" };
+  if (delta > 0) return { cssClass: "trend--up", label: `+${delta}` };
+  return { cssClass: "trend--down", label: `${delta}` };
+});
+
+// ── Article detail ────────────────────────────────────────────────────────
+const selectedContract = ref<ContractDTO | null>(null);
+const isDetailOpen = ref(false);
+
+function openDetail(contract: ContractDTO) {
+  selectedContract.value = contract;
+  isDetailOpen.value = true;
+}
+
+function closeDetail() {
+  isDetailOpen.value = false;
+}
+
+/**
+ * Back goes to this league's page rather than through history: the page is also
+ * reachable from a shared link, where `router.back()` leaves the app.
+ */
+function goBack() {
+  router.push({ name: "League", params: { leagueId: leagueId.value } });
+}
+
+async function handleRefresh(event: CustomEvent) {
+  await refetch();
+  (event.target as HTMLIonRefresherElement).complete();
+}
+</script>
+
+<style scoped>
+.page-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.back-btn {
+  --padding-start: 0;
+  --padding-end: 0;
+  margin: 0;
+}
+
+.rank-badge {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Head-to-head ──────────────────────────────── */
+.head-to-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  border: 1px solid var(--ion-border-color);
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.gap-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.gap-icon--ahead {
+  color: var(--ion-color-success);
+}
+
+.gap-icon--behind {
+  color: var(--ion-color-danger);
+}
+
+.my-team-link {
+  --padding-start: 0.25rem;
+  --padding-end: 0.25rem;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+/* ── Summary ───────────────────────────────────── */
+.summary-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.summary-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.5rem;
+  border: 1px solid var(--ion-border-color);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.summary-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ion-color-medium);
+}
+
+.summary-value {
+  font-size: 1.05rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.trend--up {
+  color: var(--ion-color-success);
+}
+.trend--down {
+  color: var(--ion-color-danger);
+}
+.trend--stable,
+.trend--new {
+  color: var(--ion-color-medium);
+}
+
+/* ── States ────────────────────────────────────── */
+.state-card {
+  margin-inline: 0;
+}
+
+.state-title {
+  font-weight: 600;
+}
+
+.state-detail {
+  font-size: 0.85rem;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.error-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.pitch-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skeleton-summary {
+  height: 3.5rem;
+  border-radius: 8px;
+}
+
+.skeleton-pitch {
+  height: 18rem;
+  border-radius: 8px;
+}
+
+.skeleton-bench {
+  height: 6rem;
+  border-radius: 8px;
+}
+</style>

--- a/gradle/collector.versions.toml
+++ b/gradle/collector.versions.toml
@@ -1,0 +1,46 @@
+# Catalog for the scoring-collector subproject, the only JVM module in the
+# monorepo. Everything here is consumed by `collectorLibs` in
+# scoring-collector/build.gradle.kts and nowhere else; entries shared with the
+# Node subprojects live in libs.versions.toml.
+
+[versions]
+kotlin = "2.4.10"
+kotest = "6.2.3"
+mockito = "5.23.0"
+kover = "0.9.9"
+coroutines = "1.11.0"
+ktor = "3.5.2"
+
+[libraries]
+kotest-junit5-jvm = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "kotest" }
+kotest-assertions-core-jvm = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+
+[bundles]
+runtime = [
+  "kotlinx-coroutines-core",
+  "ktor-client-core",
+  "ktor-client-cio",
+  "ktor-client-content-negotiation",
+  "ktor-serialization-kotlinx-json",
+]
+testing = [
+  "kotest-junit5-jvm",
+  "kotest-assertions-core-jvm",
+  "mockito-core",
+  "ktor-client-mock",
+  "kotlinx-coroutines-test",
+]
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-qa = "org.danilopianini.gradle-kotlin-qa:1.8.1"
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,39 +1,7 @@
-[versions]
-kotlin = "2.4.10"
-kotest = "6.2.3"
-mockito = "5.23.0"
-kover = "0.9.9"
-coroutines = "1.11.0"
-ktor = "3.5.2"
-
-[libraries]
-kotest-junit5-jvm = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "kotest" }
-kotest-assertions-core-jvm = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }
-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
-ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
-ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-
-[bundles]
-kotlin-testing = [ "kotest-junit5-jvm", "kotest-assertions-core-jvm", "mockito-core" ]
-collector-runtime = [
-  "kotlinx-coroutines-core",
-  "ktor-client-core",
-  "ktor-client-cio",
-  "ktor-client-content-negotiation",
-  "ktor-serialization-kotlinx-json",
-]
-collector-testing = [ "ktor-client-mock", "kotlinx-coroutines-test" ]
+# Catalog for the build itself and the Node subprojects. The scoring-collector's
+# dependencies are scoped to collector.versions.toml.
 
 [plugins]
 gitSemVer = "org.danilopianini.git-sensitive-semantic-versioning:7.0.23"
 taskTree = "com.dorongold.task-tree:4.0.1"
 node = "com.github.node-gradle.node:7.1.0"
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-kotlin-qa = "org.danilopianini.gradle-kotlin-qa:1.8.1"
-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/scoring-collector/build.gradle.kts
+++ b/scoring-collector/build.gradle.kts
@@ -2,10 +2,10 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kotlin.qa)
-    alias(libs.plugins.kover)
+    alias(collectorLibs.plugins.kotlin.jvm)
+    alias(collectorLibs.plugins.kotlin.serialization)
+    alias(collectorLibs.plugins.kotlin.qa)
+    alias(collectorLibs.plugins.kover)
     application
 }
 
@@ -17,9 +17,8 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation(libs.bundles.collector.runtime)
-    testImplementation(libs.bundles.kotlin.testing)
-    testImplementation(libs.bundles.collector.testing)
+    implementation(collectorLibs.bundles.runtime)
+    testImplementation(collectorLibs.bundles.testing)
 }
 
 application {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,17 @@ gitHooks {
     createHooks()
 }
 
+dependencyResolutionManagement {
+    versionCatalogs {
+        // The JVM dependencies belong to scoring-collector alone, so they are
+        // catalogued apart from the shared `libs` rather than sitting next to
+        // entries every subproject can reach for.
+        create("collectorLibs") {
+            from(files("gradle/collector.versions.toml"))
+        }
+    }
+}
+
 rootProject.name = "FantasyWiki"
 
 include("frontend")


### PR DESCRIPTION
Standings rows other than your own now open that team's line-up, so the board answers "how are they set up?" instead of only "where are they?".

The page reuses TeamFormation in its existing `editable: false` mode rather than drawing its own pitch: a rival's formation can then never drift from how the viewer's own is rendered. ArticleDetail is hosted without `onSwap` and without `onRequestTrade` — both are callback props, so the actions that belong to the owner simply do not render here.

Team identity comes from the leaderboard rather than a team endpoint. The standings already carry the name, rank and points the header shows, and the page is only ever reached from that same board, so the query is usually a cache hit and the header paints with the pitch instead of after it.

The head-to-head strip is shown only when the viewer fields a team in the league: for a spectator there is no gap to state, and a zero would claim one. A team id outside the league is reported as not found rather than as a failed request, so no retry is offered that could not succeed.

Backend note: GET /api/leagues/:leagueId/teams/:teamId/lineup does not exist yet — the existing lineup route is self-scoped from the JWT. The client is written against the path api-naming-rules.md implies and is covered by an MSW handler, so the page works under devMock and 404s against a real backend until that route lands.