### PR TITLE
refactor: drop the admin's unreachable join bypass, and explain leave's guard

### DIFF
--- a/backend/src/repositories/d1/teamRepositoryD1.ts
+++ b/backend/src/repositories/d1/teamRepositoryD1.ts
@@ -31,9 +31,12 @@ export class TeamRepositoryD1 implements TeamRepository {
       // check and the write — see docs/architecture/backend-error-constants.md
       // §2, and contractRepositoryD1.create for the same shape.
       //
-      // Three ways in: the league is public; the presented code matches; or
-      // the joiner is the league's own admin, who must not be locked out of
-      // the league they created.
+      // Two ways in: the league is public, or the presented code matches.
+      // There is no third for the league's own admin, and none is needed — a
+      // league and its founder's team are written in one transaction, so an
+      // admin is a member by construction and never reaches this statement,
+      // and an admin who leaves has handed the league on before they can knock
+      // (#537).
       //
       // `closedAt IS NULL` is here and the season's end date is not, and the
       // asymmetry is the point: `closedAt` can be written by another request
@@ -61,7 +64,6 @@ export class TeamRepositoryD1 implements TeamRepository {
               )
               AND (
                     l.visibility = ?
-                 OR l.adminId = ?
                  OR (l.invitationCode IS NOT NULL AND l.invitationCode = ?)
               )`,
         )
@@ -72,7 +74,6 @@ export class TeamRepositoryD1 implements TeamRepository {
           team.leagueId,
           team.playerId,
           LeagueVisibility.PUBLIC,
-          team.playerId,
           // No code offered can never match: the column is compared against a
           // sentinel that is not a legal code rather than against NULL, which
           // would make the whole condition NULL either way.
@@ -126,6 +127,10 @@ export class TeamRepositoryD1 implements TeamRepository {
       // Setting `leftAt` back to NULL is the whole of coming back: the row, its
       // contracts and its standing were never removed, so there is nothing to
       // restore (docs/domain/league-lifecycle.md).
+      //
+      // A league's founder is not exempt from its code either. Leaving hands
+      // the league on, so by the time anyone knocks here they are an ex-admin
+      // like any other returning player.
       const result = await this.db
         .prepare(
           `UPDATE teams
@@ -139,7 +144,6 @@ export class TeamRepositoryD1 implements TeamRepository {
                        AND l.closedAt IS NULL
                        AND (
                              l.visibility = ?
-                          OR l.adminId = ?
                           OR (l.invitationCode IS NOT NULL
                               AND l.invitationCode = ?)
                        )
@@ -150,7 +154,6 @@ export class TeamRepositoryD1 implements TeamRepository {
           team.playerId,
           team.leagueId,
           LeagueVisibility.PUBLIC,
-          team.playerId,
           team.invitationCode ?? "",
         )
         .run();
@@ -275,9 +278,22 @@ export class TeamRepositoryD1 implements TeamRepository {
     try {
       // Stamp the departure, hand the league on if its admin is the one
       // walking out, and erase the league if nobody is left — one batch, so D1
-      // runs them as one transaction. Statements 2 and 3 are conditioned on
-      // this exact departure having been written, or a refused leave would
-      // delete a league everyone had already abandoned.
+      // runs them as one transaction.
+      //
+      // Statements 2 and 3 each carry `EXISTS (SELECT 1 FROM teams WHERE
+      // id = ? AND leftAt = ?)`: they act only if *this* departure was the one
+      // written. Without it a refused leave would still be read by statement 3
+      // as the one that emptied the league, and delete a league everyone had
+      // already abandoned.
+      //
+      // No production path reaches that state today, and the conditioning is
+      // kept anyway (#538). It bites only on a memberless league still
+      // standing, and statement 3 is itself the reason no such league exists —
+      // the last member's departure takes the league with it. This is not dead
+      // code; it is code whose trigger this same batch removes, and anything
+      // that stops a league being deleted here — an empty league kept for its
+      // archive, a soft close — makes it live again. Do not drop it for want
+      // of a test.
       const results = await this.db.batch([
         this.db
           .prepare(

--- a/backend/src/repositories/teamRepository.ts
+++ b/backend/src/repositories/teamRepository.ts
@@ -36,11 +36,11 @@ export const TEAM_ERRORS = {
    * the same thing.
    *
    * Its own error rather than folded into `LEAGUE_IS_PRIVATE` or a 404, because
-   * it is the one join refusal that is *not* about the caller: a valid code and
-   * the league's own admin are turned away by it too, and telling someone their
-   * invitation is fine but the season ended is the difference between a dead
-   * link and an explanation. Nothing is hidden by saying so — the league page,
-   * its standings and its end date are already readable by anyone with the id
+   * it is the one join refusal that is *not* about the caller: a valid code is
+   * turned away by it too, and telling someone their invitation is fine but the
+   * season ended is the difference between a dead link and an explanation.
+   * Nothing is hidden by saying so — the league page, its standings and its end
+   * date are already readable by anyone with the id
    * (docs/domain/league-visibility.md).
    */
   LEAGUE_INACTIVE: "This league is no longer running.",
@@ -98,10 +98,17 @@ export interface TeamRepository {
    * derived credits is trivially STARTING_CREDITS.
    *
    * `invitationCode` is the code the joiner presented, if any. The league's
-   * own rules — public, or private and this code matches, or private and this
-   * is the admin — are evaluated *inside* the INSERT rather than checked
-   * first, because D1 has no interactive transactions and a check followed by
-   * a write is a race. Rejection surfaces as `TEAM_ERRORS.JOIN_CONFLICT`.
+   * own rules — public, or private and this code matches — are evaluated
+   * *inside* the INSERT rather than checked first, because D1 has no
+   * interactive transactions and a check followed by a write is a race.
+   * Rejection surfaces as `TEAM_ERRORS.JOIN_CONFLICT`.
+   *
+   * The league's **admin is not a third way in**, and wants none: founding a
+   * league writes its founder's team in the same transaction, so an admin is
+   * already a member by construction and never joins. If they leave,
+   * {@link leave} hands the league on before they can come back, so a founder
+   * returning to their own private league is asked for its code like anybody
+   * else (docs/domain/league-visibility.md).
    *
    * Two further conditions ride in the same statement: the league is not
    * closed, and this player holds no row here already. A player who *left* does
@@ -125,7 +132,9 @@ export interface TeamRepository {
    *
    * Guarded like {@link create} and for the same reason: they really did leave,
    * the league is not closed, and its entry rules admit them — a player who
-   * left a league that has since gone private needs the code like anyone else.
+   * left a league that has since gone private needs the code like anyone else,
+   * and so does the founder of a private league they walked out of, since
+   * leaving handed the adminship on.
    * Rejection surfaces as `TEAM_ERRORS.JOIN_CONFLICT`, classified by the same
    * re-read.
    */
@@ -198,8 +207,13 @@ export interface TeamRepository {
    * `TEAM_ERRORS.LEAVE_CONFLICT`.
    *
    * `teamId` is passed rather than looked up here so steps 2 and 3 can be
-   * conditioned on this exact departure having been written; see the
-   * implementation. See docs/domain/league-lifecycle.md for the rules.
+   * conditioned on this exact departure having been written — without that, a
+   * refused second departure would be read as the one that emptied the league,
+   * and step 3 would delete it. That state is unreachable by construction: step
+   * 3 is itself why a memberless league never stands, since the last member's
+   * departure takes the league with it. The conditioning is kept regardless,
+   * for the day something else leaves one standing; the implementation says so
+   * at length. See docs/domain/league-lifecycle.md for the rules.
    */
   leave(departure: {
     teamId: string;

--- a/backend/src/tests/integration/leagueVisibility.integration.test.ts
+++ b/backend/src/tests/integration/leagueVisibility.integration.test.ts
@@ -209,6 +209,38 @@ describe("the join gate", () => {
     expect(result).toEqual({ ok: false, error: TEAM_ERRORS.LEAGUE_IS_PRIVATE });
   });
 
+  it("asks a founder who left their own private league for its code", async () => {
+    // The gate used to admit `l.adminId` outright, and #537 removed it as
+    // unreachable. The clause itself was never testable — that is what made it
+    // worth removing — so what is pinned here is the reason it was unreachable:
+    // a founder who walks out is an ex-admin by the time they can knock,
+    // because leaving hands the league on in the same transaction.
+    const founder = await makePlayer("founder");
+    const league = await seedPrivate(founder.id);
+    const successor = await makePlayer("successor");
+    unwrap(
+      await teamService.createTeam(
+        successor.id,
+        league.id,
+        "Successors",
+        PRIVATE_CODE,
+      ),
+      "successor's team",
+    );
+    unwrap(await teamService.leaveLeague(founder.id, league.id), "departure");
+
+    const bare = await teamService.createTeam(founder.id, league.id, "Return");
+    const withCode = await teamService.createTeam(
+      founder.id,
+      league.id,
+      "Return",
+      PRIVATE_CODE,
+    );
+
+    expect(bare).toEqual({ ok: false, error: TEAM_ERRORS.LEAGUE_IS_PRIVATE });
+    expect(withCode.ok).toBe(true);
+  });
+
   it("does not treat a codeless private league as open to an empty code", async () => {
     // The SQL compares against '' when no code is offered. A private league
     // whose code is NULL must not match that.

--- a/docs/adr/0008-league-invitation-codes.md
+++ b/docs/adr/0008-league-invitation-codes.md
@@ -16,6 +16,12 @@ related:
 > The join-by-code flow (#7) landed with `GET /api/leagues/by-code/:code`,
 > `LeagueRepository.findIdByInvitationCode`, the `/leagues/join` page and invitation links — and
 > with the rate limiting §1 left as the one accepted risk's outstanding mitigation.
+>
+> **Amended (#537):** the third arm of the gate below, `l.adminId = ?`, was removed from both the
+> join `INSERT` and the rejoin `UPDATE`. Once league creation wrote the founder's team in the same
+> transaction, no path could reach it — an admin is a member by construction, and one who leaves
+> has handed the league on before they can come back. The snippet and the wording here are the
+> amended ones.
 
 Leagues could not be private, and joining one was ungated: any authenticated player who knew a
 league id could create a team in it. This ADR records how the invitation code is shaped, where it
@@ -124,7 +130,7 @@ INSERT INTO teams (id, name, playerId, leagueId)
 SELECT ?, ?, ?, l.id
   FROM leagues l
  WHERE l.id = ?
-   AND (l.visibility = 'public' OR l.adminId = ? OR l.invitationCode = ?)
+   AND (l.visibility = 'public' OR l.invitationCode = ?)
 ```
 
 On rejection the repository returns one sentinel, `TEAM_ERRORS.JOIN_CONFLICT` — at write time it
@@ -145,13 +151,13 @@ a guesser their generator is aimed correctly, which is most of what they want to
 One join refusal is deliberately *not* hidden. A league whose season has ended, or that its admin
 closed early, answers `TEAM_ERRORS.LEAGUE_INACTIVE` (409) — the rule is `isLeagueInactive` in
 `model/league.ts` and is not respelled anywhere else. It is safe to be plain about because it is
-not about the caller: a valid code and the league's own admin are turned away by it too, and the
-league's dates are already readable by anyone with its id. Telling someone holding a real
-invitation that the season is over, rather than that their code is bad, is the difference between
-an explanation and a dead link. This one check sits in the service rather than inside the guarded
-`INSERT`, because moving it there would mean writing the model function out a second time as SQL;
-what that costs is a race one request wide, and one extra team in a league that has stopped scoring
-is not the failure the guarded write exists to prevent.
+not about the caller: a valid code is turned away by it too, and the league's dates are already
+readable by anyone with its id. Telling someone holding a real invitation that the season is over,
+rather than that their code is bad, is the difference between an explanation and a dead link. This
+one check sits in the service rather than inside the guarded `INSERT`, because moving it there
+would mean writing the model function out a second time as SQL; what that costs is a race one
+request wide, and one extra team in a league that has stopped scoring is not the failure the
+guarded write exists to prevent.
 
 ### 4. Uniqueness is an index plus a bounded retry
 
@@ -187,7 +193,8 @@ consistent rather than an exception.
 ## Consequences
 
 - `adminId` becomes load-bearing. It was stored, selected by both repositories, and read by no
-  production code; it now decides both admin entry and the `admin` invite policy.
+  production code; it now decides the `admin` invite policy. (It also decided entry to the league
+  the admin owned, until #537 found that arm of the gate unreachable and removed it.)
 - `TEAM_ERRORS` grew from one constant to six, because the route could no longer map every
   `createTeam` failure to 400 — a permission refusal is 403 and a missing league 404, and a status
   may never be derived from message content.

--- a/docs/domain/league-visibility.md
+++ b/docs/domain/league-visibility.md
@@ -13,8 +13,9 @@ Every league is **public** or **private**.
 - A **public** league can be joined by any authenticated player, with nothing
   in hand. It has **no invitation code** — there is nothing for one to guard.
 - A **private** league can be joined only by presenting its **invitation
-  code** — or by its **league admin**, who is never locked out of the league
-  they own.
+  code**. There is no exception for its **league admin**, and none is needed:
+  an admin is already in the league they own — see below — so there is nothing
+  for an exception to let in.
 
 The Global League is public, and therefore codeless. It is the one league every
 player is enrolled in on first login, so it must stay joinable by anyone.
@@ -54,8 +55,12 @@ league list is scoped to the leagues a player has a team in, so a league written
 without its founder would be invisible to everyone, and a private one would hold
 an invitation code nobody could reach.
 
-The founder is the league's **admin**, which is what lets them back in without
-presenting the code to their own league.
+The founder is the league's **admin** — and because founding *is* joining, an
+admin is a member by construction and never has to get past the gate at all.
+Nor is there a back way in for one who left: leaving
+[hands the league on](./league-lifecycle.md#when-the-admin-leaves) in the same
+transaction, so a founder coming back to their own private league presents its
+code like anybody else. The gate therefore never has to name the admin.
 
 A caller the policy does not allow is answered exactly as if the league did not
 exist. Telling a stranger that a code exists tells them there is something

--- a/frontend/src/components/TeamCreationForm.vue
+++ b/frontend/src/components/TeamCreationForm.vue
@@ -78,10 +78,11 @@ import { TeamDTO } from "../../../dto/teamDTO";
  * `invitationCode` is what the host was let through the gate with, handed back
  * so the write can present it too — a private league checks it inside the
  * INSERT, so naming a team is the moment it is actually spent. Absent for
- * signup, for a public league, and for a league's own admin, none of which need
- * one. The form neither validates nor displays it: the surface that collected
- * it already did (`useLeagueByCode`), and re-checking here would be a second
- * copy of a rule the shared model states once.
+ * signup and for a public league, neither of which needs one; a league's own
+ * admin never reaches this form for their own league, since founding it created
+ * their team. The form neither validates nor displays it: the surface that
+ * collected it already did (`useLeagueByCode`), and re-checking here would be a
+ * second copy of a rule the shared model states once.
  */
 const props = defineProps<{ league: LeagueDTO; invitationCode?: string }>();
 const emit = defineEmits<{ created: [team: TeamDTO] }>();


### PR DESCRIPTION
Resolves the two decisions #534's port off raw SQL left open. Both clauses were untested, and untestable for the same reason: no production path reaches the state they guard.

## #537 — the clause is removed

`OR l.adminId = ?` is gone from the join `INSERT` and the rejoin `UPDATE` in `TeamRepositoryD1`, together with its bind.

It was never live. `createWithFoundingTeam` writes a league and its founder's team in one transaction — and with a *plain* `INSERT`, not the gated one — so an admin is a member by construction and never joins. If they leave, `leave` hands the league to the most senior remaining member in the same transaction, so a returning founder is an ex-admin judged on the code like anyone else. A sole member's departure deletes the league, so there is no "admin with a departed team" left either.

Said in the docstring, in `docs/domain/league-visibility.md` (both the rule and the now-false "which is what lets them back in"), in ADR 0008 (status amendment, the SQL snippet, and the `adminId` consequence) and in the `TeamCreationForm` comment, instead of promising a bypass that could not fire.

One test added, in the join gate's own file: a founder who walked out of their own private league is asked for its code, and gets in with it. That does not pin the removed clause — nothing can, which was the point — it pins the handover that made it unreachable, and its comment says so rather than overclaiming.

## #538 — the conditioning is kept, and explained

`leave`'s statements 2 and 3 stay conditioned on this exact departure having been written. Both the `TeamRepository.leave` docstring and the batch comment now say why the branch looks dead and is not: it bites only on a memberless league still standing, and statement 3 of the same batch is the reason no such league exists. Anything that stops a league being deleted there — an empty league kept for its archive, a soft close — makes it live again, so it is not to be dropped for want of a test.

Closes #537
Closes #538